### PR TITLE
Data flow: generalize flow-through summaries

### DIFF
--- a/change-notes/1.24/analysis-cpp.md
+++ b/change-notes/1.24/analysis-cpp.md
@@ -26,10 +26,10 @@ The following changes in version 1.24 affect C/C++ analysis in all applications.
 
 ## Changes to libraries
 
-* The data-flow library has been improved when flow through functions needs to be
-  combined with both taint tracking and flow through fields allowing more flow
-  to be tracked. This affects and improves some security queries, which may
-  report additional results.
+* The data-flow library has been improved, which affects and improves some security queries. The improvements are:
+  - Track flow through functions that combine taint tracking with flow through fields.
+  - Track flow through clone-like functions, that is, functions that read contents of a field from a
+    parameter and stores the value in the field of a returned object.
 * Created the `semmle.code.cpp.models.interfaces.Allocation` library to model allocation such as `new` expressions and calls to `malloc`. This in intended to replace the functionality in `semmle.code.cpp.commons.Alloc` with a more consistent and useful interface.
 * Created the `semmle.code.cpp.models.interfaces.Deallocation` library to model deallocation such as `delete` expressions and calls to `free`. This in intended to replace the functionality in `semmle.code.cpp.commons.Alloc` with a more consistent and useful interface.
 * The new class `StackVariable` should be used in place of `LocalScopeVariable`

--- a/change-notes/1.24/analysis-csharp.md
+++ b/change-notes/1.24/analysis-csharp.md
@@ -29,10 +29,10 @@ The following changes in version 1.24 affect C# analysis in all applications.
 
 ## Changes to libraries
 
-* The data-flow library has been improved when flow through methods needs to be
-  combined with both taint tracking and flow through fields allowing more flow
-  to be tracked. This affects and improves most security queries, which may
-  report additional results.
+* The data-flow library has been improved, which affects and improves most security queries. The improvements are:
+  - Track flow through methods that combine taint tracking with flow through fields.
+  - Track flow through clone-like methods, that is, methods that read contents of a field from a
+    parameter and stores the value in the field of a returned object.
 * The taint tracking library now tracks flow through (implicit or explicit) conversion operator calls.
 * [Code contracts](https://docs.microsoft.com/en-us/dotnet/framework/debug-trace-profile/code-contracts) are now recognized, and are treated like any other assertion methods.
 * Expression nullability flow state is given by the predicates `Expr.hasNotNullFlowState()` and `Expr.hasMaybeNullFlowState()`.

--- a/change-notes/1.24/analysis-java.md
+++ b/change-notes/1.24/analysis-java.md
@@ -25,10 +25,10 @@ The following changes in version 1.24 affect Java analysis in all applications.
 
 ## Changes to libraries
 
-* The data-flow library has been improved when flow through methods needs to be
-  combined with both taint tracking and flow through fields allowing more flow
-  to be tracked. This affects and improves most security queries, which may
-  report additional results.
+* The data-flow library has been improved, which affects and improves most security queries. The improvements are:
+  - Track flow through methods that combine taint tracking with flow through fields.
+  - Track flow through clone-like methods, that is, methods that read contents of a field from a
+    parameter and stores the value in the field of a returned object.
 * Identification of test classes has been improved. Previously, one of the
   match conditions would classify any class with a name containing the string
   "Test" as a test class, but now this matching has been replaced with one that

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -383,17 +383,28 @@ private module Cached {
           contentOut = TContentNone() and
           compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
           or
-          // getter(+setter)
+          // getter
           exists(Content fIn |
             contentIn.getContent() = fIn and
-            compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
+            contentOut = TContentNone() and
+            compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType()) and
+            compatibleTypes(fIn.getType(), getErasedNodeTypeBound(out))
           )
           or
           // setter
           exists(Content fOut |
             contentIn = TContentNone() and
             contentOut.getContent() = fOut and
-            compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType())
+            compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(out))
+          )
+          or
+          // getter+setter
+          exists(Content fIn, Content fOut |
+            contentIn.getContent() = fIn and
+            contentOut.getContent() = fOut and
+            compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(out))
           )
         )
       }

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -754,8 +754,14 @@ private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
 }
 
 pragma[noinline]
+private ReturnPosition getReturnPosition0(ReturnNodeExt ret, ReturnKindExt kind) {
+  result.getCallable() = returnNodeGetEnclosingCallable(ret) and
+  kind = result.getKind()
+}
+
+pragma[noinline]
 ReturnPosition getReturnPosition(ReturnNodeExt ret) {
-  result = TReturnPosition0(returnNodeGetEnclosingCallable(ret), ret.getKind())
+  result = getReturnPosition0(ret, ret.getKind())
 }
 
 bindingset[cc, callable]

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplCommon.qll
@@ -1,915 +1,860 @@
 private import DataFlowImplSpecific::Private
-import DataFlowImplSpecific::Public
+private import DataFlowImplSpecific::Public
+import Cached
 
-private ReturnNode getAReturnNodeOfKind(ReturnKind kind) { result.getKind() = kind }
+cached
+private module Cached {
+  /**
+   * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
+   * The instance parameter is considered to have index `-1`.
+   */
+  pragma[nomagic]
+  private predicate viableParam(DataFlowCall call, int i, ParameterNode p) {
+    p.isParameterOf(viableCallable(call), i)
+  }
 
-module Public {
-  import ImplCommon
-  import FlowThrough_v2
-}
+  /**
+   * Holds if `arg` is a possible argument to `p` in `call`, taking virtual
+   * dispatch into account.
+   */
+  cached
+  predicate viableParamArg(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
+    exists(int i |
+      viableParam(call, i, p) and
+      arg.argumentOf(call, i)
+    )
+  }
 
-private module ImplCommon {
-  import Cached
+  /** Provides predicates for calculating flow-through summaries. */
+  private module FlowThrough {
+    /**
+     * The first flow-through approximation:
+     *
+     * - Input/output access paths are abstracted with a Boolean parameter
+     *   that indicates (non-)emptiness.
+     */
+    private module Cand {
+      /**
+       * Holds if `p` can flow to `node` in the same callable using only
+       * value-preserving steps.
+       *
+       * `read` indicates whether it is contents of `p` that can flow to `node`,
+       * and `stored` indicates whether it flows to contents of `node`.
+       */
+      pragma[nomagic]
+      private predicate parameterValueFlowCand(
+        ParameterNode p, Node node, boolean read, boolean stored
+      ) {
+        p = node and
+        read = false and
+        stored = false
+        or
+        // local flow
+        exists(Node mid |
+          parameterValueFlowCand(p, mid, read, stored) and
+          simpleLocalFlowStep(mid, node)
+        )
+        or
+        // read
+        exists(Node mid, boolean readMid, boolean storedMid |
+          parameterValueFlowCand(p, mid, readMid, storedMid) and
+          readStep(mid, _, node) and
+          stored = false
+        |
+          // value neither read nor stored prior to read
+          readMid = false and
+          storedMid = false and
+          read = true
+          or
+          // value (possibly read and then) stored prior to read (same content)
+          read = readMid and
+          storedMid = true
+        )
+        or
+        // store
+        exists(Node mid |
+          parameterValueFlowCand(p, mid, read, false) and
+          storeStep(mid, _, node) and
+          stored = true
+        )
+        or
+        // flow through: no prior read or store
+        exists(ArgumentNode arg |
+          parameterValueFlowArgCand(p, arg, false, false) and
+          argumentValueFlowsThroughCand(arg, node, read, stored)
+        )
+        or
+        // flow through: no read or store inside method
+        exists(ArgumentNode arg |
+          parameterValueFlowArgCand(p, arg, read, stored) and
+          argumentValueFlowsThroughCand(arg, node, false, false)
+        )
+        or
+        // flow through: possible prior read and prior store with compatible
+        // flow-through method
+        exists(ArgumentNode arg, boolean mid |
+          parameterValueFlowArgCand(p, arg, read, mid) and
+          argumentValueFlowsThroughCand(arg, node, mid, stored)
+        )
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowArgCand(
+        ParameterNode p, ArgumentNode arg, boolean read, boolean stored
+      ) {
+        parameterValueFlowCand(p, arg, read, stored)
+      }
+
+      pragma[nomagic]
+      predicate parameterValueFlowsToPreUpdateCand(ParameterNode p, PostUpdateNode n) {
+        parameterValueFlowCand(p, n.getPreUpdateNode(), false, false)
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowsToPostUpdateCand(
+        ParameterNode p, PostUpdateNode n, boolean read
+      ) {
+        parameterValueFlowCand(p, n, read, true)
+      }
+
+      /**
+       * Holds if `p` can flow to a return node of kind `kind` in the same
+       * callable using only value-preserving steps, not taking call contexts
+       * into account.
+       *
+       * `read` indicates whether it is contents of `p` that can flow to the return
+       * node, and `stored` indicates whether it flows to contents of the return
+       * node.
+       */
+      predicate parameterValueFlowReturnCand(
+        ParameterNode p, ReturnKindExt kind, boolean read, boolean stored
+      ) {
+        exists(ReturnNode ret |
+          parameterValueFlowCand(p, ret, read, stored) and
+          kind = TValueReturn(ret.getKind())
+        )
+        or
+        exists(ParameterNode p2, int pos2, PostUpdateNode n |
+          parameterValueFlowsToPostUpdateCand(p, n, read) and
+          parameterValueFlowsToPreUpdateCand(p2, n) and
+          p2.isParameterOf(_, pos2) and
+          kind = TParamUpdate(pos2) and
+          p != p2 and
+          stored = true
+        )
+      }
+
+      pragma[nomagic]
+      private predicate argumentValueFlowsThroughCand0(
+        DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, boolean read, boolean stored
+      ) {
+        exists(ParameterNode param | viableParamArg(call, param, arg) |
+          parameterValueFlowReturnCand(param, kind, read, stored)
+        )
+      }
+
+      /**
+       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
+       * not taking call contexts into account.
+       *
+       * `read` indicates whether it is contents of `arg` that can flow to `out`, and
+       * `stored` indicates whether it flows to contents of `out`.
+       */
+      predicate argumentValueFlowsThroughCand(
+        ArgumentNode arg, Node out, boolean read, boolean stored
+      ) {
+        exists(DataFlowCall call, ReturnKindExt kind |
+          argumentValueFlowsThroughCand0(call, arg, kind, read, stored) and
+          out = kind.getAnOutNode(call)
+        )
+      }
+
+      predicate cand(ParameterNode p, Node n) {
+        parameterValueFlowCand(p, n, _, _) and
+        (
+          parameterValueFlowReturnCand(p, _, _, _)
+          or
+          parameterValueFlowsToPreUpdateCand(p, _)
+        )
+      }
+    }
+
+    private module LocalFlowBigStep {
+      private predicate localFlowEntry(Node n) {
+        Cand::cand(_, n) and
+        (
+          n instanceof ParameterNode or
+          n instanceof OutNode or
+          n instanceof PostUpdateNode or
+          readStep(_, _, n) or
+          n instanceof CastNode
+        )
+      }
+
+      private predicate localFlowExit(Node n) {
+        Cand::cand(_, n) and
+        (
+          n instanceof ArgumentNode
+          or
+          n instanceof ReturnNode
+          or
+          Cand::parameterValueFlowsToPreUpdateCand(_, n)
+          or
+          storeStep(n, _, _)
+          or
+          readStep(n, _, _)
+          or
+          n instanceof CastNode
+          or
+          n =
+            any(PostUpdateNode pun | Cand::parameterValueFlowsToPreUpdateCand(_, pun))
+                .getPreUpdateNode()
+        )
+      }
+
+      pragma[nomagic]
+      private predicate localFlowStepPlus(Node node1, Node node2) {
+        localFlowEntry(node1) and
+        simpleLocalFlowStep(node1, node2) and
+        node1 != node2 and
+        Cand::cand(_, node2)
+        or
+        exists(Node mid |
+          localFlowStepPlus(node1, mid) and
+          simpleLocalFlowStep(mid, node2) and
+          not mid instanceof CastNode and
+          Cand::cand(_, node2)
+        )
+      }
+
+      pragma[nomagic]
+      predicate localFlowBigStep(Node node1, Node node2) {
+        localFlowStepPlus(node1, node2) and
+        localFlowExit(node2)
+      }
+    }
+
+    /**
+     * The final flow-through calculation:
+     *
+     * - Input/output access paths are abstracted with a `ContentOption` parameter
+     *   that represents the head of the access path.
+     * - Types are checked using the `compatibleTypes()` relation.
+     */
+    module Final {
+      /**
+       * Holds if `p` can flow to `node` in the same callable using only
+       * value-preserving steps, not taking call contexts into account.
+       *
+       * `contentIn` describes the content of `p` that can flow to `node`
+       * (if any), and `contentOut` describes the content of `node` that
+       * it flows to (if any).
+       */
+      predicate parameterValueFlow(
+        ParameterNode p, Node node, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow0(p, node, contentIn, contentOut) and
+        Cand::cand(p, node) and
+        if node instanceof CastingNode
+        then
+          // normal flow through
+          contentIn = TContentNone() and
+          contentOut = TContentNone() and
+          compatibleTypes(getErasedNodeTypeBound(p), getErasedNodeTypeBound(node))
+          or
+          // getter
+          exists(Content fIn |
+            contentIn.getContent() = fIn and
+            contentOut = TContentNone() and
+            compatibleTypes(fIn.getType(), getErasedNodeTypeBound(node))
+          )
+          or
+          // setter
+          exists(Content fOut |
+            contentIn = TContentNone() and
+            contentOut.getContent() = fOut and
+            compatibleTypes(getErasedNodeTypeBound(p), fOut.getType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(node))
+          )
+          or
+          // getter+setter
+          exists(Content fIn, Content fOut |
+            contentIn.getContent() = fIn and
+            contentOut.getContent() = fOut and
+            compatibleTypes(fIn.getType(), fOut.getType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(node))
+          )
+        else any()
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlow0(
+        ParameterNode p, Node node, ContentOption contentIn, ContentOption contentOut
+      ) {
+        p = node and
+        Cand::cand(p, _) and
+        contentIn = TContentNone() and
+        contentOut = TContentNone()
+        or
+        // local flow
+        exists(Node mid |
+          parameterValueFlow(p, mid, contentIn, contentOut) and
+          LocalFlowBigStep::localFlowBigStep(mid, node)
+        )
+        or
+        // read
+        exists(Node mid, Content f, ContentOption contentInMid, ContentOption contentOutMid |
+          parameterValueFlow(p, mid, contentInMid, contentOutMid) and
+          readStep(mid, f, node)
+        |
+          // value neither read nor stored prior to read
+          contentInMid = TContentNone() and
+          contentOutMid = TContentNone() and
+          contentIn.getContent() = f and
+          contentOut = TContentNone() and
+          Cand::parameterValueFlowReturnCand(p, _, true, _)
+          or
+          // value (possibly read and then) stored prior to read (same content)
+          contentIn = contentInMid and
+          contentOutMid.getContent() = f and
+          contentOut = TContentNone()
+        )
+        or
+        // store
+        exists(Node mid, Content f |
+          parameterValueFlow(p, mid, contentIn, TContentNone()) and
+          storeStep(mid, f, node) and
+          contentOut.getContent() = f
+        )
+        or
+        // flow through: no prior read or store
+        exists(ArgumentNode arg |
+          parameterValueFlowArg(p, arg, TContentNone(), TContentNone()) and
+          argumentValueFlowsThrough(arg, node, contentIn, contentOut)
+        )
+        or
+        // flow through: no read or store inside method
+        exists(ArgumentNode arg |
+          parameterValueFlowArg(p, arg, contentIn, contentOut) and
+          argumentValueFlowsThrough(arg, node, TContentNone(), TContentNone())
+        )
+        or
+        // flow through: possible prior read and prior store with compatible
+        // flow-through method
+        exists(ArgumentNode arg, ContentOption contentMid |
+          parameterValueFlowArg(p, arg, contentIn, contentMid) and
+          argumentValueFlowsThrough(arg, node, contentMid, contentOut)
+        )
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowArg(
+        ParameterNode p, ArgumentNode arg, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow(p, arg, contentIn, contentOut) and
+        Cand::argumentValueFlowsThroughCand(arg, _, _, _)
+      }
+
+      pragma[nomagic]
+      predicate parameterValueFlowsToPostUpdate(
+        ParameterNode p, PostUpdateNode n, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow(p, n, contentIn, contentOut) and
+        contentOut.hasContent()
+      }
+
+      pragma[nomagic]
+      predicate argumentValueFlowsThrough0(
+        DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, ContentOption contentIn,
+        ContentOption contentOut
+      ) {
+        exists(ParameterNode param | viableParamArg(call, param, arg) |
+          parameterValueFlowReturn(param, _, kind, contentIn, contentOut)
+        )
+      }
+
+      /**
+       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
+       * not taking call contexts into account.
+       *
+       * `contentIn` describes the content of `arg` that can flow to `out` (if any), and
+       * `contentOut` describes the content of `out` that it flows to (if any).
+       */
+      private predicate argumentValueFlowsThrough(
+        ArgumentNode arg, Node out, ContentOption contentIn, ContentOption contentOut
+      ) {
+        exists(DataFlowCall call, ReturnKindExt kind |
+          argumentValueFlowsThrough0(call, arg, kind, contentIn, contentOut) and
+          out = kind.getAnOutNode(call)
+        )
+      }
+    }
+
+    import Final
+  }
+
+  /**
+   * Holds if `p` can flow to the pre-update node associated with post-update
+   * node `n`, in the same callable, using only value-preserving steps.
+   */
+  cached
+  predicate parameterValueFlowsToPreUpdate(ParameterNode p, PostUpdateNode n) {
+    FlowThrough::parameterValueFlow(p, n.getPreUpdateNode(), TContentNone(), TContentNone())
+  }
+
+  /**
+   * Holds if `p` can flow to a return node of kind `kind` in the same
+   * callable using only value-preserving steps.
+   *
+   * `contentIn` describes the content of `p` that can flow to the return
+   * node (if any), and `contentOut` describes the content of the return
+   * node that it flows to (if any).
+   */
+  cached
+  predicate parameterValueFlowReturn(
+    ParameterNode p, Node ret, ReturnKindExt kind, ContentOption contentIn, ContentOption contentOut
+  ) {
+    ret =
+      any(ReturnNode n |
+        FlowThrough::parameterValueFlow(p, n, contentIn, contentOut) and
+        kind = TValueReturn(n.getKind())
+      )
+    or
+    ret =
+      any(PostUpdateNode n |
+        exists(ParameterNode p2, int pos2 |
+          FlowThrough::parameterValueFlowsToPostUpdate(p, n, contentIn, contentOut) and
+          parameterValueFlowsToPreUpdate(p2, n) and
+          p2.isParameterOf(_, pos2) and
+          kind = TParamUpdate(pos2) and
+          p != p2
+        )
+      )
+  }
+
+  /**
+   * Holds if `arg` flows to `out` through `call` using only value-preserving steps.
+   *
+   * `contentIn` describes the content of `arg` that can flow to `out` (if any), and
+   * `contentOut` describes the content of `out` that it flows to (if any).
+   */
+  cached
+  predicate argumentValueFlowsThrough(
+    DataFlowCall call, ArgumentNode arg, ContentOption contentIn, ContentOption contentOut, Node out
+  ) {
+    exists(ReturnKindExt kind |
+      FlowThrough::argumentValueFlowsThrough0(call, arg, kind, contentIn, contentOut) and
+      out = kind.getAnOutNode(call)
+    |
+      // normal flow through
+      contentIn = TContentNone() and
+      contentOut = TContentNone() and
+      compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
+      or
+      // getter
+      exists(Content fIn |
+        contentIn.getContent() = fIn and
+        contentOut = TContentNone() and
+        compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
+      )
+      or
+      // setter
+      exists(Content fOut |
+        contentIn = TContentNone() and
+        contentOut.getContent() = fOut and
+        compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType())
+      )
+      or
+      // getter+setter
+      exists(Content fIn, Content fOut |
+        contentIn.getContent() = fIn and
+        contentOut.getContent() = fOut and
+        compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
+      )
+    )
+  }
+
+  /**
+   * Holds if data can flow from `node1` to `node2` via a direct assignment to
+   * `f`.
+   *
+   * This includes reverse steps through reads when the result of the read has
+   * been stored into, in order to handle cases like `x.f1.f2 = y`.
+   */
+  cached
+  predicate storeDirect(Node node1, Content f, Node node2) {
+    storeStep(node1, f, node2) and readStep(_, f, _)
+    or
+    exists(Node n1, Node n2 |
+      n1 = node1.(PostUpdateNode).getPreUpdateNode() and
+      n2 = node2.(PostUpdateNode).getPreUpdateNode()
+    |
+      argumentValueFlowsThrough(_, n2, TContentSome(f), TContentNone(), n1)
+      or
+      readStep(n2, f, n1)
+    )
+  }
+
+  /**
+   * Holds if the call context `call` either improves virtual dispatch in
+   * `callable` or if it allows us to prune unreachable nodes in `callable`.
+   */
+  cached
+  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+    reducedViableImplInCallContext(_, callable, call)
+    or
+    exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
+  }
 
   cached
-  private module Cached {
-    /**
-     * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
-     * The instance parameter is considered to have index `-1`.
-     */
-    pragma[nomagic]
-    private predicate viableParam(DataFlowCall call, int i, ParameterNode p) {
-      p.isParameterOf(viableCallable(call), i)
-    }
+  newtype TCallContext =
+    TAnyCallContext() or
+    TSpecificCall(DataFlowCall call) { recordDataFlowCallSite(call, _) } or
+    TSomeCall() or
+    TReturn(DataFlowCallable c, DataFlowCall call) { reducedViableImplInReturn(c, call) }
 
-    /**
-     * Holds if `arg` is a possible argument to `p` in `call`, taking virtual
-     * dispatch into account.
-     */
-    cached
-    predicate viableParamArg(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
-      exists(int i |
-        viableParam(call, i, p) and
-        arg.argumentOf(call, i)
+  cached
+  newtype TReturnPosition =
+    TReturnPosition0(DataFlowCallable c, ReturnKindExt kind) {
+      exists(ReturnNodeExt ret |
+        c = returnNodeGetEnclosingCallable(ret) and
+        kind = ret.getKind()
       )
     }
 
-    /*
-     * The `FlowThrough_*` modules take a `step` relation as input and provide
-     * an `argumentValueFlowsThrough` relation as output.
-     *
-     * `FlowThrough_v1` includes just `simpleLocalFlowStep`, which is then used
-     * to detect getters and setters.
-     * `FlowThrough_v2` then includes a little bit of local field flow on top
-     * of `simpleLocalFlowStep`.
-     */
-
-    private module FlowThrough_v1 {
-      private predicate step = simpleLocalFlowStep/2;
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, not taking call contexts into account.
-       */
-      private predicate parameterValueFlowCand(ParameterNode p, Node node) {
-        p = node
-        or
-        exists(Node mid |
-          parameterValueFlowCand(p, mid) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlowCand(p, arg) and
-          argumentValueFlowsThroughCand(arg, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, not taking call contexts
-       * into account.
-       */
-      private predicate parameterValueFlowsThroughCand(ParameterNode p, ReturnKind kind) {
-        parameterValueFlowCand(p, getAReturnNodeOfKind(kind))
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThroughCand0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind
-      ) {
-        exists(ParameterNode param | viableParamArg(call, param, arg) |
-          parameterValueFlowsThroughCand(param, kind)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * not taking call contexts into account.
-       */
-      private predicate argumentValueFlowsThroughCand(ArgumentNode arg, OutNode out) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThroughCand0(call, arg, kind)
-        |
-          out = getAnOutNode(call, kind) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-
-      /**
-       * Holds if `arg` is the `i`th argument of `call` inside the callable
-       * `enclosing`, and `arg` may flow through `call`.
-       */
-      pragma[noinline]
-      private predicate argumentOf(
-        DataFlowCall call, int i, ArgumentNode arg, DataFlowCallable enclosing
-      ) {
-        arg.argumentOf(call, i) and
-        argumentValueFlowsThroughCand(arg, _) and
-        enclosing = arg.getEnclosingCallable()
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg0(
-        int i, ArgumentNode arg, CallContext outercc, DataFlowCall call
-      ) {
-        exists(DataFlowCallable c | argumentOf(call, i, arg, c) |
-          (
-            outercc = TAnyCallContext()
-            or
-            outercc = TSomeCall()
-            or
-            exists(DataFlowCall other | outercc = TSpecificCall(other) |
-              recordDataFlowCallSite(other, c)
-            )
-          ) and
-          not isUnreachableInCall(arg, outercc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg1(
-        ParameterNode p, DataFlowCallable callable, int i, ArgumentNode arg, CallContext outercc,
-        DataFlowCall call
-      ) {
-        viableParamArg0(i, arg, outercc, call) and
-        callable = resolveCall(call, outercc) and
-        p.isParameterOf(callable, any(int j | j <= i and j >= i))
-      }
-
-      /**
-       * Holds if `arg` is a possible argument to `p`, in the call `call`, and
-       * `arg` may flow through `call`. The possible contexts before and after
-       * entering the callable are `outercc` and `innercc`, respectively.
-       */
-      private predicate viableParamArg(
-        DataFlowCall call, ParameterNode p, ArgumentNode arg, CallContext outercc,
-        CallContextCall innercc
-      ) {
-        exists(int i, DataFlowCallable callable |
-          viableParamArg1(p, callable, i, arg, outercc, call)
-        |
-          if recordDataFlowCallSite(call, callable)
-          then innercc = TSpecificCall(call)
-          else innercc = TSomeCall()
-        )
-      }
-
-      private CallContextCall getAValidCallContextForParameter(ParameterNode p) {
-        result = TSomeCall()
-        or
-        exists(DataFlowCall call, DataFlowCallable callable |
-          result = TSpecificCall(call) and
-          p.isParameterOf(callable, _) and
-          recordDataFlowCallSite(call, callable)
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlow(ParameterNode p, Node node, CallContextCall cc) {
-        p = node and
-        parameterValueFlowsThroughCand(p, _) and
-        cc = getAValidCallContextForParameter(p)
-        or
-        exists(Node mid |
-          parameterValueFlow(p, mid, cc) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlow(p, arg, cc) and
-          argumentValueFlowsThrough(arg, node, cc) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlowsThrough(
-        ParameterNode p, ReturnKind kind, CallContextCall cc
-      ) {
-        parameterValueFlow(p, getAReturnNodeOfKind(kind), cc)
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThrough0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind, CallContext cc
-      ) {
-        exists(ParameterNode param, CallContext innercc |
-          viableParamArg(call, param, arg, cc, innercc) and
-          parameterValueFlowsThrough(param, kind, innercc)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * in call context cc.
-       */
-      predicate argumentValueFlowsThrough(ArgumentNode arg, OutNode out, CallContext cc) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThrough0(call, arg, kind, cc)
-        |
-          out = getAnOutNode(call, kind) and
-          not isUnreachableInCall(out, cc.(CallContextSpecificCall).getCall()) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-    }
-
-    /**
-     * Holds if `p` can flow to the pre-update node of `n` in the same callable
-     * using only value-preserving steps.
-     */
-    cached
-    predicate parameterValueFlowsToUpdate(ParameterNode p, PostUpdateNode n) {
-      parameterValueFlowNoCtx(p, n.getPreUpdateNode())
-    }
-
-    /**
-     * Holds if data can flow from `node1` to `node2` in one local step or a step
-     * through a value-preserving method.
-     */
-    private predicate localValueStep(Node node1, Node node2) {
-      simpleLocalFlowStep(node1, node2) or
-      FlowThrough_v1::argumentValueFlowsThrough(node1, node2, _)
-    }
-
-    /**
-     * Holds if `p` can flow to `node` in the same callable allowing local flow
-     * steps and value flow through methods. Call contexts are only accounted
-     * for in the nested calls.
-     */
-    private predicate parameterValueFlowNoCtx(ParameterNode p, Node node) {
-      p = node
-      or
-      exists(Node mid |
-        parameterValueFlowNoCtx(p, mid) and
-        localValueStep(mid, node) and
-        compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-      )
-    }
-
-    /*
-     * Calculation of `predicate store(Node node1, Content f, Node node2)`:
-     * There are four cases:
-     * - The base case: A direct local assignment given by `storeStep`.
-     * - A call to a method or constructor with two arguments, `arg1` and `arg2`,
-     *   such that the call has the side-effect `arg2.f = arg1`.
-     * - A call to a method that returns an object in which an argument has been
-     *   stored.
-     * - A reverse step through a read when the result of the read has been
-     *   stored into. This handles cases like `x.f1.f2 = y`.
-     * `storeViaSideEffect` covers the first two cases, and `storeReturn` covers
-     * the third case.
-     */
-
-    /**
-     * Holds if data can flow from `node1` to `node2` via a direct assignment to
-     * `f` or via a call that acts as a setter.
-     */
-    cached
-    predicate store(Node node1, Content f, Node node2) {
-      storeViaSideEffect(node1, f, node2) or
-      storeReturn(node1, f, node2) or
-      read(node2.(PostUpdateNode).getPreUpdateNode(), f, node1.(PostUpdateNode).getPreUpdateNode())
-    }
-
-    private predicate storeViaSideEffect(Node node1, Content f, PostUpdateNode node2) {
-      storeStep(node1, f, node2) and readStep(_, f, _)
-      or
-      exists(DataFlowCall call, int i1, int i2 |
-        setterCall(call, i1, i2, f) and
-        node1.(ArgumentNode).argumentOf(call, i1) and
-        node2.getPreUpdateNode().(ArgumentNode).argumentOf(call, i2) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getContainerType())
-      )
-    }
-
-    pragma[nomagic]
-    private predicate setterInParam(ParameterNode p1, Content f, ParameterNode p2) {
-      exists(Node n1, PostUpdateNode n2 |
-        parameterValueFlowNoCtx(p1, n1) and
-        storeViaSideEffect(n1, f, n2) and
-        parameterValueFlowNoCtx(p2, n2.getPreUpdateNode()) and
-        p1 != p2
-      )
-    }
-
-    pragma[nomagic]
-    private predicate setterCall(DataFlowCall call, int i1, int i2, Content f) {
-      exists(DataFlowCallable callable, ParameterNode p1, ParameterNode p2 |
-        setterInParam(p1, f, p2) and
-        callable = viableCallable(call) and
-        p1.isParameterOf(callable, i1) and
-        p2.isParameterOf(callable, i2)
-      )
-    }
-
-    pragma[noinline]
-    private predicate storeReturn0(DataFlowCall call, ReturnKind kind, ArgumentNode arg, Content f) {
-      exists(ParameterNode p |
-        viableParamArg(call, p, arg) and
-        setterReturn(p, f, kind)
-      )
-    }
-
-    private predicate storeReturn(Node node1, Content f, Node node2) {
-      exists(DataFlowCall call, ReturnKind kind |
-        storeReturn0(call, kind, node1, f) and
-        node2 = getAnOutNode(call, kind) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getContainerType())
-      )
-    }
-
-    private predicate setterReturn(ParameterNode p, Content f, ReturnKind kind) {
-      exists(Node n1, Node n2 |
-        parameterValueFlowNoCtx(p, n1) and
-        store(n1, f, n2) and
-        localValueStep*(n2, getAReturnNodeOfKind(kind))
-      )
-    }
-
-    pragma[noinline]
-    private predicate read0(DataFlowCall call, ReturnKind kind, ArgumentNode arg, Content f) {
-      exists(ParameterNode p |
-        viableParamArg(call, p, arg) and
-        getter(p, f, kind)
-      )
-    }
-
-    /**
-     * Holds if data can flow from `node1` to `node2` via a direct read of `f` or
-     * via a getter.
-     */
-    cached
-    predicate read(Node node1, Content f, Node node2) {
-      readStep(node1, f, node2)
-      or
-      exists(DataFlowCall call, ReturnKind kind |
-        read0(call, kind, node1, f) and
-        node2 = getAnOutNode(call, kind) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getContainerType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getType())
-      )
-    }
-
-    private predicate getter(ParameterNode p, Content f, ReturnKind kind) {
-      exists(Node n1, Node n2 |
-        parameterValueFlowNoCtx(p, n1) and
-        read(n1, f, n2) and
-        localValueStep*(n2, getAReturnNodeOfKind(kind))
-      )
-    }
-
-    cached
-    predicate localStoreReadStep(Node node1, Node node2) {
-      exists(Node mid1, Node mid2, Content f |
-        store(node1, f, mid1) and
-        localValueStep*(mid1, mid2) and
-        read(mid2, f, node2) and
-        compatibleTypes(getErasedNodeTypeBound(node1), getErasedNodeTypeBound(node2))
-      )
-    }
-
-    cached
-    module FlowThrough_v2 {
-      private predicate step(Node node1, Node node2) {
-        simpleLocalFlowStep(node1, node2) or
-        localStoreReadStep(node1, node2)
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, not taking call contexts into account.
-       */
-      private predicate parameterValueFlowCand(ParameterNode p, Node node) {
-        p = node
-        or
-        exists(Node mid |
-          parameterValueFlowCand(p, mid) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlowCand(p, arg) and
-          argumentValueFlowsThroughCand(arg, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, not taking call contexts
-       * into account.
-       */
-      private predicate parameterValueFlowsThroughCand(ParameterNode p, ReturnKind kind) {
-        parameterValueFlowCand(p, getAReturnNodeOfKind(kind))
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThroughCand0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind
-      ) {
-        exists(ParameterNode param | viableParamArg(call, param, arg) |
-          parameterValueFlowsThroughCand(param, kind)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * not taking call contexts into account.
-       */
-      private predicate argumentValueFlowsThroughCand(ArgumentNode arg, OutNode out) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThroughCand0(call, arg, kind)
-        |
-          out = getAnOutNode(call, kind) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-
-      /**
-       * Holds if `arg` is the `i`th argument of `call` inside the callable
-       * `enclosing`, and `arg` may flow through `call`.
-       */
-      pragma[noinline]
-      private predicate argumentOf(
-        DataFlowCall call, int i, ArgumentNode arg, DataFlowCallable enclosing
-      ) {
-        arg.argumentOf(call, i) and
-        argumentValueFlowsThroughCand(arg, _) and
-        enclosing = arg.getEnclosingCallable()
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg0(
-        int i, ArgumentNode arg, CallContext outercc, DataFlowCall call
-      ) {
-        exists(DataFlowCallable c | argumentOf(call, i, arg, c) |
-          (
-            outercc = TAnyCallContext()
-            or
-            outercc = TSomeCall()
-            or
-            exists(DataFlowCall other | outercc = TSpecificCall(other) |
-              recordDataFlowCallSite(other, c)
-            )
-          ) and
-          not isUnreachableInCall(arg, outercc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg1(
-        ParameterNode p, DataFlowCallable callable, int i, ArgumentNode arg, CallContext outercc,
-        DataFlowCall call
-      ) {
-        viableParamArg0(i, arg, outercc, call) and
-        callable = resolveCall(call, outercc) and
-        p.isParameterOf(callable, any(int j | j <= i and j >= i))
-      }
-
-      /**
-       * Holds if `arg` is a possible argument to `p`, in the call `call`, and
-       * `arg` may flow through `call`. The possible contexts before and after
-       * entering the callable are `outercc` and `innercc`, respectively.
-       */
-      private predicate viableParamArg(
-        DataFlowCall call, ParameterNode p, ArgumentNode arg, CallContext outercc,
-        CallContextCall innercc
-      ) {
-        exists(int i, DataFlowCallable callable |
-          viableParamArg1(p, callable, i, arg, outercc, call)
-        |
-          if recordDataFlowCallSite(call, callable)
-          then innercc = TSpecificCall(call)
-          else innercc = TSomeCall()
-        )
-      }
-
-      private CallContextCall getAValidCallContextForParameter(ParameterNode p) {
-        result = TSomeCall()
-        or
-        exists(DataFlowCall call, DataFlowCallable callable |
-          result = TSpecificCall(call) and
-          p.isParameterOf(callable, _) and
-          recordDataFlowCallSite(call, callable)
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlow(ParameterNode p, Node node, CallContextCall cc) {
-        p = node and
-        parameterValueFlowsThroughCand(p, _) and
-        cc = getAValidCallContextForParameter(p)
-        or
-        exists(Node mid |
-          parameterValueFlow(p, mid, cc) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlow(p, arg, cc) and
-          argumentValueFlowsThrough(arg, node, cc) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, in call context `cc`.
-       */
-      cached
-      predicate parameterValueFlowsThrough(ParameterNode p, ReturnKind kind, CallContextCall cc) {
-        parameterValueFlow(p, getAReturnNodeOfKind(kind), cc)
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThrough0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind, CallContext cc
-      ) {
-        exists(ParameterNode param, CallContext innercc |
-          viableParamArg(call, param, arg, cc, innercc) and
-          parameterValueFlowsThrough(param, kind, innercc)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * in call context cc.
-       */
-      cached
-      predicate argumentValueFlowsThrough(ArgumentNode arg, OutNode out, CallContext cc) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThrough0(call, arg, kind, cc)
-        |
-          out = getAnOutNode(call, kind) and
-          not isUnreachableInCall(out, cc.(CallContextSpecificCall).getCall()) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-    }
-
-    /**
-     * Holds if the call context `call` either improves virtual dispatch in
-     * `callable` or if it allows us to prune unreachable nodes in `callable`.
-     */
-    cached
-    predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
-      reducedViableImplInCallContext(_, callable, call)
-      or
-      exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
-    }
-
-    cached
-    newtype TCallContext =
-      TAnyCallContext() or
-      TSpecificCall(DataFlowCall call) { recordDataFlowCallSite(call, _) } or
-      TSomeCall() or
-      TReturn(DataFlowCallable c, DataFlowCall call) { reducedViableImplInReturn(c, call) }
-
-    cached
-    newtype TReturnPosition =
-      TReturnPosition0(DataFlowCallable c, ReturnKindExt kind) { returnPosition(_, c, kind) }
-
-    cached
-    newtype TLocalFlowCallContext =
-      TAnyLocalCall() or
-      TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
-  }
-
-  pragma[noinline]
-  private predicate returnPosition(ReturnNodeExt ret, DataFlowCallable c, ReturnKindExt kind) {
-    c = returnNodeGetEnclosingCallable(ret) and
-    kind = ret.getKind()
-  }
-
-  /**
-   * A call context to restrict the targets of virtual dispatch, prune local flow,
-   * and match the call sites of flow into a method with flow out of a method.
-   *
-   * There are four cases:
-   * - `TAnyCallContext()` : No restrictions on method flow.
-   * - `TSpecificCall(DataFlowCall call)` : Flow entered through the
-   *    given `call`. This call improves the set of viable
-   *    dispatch targets for at least one method call in the current callable
-   *    or helps prune unreachable nodes in the current callable.
-   * - `TSomeCall()` : Flow entered through a parameter. The
-   *    originating call does not improve the set of dispatch targets for any
-   *    method call in the current callable and was therefore not recorded.
-   * - `TReturn(Callable c, DataFlowCall call)` : Flow reached `call` from `c` and
-   *    this dispatch target of `call` implies a reduced set of dispatch origins
-   *    to which data may flow if it should reach a `return` statement.
-   */
-  abstract class CallContext extends TCallContext {
-    abstract string toString();
-
-    /** Holds if this call context is relevant for `callable`. */
-    abstract predicate relevantFor(DataFlowCallable callable);
-  }
-
-  class CallContextAny extends CallContext, TAnyCallContext {
-    override string toString() { result = "CcAny" }
-
-    override predicate relevantFor(DataFlowCallable callable) { any() }
-  }
-
-  abstract class CallContextCall extends CallContext { }
-
-  class CallContextSpecificCall extends CallContextCall, TSpecificCall {
-    override string toString() {
-      exists(DataFlowCall call | this = TSpecificCall(call) | result = "CcCall(" + call + ")")
-    }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      recordDataFlowCallSite(getCall(), callable)
-    }
-
-    DataFlowCall getCall() { this = TSpecificCall(result) }
-  }
-
-  class CallContextSomeCall extends CallContextCall, TSomeCall {
-    override string toString() { result = "CcSomeCall" }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      exists(ParameterNode p | p.getEnclosingCallable() = callable)
-    }
-  }
-
-  class CallContextReturn extends CallContext, TReturn {
-    override string toString() {
-      exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
-    }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      exists(DataFlowCall call | this = TReturn(_, call) and call.getEnclosingCallable() = callable)
-    }
-  }
-
-  /**
-   * A call context that is relevant for pruning local flow.
-   */
-  abstract class LocalCallContext extends TLocalFlowCallContext {
-    abstract string toString();
-
-    /** Holds if this call context is relevant for `callable`. */
-    abstract predicate relevantFor(DataFlowCallable callable);
-  }
-
-  class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
-    override string toString() { result = "LocalCcAny" }
-
-    override predicate relevantFor(DataFlowCallable callable) { any() }
-  }
-
-  class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
-    LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
-
-    DataFlowCall call;
-
-    DataFlowCall getCall() { result = call }
-
-    override string toString() { result = "LocalCcCall(" + call + ")" }
-
-    override predicate relevantFor(DataFlowCallable callable) { relevantLocalCCtx(call, callable) }
-  }
-
-  private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
-    exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
-  }
-
-  /**
-   * Gets the local call context given the call context and the callable that
-   * the contexts apply to.
-   */
-  LocalCallContext getLocalCallContext(CallContext ctx, DataFlowCallable callable) {
-    ctx.relevantFor(callable) and
-    if relevantLocalCCtx(ctx.(CallContextSpecificCall).getCall(), callable)
-    then result.(LocalCallContextSpecificCall).getCall() = ctx.(CallContextSpecificCall).getCall()
-    else result instanceof LocalCallContextAny
-  }
-
-  /**
-   * A node from which flow can return to the caller. This is either a regular
-   * `ReturnNode` or a `PostUpdateNode` corresponding to the value of a parameter.
-   */
-  class ReturnNodeExt extends Node {
-    ReturnNodeExt() {
-      this instanceof ReturnNode or
-      parameterValueFlowsToUpdate(_, this)
-    }
-
-    /** Gets the kind of this returned value. */
-    ReturnKindExt getKind() {
-      result = TValueReturn(this.(ReturnNode).getKind())
-      or
-      exists(ParameterNode p, int pos |
-        parameterValueFlowsToUpdate(p, this) and
-        p.isParameterOf(_, pos) and
-        result = TParamUpdate(pos)
-      )
-    }
-  }
-
-  private newtype TReturnKindExt =
+  cached
+  newtype TLocalFlowCallContext =
+    TAnyLocalCall() or
+    TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
+
+  cached
+  newtype TReturnKindExt =
     TValueReturn(ReturnKind kind) or
-    TParamUpdate(int pos) {
-      exists(ParameterNode p | parameterValueFlowsToUpdate(p, _) and p.isParameterOf(_, pos))
-    }
-
-  /**
-   * An extended return kind. A return kind describes how data can be returned
-   * from a callable. This can either be through a returned value or an updated
-   * parameter.
-   */
-  abstract class ReturnKindExt extends TReturnKindExt {
-    /** Gets a textual representation of this return kind. */
-    abstract string toString();
-
-    /** Gets a node corresponding to data flow out of `call`. */
-    abstract Node getAnOutNode(DataFlowCall call);
-  }
-
-  class ValueReturnKind extends ReturnKindExt, TValueReturn {
-    private ReturnKind kind;
-
-    ValueReturnKind() { this = TValueReturn(kind) }
-
-    ReturnKind getKind() { result = kind }
-
-    override string toString() { result = kind.toString() }
-
-    override Node getAnOutNode(DataFlowCall call) { result = getAnOutNode(call, this.getKind()) }
-  }
-
-  class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
-    private int pos;
-
-    ParamUpdateReturnKind() { this = TParamUpdate(pos) }
-
-    int getPosition() { result = pos }
-
-    override string toString() { result = "param update " + pos }
-
-    override Node getAnOutNode(DataFlowCall call) {
-      exists(ArgumentNode arg |
-        result.(PostUpdateNode).getPreUpdateNode() = arg and
-        arg.argumentOf(call, this.getPosition())
-      )
-    }
-  }
-
-  /** A callable tagged with a relevant return kind. */
-  class ReturnPosition extends TReturnPosition0 {
-    private DataFlowCallable c;
-    private ReturnKindExt kind;
-
-    ReturnPosition() { this = TReturnPosition0(c, kind) }
-
-    /** Gets the callable. */
-    DataFlowCallable getCallable() { result = c }
-
-    /** Gets the return kind. */
-    ReturnKindExt getKind() { result = kind }
-
-    /** Gets a textual representation of this return position. */
-    string toString() { result = "[" + kind + "] " + c }
-  }
-
-  pragma[noinline]
-  DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
-    result = ret.getEnclosingCallable()
-  }
-
-  pragma[noinline]
-  ReturnPosition getReturnPosition(ReturnNodeExt ret) {
-    exists(DataFlowCallable c, ReturnKindExt k | returnPosition(ret, c, k) |
-      result = TReturnPosition0(c, k)
-    )
-  }
-
-  bindingset[cc, callable]
-  predicate resolveReturn(CallContext cc, DataFlowCallable callable, DataFlowCall call) {
-    cc instanceof CallContextAny and callable = viableCallable(call)
-    or
-    exists(DataFlowCallable c0, DataFlowCall call0 |
-      call0.getEnclosingCallable() = callable and
-      cc = TReturn(c0, call0) and
-      c0 = prunedViableImplInCallContextReverse(call0, call)
-    )
-  }
-
-  bindingset[call, cc]
-  DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
-    exists(DataFlowCall ctx | cc = TSpecificCall(ctx) |
-      if reducedViableImplInCallContext(call, _, ctx)
-      then result = prunedViableImplInCallContext(call, ctx)
-      else result = viableCallable(call)
-    )
-    or
-    result = viableCallable(call) and cc instanceof CallContextSomeCall
-    or
-    result = viableCallable(call) and cc instanceof CallContextAny
-    or
-    result = viableCallable(call) and cc instanceof CallContextReturn
-  }
-
-  newtype TSummary =
-    TSummaryVal() or
-    TSummaryTaint() or
-    TSummaryReadVal(Content f) or
-    TSummaryReadTaint(Content f) or
-    TSummaryTaintStore(Content f)
-
-  /**
-   * A summary of flow through a callable. This can either be value-preserving
-   * if no additional steps are used, taint-flow if at least one additional step
-   * is used, or any one of those combined with a store or a read. Summaries
-   * recorded at a return node are restricted to include at least one additional
-   * step, as the value-based summaries are calculated independent of the
-   * configuration.
-   */
-  class Summary extends TSummary {
-    string toString() {
-      result = "Val" and this = TSummaryVal()
-      or
-      result = "Taint" and this = TSummaryTaint()
-      or
-      exists(Content f |
-        result = "ReadVal " + f.toString() and this = TSummaryReadVal(f)
-        or
-        result = "ReadTaint " + f.toString() and this = TSummaryReadTaint(f)
-        or
-        result = "TaintStore " + f.toString() and this = TSummaryTaintStore(f)
-      )
-    }
-
-    /** Gets the summary that results from extending this with an additional step. */
-    Summary additionalStep() {
-      this = TSummaryVal() and result = TSummaryTaint()
-      or
-      this = TSummaryTaint() and result = TSummaryTaint()
-      or
-      exists(Content f | this = TSummaryReadVal(f) and result = TSummaryReadTaint(f))
-      or
-      exists(Content f | this = TSummaryReadTaint(f) and result = TSummaryReadTaint(f))
-    }
-
-    /** Gets the summary that results from extending this with a read. */
-    Summary readStep(Content f) { this = TSummaryVal() and result = TSummaryReadVal(f) }
-
-    /** Gets the summary that results from extending this with a store. */
-    Summary storeStep(Content f) { this = TSummaryTaint() and result = TSummaryTaintStore(f) }
-
-    /** Gets the summary that results from extending this with `step`. */
-    bindingset[this, step]
-    Summary compose(Summary step) {
-      this = TSummaryVal() and result = step
-      or
-      this = TSummaryTaint() and
-      (step = TSummaryTaint() or step = TSummaryTaintStore(_)) and
-      result = step
-      or
-      exists(Content f |
-        this = TSummaryReadVal(f) and step = TSummaryTaint() and result = TSummaryReadTaint(f)
-      )
-      or
-      this = TSummaryReadTaint(_) and step = TSummaryTaint() and result = this
-    }
-
-    /** Holds if this summary does not include any taint steps. */
-    predicate isPartial() {
-      this = TSummaryVal() or
-      this = TSummaryReadVal(_)
-    }
-  }
-
-  pragma[noinline]
-  DataFlowType getErasedNodeType(Node n) { result = getErasedRepr(n.getType()) }
-
-  pragma[noinline]
-  DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
+    TParamUpdate(int pos) { exists(ParameterNode p | p.isParameterOf(_, pos)) }
 }
+
+/**
+ * A `Node` at which a cast can occur such that the type should be checked.
+ */
+class CastingNode extends Node {
+  CastingNode() {
+    this instanceof ParameterNode or
+    this instanceof CastNode or
+    this instanceof OutNode or
+    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
+  }
+}
+
+newtype TContentOption =
+  TContentNone() or
+  TContentSome(Content f)
+
+class ContentOption extends TContentOption {
+  Content getContent() { this = TContentSome(result) }
+
+  predicate hasContent() { exists(this.getContent()) }
+
+  string toString() {
+    result = this.getContent().toString()
+    or
+    not this.hasContent() and
+    result = ""
+  }
+}
+
+/**
+ * A call context to restrict the targets of virtual dispatch, prune local flow,
+ * and match the call sites of flow into a method with flow out of a method.
+ *
+ * There are four cases:
+ * - `TAnyCallContext()` : No restrictions on method flow.
+ * - `TSpecificCall(DataFlowCall call)` : Flow entered through the
+ *    given `call`. This call improves the set of viable
+ *    dispatch targets for at least one method call in the current callable
+ *    or helps prune unreachable nodes in the current callable.
+ * - `TSomeCall()` : Flow entered through a parameter. The
+ *    originating call does not improve the set of dispatch targets for any
+ *    method call in the current callable and was therefore not recorded.
+ * - `TReturn(Callable c, DataFlowCall call)` : Flow reached `call` from `c` and
+ *    this dispatch target of `call` implies a reduced set of dispatch origins
+ *    to which data may flow if it should reach a `return` statement.
+ */
+abstract class CallContext extends TCallContext {
+  abstract string toString();
+
+  /** Holds if this call context is relevant for `callable`. */
+  abstract predicate relevantFor(DataFlowCallable callable);
+}
+
+class CallContextAny extends CallContext, TAnyCallContext {
+  override string toString() { result = "CcAny" }
+
+  override predicate relevantFor(DataFlowCallable callable) { any() }
+}
+
+abstract class CallContextCall extends CallContext { }
+
+class CallContextSpecificCall extends CallContextCall, TSpecificCall {
+  override string toString() {
+    exists(DataFlowCall call | this = TSpecificCall(call) | result = "CcCall(" + call + ")")
+  }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    recordDataFlowCallSite(getCall(), callable)
+  }
+
+  DataFlowCall getCall() { this = TSpecificCall(result) }
+}
+
+class CallContextSomeCall extends CallContextCall, TSomeCall {
+  override string toString() { result = "CcSomeCall" }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    exists(ParameterNode p | p.getEnclosingCallable() = callable)
+  }
+}
+
+class CallContextReturn extends CallContext, TReturn {
+  override string toString() {
+    exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
+  }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    exists(DataFlowCall call | this = TReturn(_, call) and call.getEnclosingCallable() = callable)
+  }
+}
+
+/**
+ * A call context that is relevant for pruning local flow.
+ */
+abstract class LocalCallContext extends TLocalFlowCallContext {
+  abstract string toString();
+
+  /** Holds if this call context is relevant for `callable`. */
+  abstract predicate relevantFor(DataFlowCallable callable);
+}
+
+class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
+  override string toString() { result = "LocalCcAny" }
+
+  override predicate relevantFor(DataFlowCallable callable) { any() }
+}
+
+class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
+  LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
+
+  DataFlowCall call;
+
+  DataFlowCall getCall() { result = call }
+
+  override string toString() { result = "LocalCcCall(" + call + ")" }
+
+  override predicate relevantFor(DataFlowCallable callable) { relevantLocalCCtx(call, callable) }
+}
+
+private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
+  exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
+}
+
+/**
+ * Gets the local call context given the call context and the callable that
+ * the contexts apply to.
+ */
+LocalCallContext getLocalCallContext(CallContext ctx, DataFlowCallable callable) {
+  ctx.relevantFor(callable) and
+  if relevantLocalCCtx(ctx.(CallContextSpecificCall).getCall(), callable)
+  then result.(LocalCallContextSpecificCall).getCall() = ctx.(CallContextSpecificCall).getCall()
+  else result instanceof LocalCallContextAny
+}
+
+/**
+ * A node from which flow can return to the caller. This is either a regular
+ * `ReturnNode` or a `PostUpdateNode` corresponding to the value of a parameter.
+ */
+class ReturnNodeExt extends Node {
+  ReturnNodeExt() {
+    this instanceof ReturnNode or
+    parameterValueFlowsToPreUpdate(_, this)
+  }
+
+  /** Gets the kind of this returned value. */
+  ReturnKindExt getKind() {
+    result = TValueReturn(this.(ReturnNode).getKind())
+    or
+    exists(ParameterNode p, int pos |
+      parameterValueFlowsToPreUpdate(p, this) and
+      p.isParameterOf(_, pos) and
+      result = TParamUpdate(pos)
+    )
+  }
+}
+
+/**
+ * An extended return kind. A return kind describes how data can be returned
+ * from a callable. This can either be through a returned value or an updated
+ * parameter.
+ */
+abstract class ReturnKindExt extends TReturnKindExt {
+  /** Gets a textual representation of this return kind. */
+  abstract string toString();
+
+  /** Gets a node corresponding to data flow out of `call`. */
+  abstract Node getAnOutNode(DataFlowCall call);
+}
+
+class ValueReturnKind extends ReturnKindExt, TValueReturn {
+  private ReturnKind kind;
+
+  ValueReturnKind() { this = TValueReturn(kind) }
+
+  ReturnKind getKind() { result = kind }
+
+  override string toString() { result = kind.toString() }
+
+  override Node getAnOutNode(DataFlowCall call) { result = getAnOutNode(call, this.getKind()) }
+}
+
+class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
+  private int pos;
+
+  ParamUpdateReturnKind() { this = TParamUpdate(pos) }
+
+  int getPosition() { result = pos }
+
+  override string toString() { result = "param update " + pos }
+
+  override PostUpdateNode getAnOutNode(DataFlowCall call) {
+    exists(ArgumentNode arg |
+      result.getPreUpdateNode() = arg and
+      arg.argumentOf(call, this.getPosition())
+    )
+  }
+}
+
+/** A callable tagged with a relevant return kind. */
+class ReturnPosition extends TReturnPosition0 {
+  private DataFlowCallable c;
+  private ReturnKindExt kind;
+
+  ReturnPosition() { this = TReturnPosition0(c, kind) }
+
+  /** Gets the callable. */
+  DataFlowCallable getCallable() { result = c }
+
+  /** Gets the return kind. */
+  ReturnKindExt getKind() { result = kind }
+
+  /** Gets a textual representation of this return position. */
+  string toString() { result = "[" + kind + "] " + c }
+}
+
+pragma[noinline]
+private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
+  result = ret.getEnclosingCallable()
+}
+
+pragma[noinline]
+ReturnPosition getReturnPosition(ReturnNodeExt ret) {
+  result = TReturnPosition0(returnNodeGetEnclosingCallable(ret), ret.getKind())
+}
+
+bindingset[cc, callable]
+predicate resolveReturn(CallContext cc, DataFlowCallable callable, DataFlowCall call) {
+  cc instanceof CallContextAny and callable = viableCallable(call)
+  or
+  exists(DataFlowCallable c0, DataFlowCall call0 |
+    call0.getEnclosingCallable() = callable and
+    cc = TReturn(c0, call0) and
+    c0 = prunedViableImplInCallContextReverse(call0, call)
+  )
+}
+
+bindingset[call, cc]
+DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
+  exists(DataFlowCall ctx | cc = TSpecificCall(ctx) |
+    if reducedViableImplInCallContext(call, _, ctx)
+    then result = prunedViableImplInCallContext(call, ctx)
+    else result = viableCallable(call)
+  )
+  or
+  result = viableCallable(call) and cc instanceof CallContextSomeCall
+  or
+  result = viableCallable(call) and cc instanceof CallContextAny
+  or
+  result = viableCallable(call) and cc instanceof CallContextReturn
+}
+
+newtype TSummary =
+  TSummaryVal() or
+  TSummaryTaint() or
+  TSummaryReadVal(Content f) or
+  TSummaryReadTaint(Content f) or
+  TSummaryTaintStore(Content f)
+
+/**
+ * A summary of flow through a callable. This can either be value-preserving
+ * if no additional steps are used, taint-flow if at least one additional step
+ * is used, or any one of those combined with a store or a read. Summaries
+ * recorded at a return node are restricted to include at least one additional
+ * step, as the value-based summaries are calculated independent of the
+ * configuration.
+ */
+class Summary extends TSummary {
+  string toString() {
+    result = "Val" and this = TSummaryVal()
+    or
+    result = "Taint" and this = TSummaryTaint()
+    or
+    exists(Content f |
+      result = "ReadVal " + f.toString() and this = TSummaryReadVal(f)
+      or
+      result = "ReadTaint " + f.toString() and this = TSummaryReadTaint(f)
+      or
+      result = "TaintStore " + f.toString() and this = TSummaryTaintStore(f)
+    )
+  }
+
+  /** Gets the summary that results from extending this with an additional step. */
+  Summary additionalStep() {
+    this = TSummaryVal() and result = TSummaryTaint()
+    or
+    this = TSummaryTaint() and result = TSummaryTaint()
+    or
+    exists(Content f | this = TSummaryReadVal(f) and result = TSummaryReadTaint(f))
+    or
+    exists(Content f | this = TSummaryReadTaint(f) and result = TSummaryReadTaint(f))
+  }
+
+  /** Gets the summary that results from extending this with a read. */
+  Summary readStep(Content f) { this = TSummaryVal() and result = TSummaryReadVal(f) }
+
+  /** Gets the summary that results from extending this with a store. */
+  Summary storeStep(Content f) { this = TSummaryTaint() and result = TSummaryTaintStore(f) }
+
+  /** Gets the summary that results from extending this with `step`. */
+  bindingset[this, step]
+  Summary compose(Summary step) {
+    this = TSummaryVal() and result = step
+    or
+    this = TSummaryTaint() and
+    (step = TSummaryTaint() or step = TSummaryTaintStore(_)) and
+    result = step
+    or
+    exists(Content f |
+      this = TSummaryReadVal(f) and step = TSummaryTaint() and result = TSummaryReadTaint(f)
+    )
+    or
+    this = TSummaryReadTaint(_) and step = TSummaryTaint() and result = this
+  }
+
+  /** Holds if this summary does not include any taint steps. */
+  predicate isPartial() {
+    this = TSummaryVal() or
+    this = TSummaryReadVal(_)
+  }
+}
+
+pragma[noinline]
+DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
+
+predicate readDirect = readStep/3;

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -301,3 +301,5 @@ class DataFlowCall extends Expr {
 }
 
 predicate isUnreachableInCall(Node n, DataFlowCall call) { none() } // stub implementation
+
+int flowThroughAccessPathLimit() { none() }

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -302,4 +302,4 @@ class DataFlowCall extends Expr {
 
 predicate isUnreachableInCall(Node n, DataFlowCall call) { none() } // stub implementation
 
-int flowThroughAccessPathLimit() { none() }
+int accessPathLimit() { result = 5 }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -383,17 +383,28 @@ private module Cached {
           contentOut = TContentNone() and
           compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
           or
-          // getter(+setter)
+          // getter
           exists(Content fIn |
             contentIn.getContent() = fIn and
-            compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
+            contentOut = TContentNone() and
+            compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType()) and
+            compatibleTypes(fIn.getType(), getErasedNodeTypeBound(out))
           )
           or
           // setter
           exists(Content fOut |
             contentIn = TContentNone() and
             contentOut.getContent() = fOut and
-            compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType())
+            compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(out))
+          )
+          or
+          // getter+setter
+          exists(Content fIn, Content fOut |
+            contentIn.getContent() = fIn and
+            contentOut.getContent() = fOut and
+            compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(out))
           )
         )
       }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -754,8 +754,14 @@ private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
 }
 
 pragma[noinline]
+private ReturnPosition getReturnPosition0(ReturnNodeExt ret, ReturnKindExt kind) {
+  result.getCallable() = returnNodeGetEnclosingCallable(ret) and
+  kind = result.getKind()
+}
+
+pragma[noinline]
 ReturnPosition getReturnPosition(ReturnNodeExt ret) {
-  result = TReturnPosition0(returnNodeGetEnclosingCallable(ret), ret.getKind())
+  result = getReturnPosition0(ret, ret.getKind())
 }
 
 bindingset[cc, callable]

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplCommon.qll
@@ -1,915 +1,860 @@
 private import DataFlowImplSpecific::Private
-import DataFlowImplSpecific::Public
+private import DataFlowImplSpecific::Public
+import Cached
 
-private ReturnNode getAReturnNodeOfKind(ReturnKind kind) { result.getKind() = kind }
+cached
+private module Cached {
+  /**
+   * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
+   * The instance parameter is considered to have index `-1`.
+   */
+  pragma[nomagic]
+  private predicate viableParam(DataFlowCall call, int i, ParameterNode p) {
+    p.isParameterOf(viableCallable(call), i)
+  }
 
-module Public {
-  import ImplCommon
-  import FlowThrough_v2
-}
+  /**
+   * Holds if `arg` is a possible argument to `p` in `call`, taking virtual
+   * dispatch into account.
+   */
+  cached
+  predicate viableParamArg(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
+    exists(int i |
+      viableParam(call, i, p) and
+      arg.argumentOf(call, i)
+    )
+  }
 
-private module ImplCommon {
-  import Cached
+  /** Provides predicates for calculating flow-through summaries. */
+  private module FlowThrough {
+    /**
+     * The first flow-through approximation:
+     *
+     * - Input/output access paths are abstracted with a Boolean parameter
+     *   that indicates (non-)emptiness.
+     */
+    private module Cand {
+      /**
+       * Holds if `p` can flow to `node` in the same callable using only
+       * value-preserving steps.
+       *
+       * `read` indicates whether it is contents of `p` that can flow to `node`,
+       * and `stored` indicates whether it flows to contents of `node`.
+       */
+      pragma[nomagic]
+      private predicate parameterValueFlowCand(
+        ParameterNode p, Node node, boolean read, boolean stored
+      ) {
+        p = node and
+        read = false and
+        stored = false
+        or
+        // local flow
+        exists(Node mid |
+          parameterValueFlowCand(p, mid, read, stored) and
+          simpleLocalFlowStep(mid, node)
+        )
+        or
+        // read
+        exists(Node mid, boolean readMid, boolean storedMid |
+          parameterValueFlowCand(p, mid, readMid, storedMid) and
+          readStep(mid, _, node) and
+          stored = false
+        |
+          // value neither read nor stored prior to read
+          readMid = false and
+          storedMid = false and
+          read = true
+          or
+          // value (possibly read and then) stored prior to read (same content)
+          read = readMid and
+          storedMid = true
+        )
+        or
+        // store
+        exists(Node mid |
+          parameterValueFlowCand(p, mid, read, false) and
+          storeStep(mid, _, node) and
+          stored = true
+        )
+        or
+        // flow through: no prior read or store
+        exists(ArgumentNode arg |
+          parameterValueFlowArgCand(p, arg, false, false) and
+          argumentValueFlowsThroughCand(arg, node, read, stored)
+        )
+        or
+        // flow through: no read or store inside method
+        exists(ArgumentNode arg |
+          parameterValueFlowArgCand(p, arg, read, stored) and
+          argumentValueFlowsThroughCand(arg, node, false, false)
+        )
+        or
+        // flow through: possible prior read and prior store with compatible
+        // flow-through method
+        exists(ArgumentNode arg, boolean mid |
+          parameterValueFlowArgCand(p, arg, read, mid) and
+          argumentValueFlowsThroughCand(arg, node, mid, stored)
+        )
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowArgCand(
+        ParameterNode p, ArgumentNode arg, boolean read, boolean stored
+      ) {
+        parameterValueFlowCand(p, arg, read, stored)
+      }
+
+      pragma[nomagic]
+      predicate parameterValueFlowsToPreUpdateCand(ParameterNode p, PostUpdateNode n) {
+        parameterValueFlowCand(p, n.getPreUpdateNode(), false, false)
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowsToPostUpdateCand(
+        ParameterNode p, PostUpdateNode n, boolean read
+      ) {
+        parameterValueFlowCand(p, n, read, true)
+      }
+
+      /**
+       * Holds if `p` can flow to a return node of kind `kind` in the same
+       * callable using only value-preserving steps, not taking call contexts
+       * into account.
+       *
+       * `read` indicates whether it is contents of `p` that can flow to the return
+       * node, and `stored` indicates whether it flows to contents of the return
+       * node.
+       */
+      predicate parameterValueFlowReturnCand(
+        ParameterNode p, ReturnKindExt kind, boolean read, boolean stored
+      ) {
+        exists(ReturnNode ret |
+          parameterValueFlowCand(p, ret, read, stored) and
+          kind = TValueReturn(ret.getKind())
+        )
+        or
+        exists(ParameterNode p2, int pos2, PostUpdateNode n |
+          parameterValueFlowsToPostUpdateCand(p, n, read) and
+          parameterValueFlowsToPreUpdateCand(p2, n) and
+          p2.isParameterOf(_, pos2) and
+          kind = TParamUpdate(pos2) and
+          p != p2 and
+          stored = true
+        )
+      }
+
+      pragma[nomagic]
+      private predicate argumentValueFlowsThroughCand0(
+        DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, boolean read, boolean stored
+      ) {
+        exists(ParameterNode param | viableParamArg(call, param, arg) |
+          parameterValueFlowReturnCand(param, kind, read, stored)
+        )
+      }
+
+      /**
+       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
+       * not taking call contexts into account.
+       *
+       * `read` indicates whether it is contents of `arg` that can flow to `out`, and
+       * `stored` indicates whether it flows to contents of `out`.
+       */
+      predicate argumentValueFlowsThroughCand(
+        ArgumentNode arg, Node out, boolean read, boolean stored
+      ) {
+        exists(DataFlowCall call, ReturnKindExt kind |
+          argumentValueFlowsThroughCand0(call, arg, kind, read, stored) and
+          out = kind.getAnOutNode(call)
+        )
+      }
+
+      predicate cand(ParameterNode p, Node n) {
+        parameterValueFlowCand(p, n, _, _) and
+        (
+          parameterValueFlowReturnCand(p, _, _, _)
+          or
+          parameterValueFlowsToPreUpdateCand(p, _)
+        )
+      }
+    }
+
+    private module LocalFlowBigStep {
+      private predicate localFlowEntry(Node n) {
+        Cand::cand(_, n) and
+        (
+          n instanceof ParameterNode or
+          n instanceof OutNode or
+          n instanceof PostUpdateNode or
+          readStep(_, _, n) or
+          n instanceof CastNode
+        )
+      }
+
+      private predicate localFlowExit(Node n) {
+        Cand::cand(_, n) and
+        (
+          n instanceof ArgumentNode
+          or
+          n instanceof ReturnNode
+          or
+          Cand::parameterValueFlowsToPreUpdateCand(_, n)
+          or
+          storeStep(n, _, _)
+          or
+          readStep(n, _, _)
+          or
+          n instanceof CastNode
+          or
+          n =
+            any(PostUpdateNode pun | Cand::parameterValueFlowsToPreUpdateCand(_, pun))
+                .getPreUpdateNode()
+        )
+      }
+
+      pragma[nomagic]
+      private predicate localFlowStepPlus(Node node1, Node node2) {
+        localFlowEntry(node1) and
+        simpleLocalFlowStep(node1, node2) and
+        node1 != node2 and
+        Cand::cand(_, node2)
+        or
+        exists(Node mid |
+          localFlowStepPlus(node1, mid) and
+          simpleLocalFlowStep(mid, node2) and
+          not mid instanceof CastNode and
+          Cand::cand(_, node2)
+        )
+      }
+
+      pragma[nomagic]
+      predicate localFlowBigStep(Node node1, Node node2) {
+        localFlowStepPlus(node1, node2) and
+        localFlowExit(node2)
+      }
+    }
+
+    /**
+     * The final flow-through calculation:
+     *
+     * - Input/output access paths are abstracted with a `ContentOption` parameter
+     *   that represents the head of the access path.
+     * - Types are checked using the `compatibleTypes()` relation.
+     */
+    module Final {
+      /**
+       * Holds if `p` can flow to `node` in the same callable using only
+       * value-preserving steps, not taking call contexts into account.
+       *
+       * `contentIn` describes the content of `p` that can flow to `node`
+       * (if any), and `contentOut` describes the content of `node` that
+       * it flows to (if any).
+       */
+      predicate parameterValueFlow(
+        ParameterNode p, Node node, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow0(p, node, contentIn, contentOut) and
+        Cand::cand(p, node) and
+        if node instanceof CastingNode
+        then
+          // normal flow through
+          contentIn = TContentNone() and
+          contentOut = TContentNone() and
+          compatibleTypes(getErasedNodeTypeBound(p), getErasedNodeTypeBound(node))
+          or
+          // getter
+          exists(Content fIn |
+            contentIn.getContent() = fIn and
+            contentOut = TContentNone() and
+            compatibleTypes(fIn.getType(), getErasedNodeTypeBound(node))
+          )
+          or
+          // setter
+          exists(Content fOut |
+            contentIn = TContentNone() and
+            contentOut.getContent() = fOut and
+            compatibleTypes(getErasedNodeTypeBound(p), fOut.getType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(node))
+          )
+          or
+          // getter+setter
+          exists(Content fIn, Content fOut |
+            contentIn.getContent() = fIn and
+            contentOut.getContent() = fOut and
+            compatibleTypes(fIn.getType(), fOut.getType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(node))
+          )
+        else any()
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlow0(
+        ParameterNode p, Node node, ContentOption contentIn, ContentOption contentOut
+      ) {
+        p = node and
+        Cand::cand(p, _) and
+        contentIn = TContentNone() and
+        contentOut = TContentNone()
+        or
+        // local flow
+        exists(Node mid |
+          parameterValueFlow(p, mid, contentIn, contentOut) and
+          LocalFlowBigStep::localFlowBigStep(mid, node)
+        )
+        or
+        // read
+        exists(Node mid, Content f, ContentOption contentInMid, ContentOption contentOutMid |
+          parameterValueFlow(p, mid, contentInMid, contentOutMid) and
+          readStep(mid, f, node)
+        |
+          // value neither read nor stored prior to read
+          contentInMid = TContentNone() and
+          contentOutMid = TContentNone() and
+          contentIn.getContent() = f and
+          contentOut = TContentNone() and
+          Cand::parameterValueFlowReturnCand(p, _, true, _)
+          or
+          // value (possibly read and then) stored prior to read (same content)
+          contentIn = contentInMid and
+          contentOutMid.getContent() = f and
+          contentOut = TContentNone()
+        )
+        or
+        // store
+        exists(Node mid, Content f |
+          parameterValueFlow(p, mid, contentIn, TContentNone()) and
+          storeStep(mid, f, node) and
+          contentOut.getContent() = f
+        )
+        or
+        // flow through: no prior read or store
+        exists(ArgumentNode arg |
+          parameterValueFlowArg(p, arg, TContentNone(), TContentNone()) and
+          argumentValueFlowsThrough(arg, node, contentIn, contentOut)
+        )
+        or
+        // flow through: no read or store inside method
+        exists(ArgumentNode arg |
+          parameterValueFlowArg(p, arg, contentIn, contentOut) and
+          argumentValueFlowsThrough(arg, node, TContentNone(), TContentNone())
+        )
+        or
+        // flow through: possible prior read and prior store with compatible
+        // flow-through method
+        exists(ArgumentNode arg, ContentOption contentMid |
+          parameterValueFlowArg(p, arg, contentIn, contentMid) and
+          argumentValueFlowsThrough(arg, node, contentMid, contentOut)
+        )
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowArg(
+        ParameterNode p, ArgumentNode arg, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow(p, arg, contentIn, contentOut) and
+        Cand::argumentValueFlowsThroughCand(arg, _, _, _)
+      }
+
+      pragma[nomagic]
+      predicate parameterValueFlowsToPostUpdate(
+        ParameterNode p, PostUpdateNode n, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow(p, n, contentIn, contentOut) and
+        contentOut.hasContent()
+      }
+
+      pragma[nomagic]
+      predicate argumentValueFlowsThrough0(
+        DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, ContentOption contentIn,
+        ContentOption contentOut
+      ) {
+        exists(ParameterNode param | viableParamArg(call, param, arg) |
+          parameterValueFlowReturn(param, _, kind, contentIn, contentOut)
+        )
+      }
+
+      /**
+       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
+       * not taking call contexts into account.
+       *
+       * `contentIn` describes the content of `arg` that can flow to `out` (if any), and
+       * `contentOut` describes the content of `out` that it flows to (if any).
+       */
+      private predicate argumentValueFlowsThrough(
+        ArgumentNode arg, Node out, ContentOption contentIn, ContentOption contentOut
+      ) {
+        exists(DataFlowCall call, ReturnKindExt kind |
+          argumentValueFlowsThrough0(call, arg, kind, contentIn, contentOut) and
+          out = kind.getAnOutNode(call)
+        )
+      }
+    }
+
+    import Final
+  }
+
+  /**
+   * Holds if `p` can flow to the pre-update node associated with post-update
+   * node `n`, in the same callable, using only value-preserving steps.
+   */
+  cached
+  predicate parameterValueFlowsToPreUpdate(ParameterNode p, PostUpdateNode n) {
+    FlowThrough::parameterValueFlow(p, n.getPreUpdateNode(), TContentNone(), TContentNone())
+  }
+
+  /**
+   * Holds if `p` can flow to a return node of kind `kind` in the same
+   * callable using only value-preserving steps.
+   *
+   * `contentIn` describes the content of `p` that can flow to the return
+   * node (if any), and `contentOut` describes the content of the return
+   * node that it flows to (if any).
+   */
+  cached
+  predicate parameterValueFlowReturn(
+    ParameterNode p, Node ret, ReturnKindExt kind, ContentOption contentIn, ContentOption contentOut
+  ) {
+    ret =
+      any(ReturnNode n |
+        FlowThrough::parameterValueFlow(p, n, contentIn, contentOut) and
+        kind = TValueReturn(n.getKind())
+      )
+    or
+    ret =
+      any(PostUpdateNode n |
+        exists(ParameterNode p2, int pos2 |
+          FlowThrough::parameterValueFlowsToPostUpdate(p, n, contentIn, contentOut) and
+          parameterValueFlowsToPreUpdate(p2, n) and
+          p2.isParameterOf(_, pos2) and
+          kind = TParamUpdate(pos2) and
+          p != p2
+        )
+      )
+  }
+
+  /**
+   * Holds if `arg` flows to `out` through `call` using only value-preserving steps.
+   *
+   * `contentIn` describes the content of `arg` that can flow to `out` (if any), and
+   * `contentOut` describes the content of `out` that it flows to (if any).
+   */
+  cached
+  predicate argumentValueFlowsThrough(
+    DataFlowCall call, ArgumentNode arg, ContentOption contentIn, ContentOption contentOut, Node out
+  ) {
+    exists(ReturnKindExt kind |
+      FlowThrough::argumentValueFlowsThrough0(call, arg, kind, contentIn, contentOut) and
+      out = kind.getAnOutNode(call)
+    |
+      // normal flow through
+      contentIn = TContentNone() and
+      contentOut = TContentNone() and
+      compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
+      or
+      // getter
+      exists(Content fIn |
+        contentIn.getContent() = fIn and
+        contentOut = TContentNone() and
+        compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
+      )
+      or
+      // setter
+      exists(Content fOut |
+        contentIn = TContentNone() and
+        contentOut.getContent() = fOut and
+        compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType())
+      )
+      or
+      // getter+setter
+      exists(Content fIn, Content fOut |
+        contentIn.getContent() = fIn and
+        contentOut.getContent() = fOut and
+        compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
+      )
+    )
+  }
+
+  /**
+   * Holds if data can flow from `node1` to `node2` via a direct assignment to
+   * `f`.
+   *
+   * This includes reverse steps through reads when the result of the read has
+   * been stored into, in order to handle cases like `x.f1.f2 = y`.
+   */
+  cached
+  predicate storeDirect(Node node1, Content f, Node node2) {
+    storeStep(node1, f, node2) and readStep(_, f, _)
+    or
+    exists(Node n1, Node n2 |
+      n1 = node1.(PostUpdateNode).getPreUpdateNode() and
+      n2 = node2.(PostUpdateNode).getPreUpdateNode()
+    |
+      argumentValueFlowsThrough(_, n2, TContentSome(f), TContentNone(), n1)
+      or
+      readStep(n2, f, n1)
+    )
+  }
+
+  /**
+   * Holds if the call context `call` either improves virtual dispatch in
+   * `callable` or if it allows us to prune unreachable nodes in `callable`.
+   */
+  cached
+  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+    reducedViableImplInCallContext(_, callable, call)
+    or
+    exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
+  }
 
   cached
-  private module Cached {
-    /**
-     * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
-     * The instance parameter is considered to have index `-1`.
-     */
-    pragma[nomagic]
-    private predicate viableParam(DataFlowCall call, int i, ParameterNode p) {
-      p.isParameterOf(viableCallable(call), i)
-    }
+  newtype TCallContext =
+    TAnyCallContext() or
+    TSpecificCall(DataFlowCall call) { recordDataFlowCallSite(call, _) } or
+    TSomeCall() or
+    TReturn(DataFlowCallable c, DataFlowCall call) { reducedViableImplInReturn(c, call) }
 
-    /**
-     * Holds if `arg` is a possible argument to `p` in `call`, taking virtual
-     * dispatch into account.
-     */
-    cached
-    predicate viableParamArg(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
-      exists(int i |
-        viableParam(call, i, p) and
-        arg.argumentOf(call, i)
+  cached
+  newtype TReturnPosition =
+    TReturnPosition0(DataFlowCallable c, ReturnKindExt kind) {
+      exists(ReturnNodeExt ret |
+        c = returnNodeGetEnclosingCallable(ret) and
+        kind = ret.getKind()
       )
     }
 
-    /*
-     * The `FlowThrough_*` modules take a `step` relation as input and provide
-     * an `argumentValueFlowsThrough` relation as output.
-     *
-     * `FlowThrough_v1` includes just `simpleLocalFlowStep`, which is then used
-     * to detect getters and setters.
-     * `FlowThrough_v2` then includes a little bit of local field flow on top
-     * of `simpleLocalFlowStep`.
-     */
-
-    private module FlowThrough_v1 {
-      private predicate step = simpleLocalFlowStep/2;
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, not taking call contexts into account.
-       */
-      private predicate parameterValueFlowCand(ParameterNode p, Node node) {
-        p = node
-        or
-        exists(Node mid |
-          parameterValueFlowCand(p, mid) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlowCand(p, arg) and
-          argumentValueFlowsThroughCand(arg, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, not taking call contexts
-       * into account.
-       */
-      private predicate parameterValueFlowsThroughCand(ParameterNode p, ReturnKind kind) {
-        parameterValueFlowCand(p, getAReturnNodeOfKind(kind))
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThroughCand0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind
-      ) {
-        exists(ParameterNode param | viableParamArg(call, param, arg) |
-          parameterValueFlowsThroughCand(param, kind)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * not taking call contexts into account.
-       */
-      private predicate argumentValueFlowsThroughCand(ArgumentNode arg, OutNode out) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThroughCand0(call, arg, kind)
-        |
-          out = getAnOutNode(call, kind) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-
-      /**
-       * Holds if `arg` is the `i`th argument of `call` inside the callable
-       * `enclosing`, and `arg` may flow through `call`.
-       */
-      pragma[noinline]
-      private predicate argumentOf(
-        DataFlowCall call, int i, ArgumentNode arg, DataFlowCallable enclosing
-      ) {
-        arg.argumentOf(call, i) and
-        argumentValueFlowsThroughCand(arg, _) and
-        enclosing = arg.getEnclosingCallable()
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg0(
-        int i, ArgumentNode arg, CallContext outercc, DataFlowCall call
-      ) {
-        exists(DataFlowCallable c | argumentOf(call, i, arg, c) |
-          (
-            outercc = TAnyCallContext()
-            or
-            outercc = TSomeCall()
-            or
-            exists(DataFlowCall other | outercc = TSpecificCall(other) |
-              recordDataFlowCallSite(other, c)
-            )
-          ) and
-          not isUnreachableInCall(arg, outercc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg1(
-        ParameterNode p, DataFlowCallable callable, int i, ArgumentNode arg, CallContext outercc,
-        DataFlowCall call
-      ) {
-        viableParamArg0(i, arg, outercc, call) and
-        callable = resolveCall(call, outercc) and
-        p.isParameterOf(callable, any(int j | j <= i and j >= i))
-      }
-
-      /**
-       * Holds if `arg` is a possible argument to `p`, in the call `call`, and
-       * `arg` may flow through `call`. The possible contexts before and after
-       * entering the callable are `outercc` and `innercc`, respectively.
-       */
-      private predicate viableParamArg(
-        DataFlowCall call, ParameterNode p, ArgumentNode arg, CallContext outercc,
-        CallContextCall innercc
-      ) {
-        exists(int i, DataFlowCallable callable |
-          viableParamArg1(p, callable, i, arg, outercc, call)
-        |
-          if recordDataFlowCallSite(call, callable)
-          then innercc = TSpecificCall(call)
-          else innercc = TSomeCall()
-        )
-      }
-
-      private CallContextCall getAValidCallContextForParameter(ParameterNode p) {
-        result = TSomeCall()
-        or
-        exists(DataFlowCall call, DataFlowCallable callable |
-          result = TSpecificCall(call) and
-          p.isParameterOf(callable, _) and
-          recordDataFlowCallSite(call, callable)
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlow(ParameterNode p, Node node, CallContextCall cc) {
-        p = node and
-        parameterValueFlowsThroughCand(p, _) and
-        cc = getAValidCallContextForParameter(p)
-        or
-        exists(Node mid |
-          parameterValueFlow(p, mid, cc) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlow(p, arg, cc) and
-          argumentValueFlowsThrough(arg, node, cc) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlowsThrough(
-        ParameterNode p, ReturnKind kind, CallContextCall cc
-      ) {
-        parameterValueFlow(p, getAReturnNodeOfKind(kind), cc)
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThrough0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind, CallContext cc
-      ) {
-        exists(ParameterNode param, CallContext innercc |
-          viableParamArg(call, param, arg, cc, innercc) and
-          parameterValueFlowsThrough(param, kind, innercc)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * in call context cc.
-       */
-      predicate argumentValueFlowsThrough(ArgumentNode arg, OutNode out, CallContext cc) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThrough0(call, arg, kind, cc)
-        |
-          out = getAnOutNode(call, kind) and
-          not isUnreachableInCall(out, cc.(CallContextSpecificCall).getCall()) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-    }
-
-    /**
-     * Holds if `p` can flow to the pre-update node of `n` in the same callable
-     * using only value-preserving steps.
-     */
-    cached
-    predicate parameterValueFlowsToUpdate(ParameterNode p, PostUpdateNode n) {
-      parameterValueFlowNoCtx(p, n.getPreUpdateNode())
-    }
-
-    /**
-     * Holds if data can flow from `node1` to `node2` in one local step or a step
-     * through a value-preserving method.
-     */
-    private predicate localValueStep(Node node1, Node node2) {
-      simpleLocalFlowStep(node1, node2) or
-      FlowThrough_v1::argumentValueFlowsThrough(node1, node2, _)
-    }
-
-    /**
-     * Holds if `p` can flow to `node` in the same callable allowing local flow
-     * steps and value flow through methods. Call contexts are only accounted
-     * for in the nested calls.
-     */
-    private predicate parameterValueFlowNoCtx(ParameterNode p, Node node) {
-      p = node
-      or
-      exists(Node mid |
-        parameterValueFlowNoCtx(p, mid) and
-        localValueStep(mid, node) and
-        compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-      )
-    }
-
-    /*
-     * Calculation of `predicate store(Node node1, Content f, Node node2)`:
-     * There are four cases:
-     * - The base case: A direct local assignment given by `storeStep`.
-     * - A call to a method or constructor with two arguments, `arg1` and `arg2`,
-     *   such that the call has the side-effect `arg2.f = arg1`.
-     * - A call to a method that returns an object in which an argument has been
-     *   stored.
-     * - A reverse step through a read when the result of the read has been
-     *   stored into. This handles cases like `x.f1.f2 = y`.
-     * `storeViaSideEffect` covers the first two cases, and `storeReturn` covers
-     * the third case.
-     */
-
-    /**
-     * Holds if data can flow from `node1` to `node2` via a direct assignment to
-     * `f` or via a call that acts as a setter.
-     */
-    cached
-    predicate store(Node node1, Content f, Node node2) {
-      storeViaSideEffect(node1, f, node2) or
-      storeReturn(node1, f, node2) or
-      read(node2.(PostUpdateNode).getPreUpdateNode(), f, node1.(PostUpdateNode).getPreUpdateNode())
-    }
-
-    private predicate storeViaSideEffect(Node node1, Content f, PostUpdateNode node2) {
-      storeStep(node1, f, node2) and readStep(_, f, _)
-      or
-      exists(DataFlowCall call, int i1, int i2 |
-        setterCall(call, i1, i2, f) and
-        node1.(ArgumentNode).argumentOf(call, i1) and
-        node2.getPreUpdateNode().(ArgumentNode).argumentOf(call, i2) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getContainerType())
-      )
-    }
-
-    pragma[nomagic]
-    private predicate setterInParam(ParameterNode p1, Content f, ParameterNode p2) {
-      exists(Node n1, PostUpdateNode n2 |
-        parameterValueFlowNoCtx(p1, n1) and
-        storeViaSideEffect(n1, f, n2) and
-        parameterValueFlowNoCtx(p2, n2.getPreUpdateNode()) and
-        p1 != p2
-      )
-    }
-
-    pragma[nomagic]
-    private predicate setterCall(DataFlowCall call, int i1, int i2, Content f) {
-      exists(DataFlowCallable callable, ParameterNode p1, ParameterNode p2 |
-        setterInParam(p1, f, p2) and
-        callable = viableCallable(call) and
-        p1.isParameterOf(callable, i1) and
-        p2.isParameterOf(callable, i2)
-      )
-    }
-
-    pragma[noinline]
-    private predicate storeReturn0(DataFlowCall call, ReturnKind kind, ArgumentNode arg, Content f) {
-      exists(ParameterNode p |
-        viableParamArg(call, p, arg) and
-        setterReturn(p, f, kind)
-      )
-    }
-
-    private predicate storeReturn(Node node1, Content f, Node node2) {
-      exists(DataFlowCall call, ReturnKind kind |
-        storeReturn0(call, kind, node1, f) and
-        node2 = getAnOutNode(call, kind) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getContainerType())
-      )
-    }
-
-    private predicate setterReturn(ParameterNode p, Content f, ReturnKind kind) {
-      exists(Node n1, Node n2 |
-        parameterValueFlowNoCtx(p, n1) and
-        store(n1, f, n2) and
-        localValueStep*(n2, getAReturnNodeOfKind(kind))
-      )
-    }
-
-    pragma[noinline]
-    private predicate read0(DataFlowCall call, ReturnKind kind, ArgumentNode arg, Content f) {
-      exists(ParameterNode p |
-        viableParamArg(call, p, arg) and
-        getter(p, f, kind)
-      )
-    }
-
-    /**
-     * Holds if data can flow from `node1` to `node2` via a direct read of `f` or
-     * via a getter.
-     */
-    cached
-    predicate read(Node node1, Content f, Node node2) {
-      readStep(node1, f, node2)
-      or
-      exists(DataFlowCall call, ReturnKind kind |
-        read0(call, kind, node1, f) and
-        node2 = getAnOutNode(call, kind) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getContainerType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getType())
-      )
-    }
-
-    private predicate getter(ParameterNode p, Content f, ReturnKind kind) {
-      exists(Node n1, Node n2 |
-        parameterValueFlowNoCtx(p, n1) and
-        read(n1, f, n2) and
-        localValueStep*(n2, getAReturnNodeOfKind(kind))
-      )
-    }
-
-    cached
-    predicate localStoreReadStep(Node node1, Node node2) {
-      exists(Node mid1, Node mid2, Content f |
-        store(node1, f, mid1) and
-        localValueStep*(mid1, mid2) and
-        read(mid2, f, node2) and
-        compatibleTypes(getErasedNodeTypeBound(node1), getErasedNodeTypeBound(node2))
-      )
-    }
-
-    cached
-    module FlowThrough_v2 {
-      private predicate step(Node node1, Node node2) {
-        simpleLocalFlowStep(node1, node2) or
-        localStoreReadStep(node1, node2)
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, not taking call contexts into account.
-       */
-      private predicate parameterValueFlowCand(ParameterNode p, Node node) {
-        p = node
-        or
-        exists(Node mid |
-          parameterValueFlowCand(p, mid) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlowCand(p, arg) and
-          argumentValueFlowsThroughCand(arg, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, not taking call contexts
-       * into account.
-       */
-      private predicate parameterValueFlowsThroughCand(ParameterNode p, ReturnKind kind) {
-        parameterValueFlowCand(p, getAReturnNodeOfKind(kind))
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThroughCand0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind
-      ) {
-        exists(ParameterNode param | viableParamArg(call, param, arg) |
-          parameterValueFlowsThroughCand(param, kind)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * not taking call contexts into account.
-       */
-      private predicate argumentValueFlowsThroughCand(ArgumentNode arg, OutNode out) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThroughCand0(call, arg, kind)
-        |
-          out = getAnOutNode(call, kind) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-
-      /**
-       * Holds if `arg` is the `i`th argument of `call` inside the callable
-       * `enclosing`, and `arg` may flow through `call`.
-       */
-      pragma[noinline]
-      private predicate argumentOf(
-        DataFlowCall call, int i, ArgumentNode arg, DataFlowCallable enclosing
-      ) {
-        arg.argumentOf(call, i) and
-        argumentValueFlowsThroughCand(arg, _) and
-        enclosing = arg.getEnclosingCallable()
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg0(
-        int i, ArgumentNode arg, CallContext outercc, DataFlowCall call
-      ) {
-        exists(DataFlowCallable c | argumentOf(call, i, arg, c) |
-          (
-            outercc = TAnyCallContext()
-            or
-            outercc = TSomeCall()
-            or
-            exists(DataFlowCall other | outercc = TSpecificCall(other) |
-              recordDataFlowCallSite(other, c)
-            )
-          ) and
-          not isUnreachableInCall(arg, outercc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg1(
-        ParameterNode p, DataFlowCallable callable, int i, ArgumentNode arg, CallContext outercc,
-        DataFlowCall call
-      ) {
-        viableParamArg0(i, arg, outercc, call) and
-        callable = resolveCall(call, outercc) and
-        p.isParameterOf(callable, any(int j | j <= i and j >= i))
-      }
-
-      /**
-       * Holds if `arg` is a possible argument to `p`, in the call `call`, and
-       * `arg` may flow through `call`. The possible contexts before and after
-       * entering the callable are `outercc` and `innercc`, respectively.
-       */
-      private predicate viableParamArg(
-        DataFlowCall call, ParameterNode p, ArgumentNode arg, CallContext outercc,
-        CallContextCall innercc
-      ) {
-        exists(int i, DataFlowCallable callable |
-          viableParamArg1(p, callable, i, arg, outercc, call)
-        |
-          if recordDataFlowCallSite(call, callable)
-          then innercc = TSpecificCall(call)
-          else innercc = TSomeCall()
-        )
-      }
-
-      private CallContextCall getAValidCallContextForParameter(ParameterNode p) {
-        result = TSomeCall()
-        or
-        exists(DataFlowCall call, DataFlowCallable callable |
-          result = TSpecificCall(call) and
-          p.isParameterOf(callable, _) and
-          recordDataFlowCallSite(call, callable)
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlow(ParameterNode p, Node node, CallContextCall cc) {
-        p = node and
-        parameterValueFlowsThroughCand(p, _) and
-        cc = getAValidCallContextForParameter(p)
-        or
-        exists(Node mid |
-          parameterValueFlow(p, mid, cc) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlow(p, arg, cc) and
-          argumentValueFlowsThrough(arg, node, cc) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, in call context `cc`.
-       */
-      cached
-      predicate parameterValueFlowsThrough(ParameterNode p, ReturnKind kind, CallContextCall cc) {
-        parameterValueFlow(p, getAReturnNodeOfKind(kind), cc)
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThrough0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind, CallContext cc
-      ) {
-        exists(ParameterNode param, CallContext innercc |
-          viableParamArg(call, param, arg, cc, innercc) and
-          parameterValueFlowsThrough(param, kind, innercc)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * in call context cc.
-       */
-      cached
-      predicate argumentValueFlowsThrough(ArgumentNode arg, OutNode out, CallContext cc) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThrough0(call, arg, kind, cc)
-        |
-          out = getAnOutNode(call, kind) and
-          not isUnreachableInCall(out, cc.(CallContextSpecificCall).getCall()) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-    }
-
-    /**
-     * Holds if the call context `call` either improves virtual dispatch in
-     * `callable` or if it allows us to prune unreachable nodes in `callable`.
-     */
-    cached
-    predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
-      reducedViableImplInCallContext(_, callable, call)
-      or
-      exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
-    }
-
-    cached
-    newtype TCallContext =
-      TAnyCallContext() or
-      TSpecificCall(DataFlowCall call) { recordDataFlowCallSite(call, _) } or
-      TSomeCall() or
-      TReturn(DataFlowCallable c, DataFlowCall call) { reducedViableImplInReturn(c, call) }
-
-    cached
-    newtype TReturnPosition =
-      TReturnPosition0(DataFlowCallable c, ReturnKindExt kind) { returnPosition(_, c, kind) }
-
-    cached
-    newtype TLocalFlowCallContext =
-      TAnyLocalCall() or
-      TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
-  }
-
-  pragma[noinline]
-  private predicate returnPosition(ReturnNodeExt ret, DataFlowCallable c, ReturnKindExt kind) {
-    c = returnNodeGetEnclosingCallable(ret) and
-    kind = ret.getKind()
-  }
-
-  /**
-   * A call context to restrict the targets of virtual dispatch, prune local flow,
-   * and match the call sites of flow into a method with flow out of a method.
-   *
-   * There are four cases:
-   * - `TAnyCallContext()` : No restrictions on method flow.
-   * - `TSpecificCall(DataFlowCall call)` : Flow entered through the
-   *    given `call`. This call improves the set of viable
-   *    dispatch targets for at least one method call in the current callable
-   *    or helps prune unreachable nodes in the current callable.
-   * - `TSomeCall()` : Flow entered through a parameter. The
-   *    originating call does not improve the set of dispatch targets for any
-   *    method call in the current callable and was therefore not recorded.
-   * - `TReturn(Callable c, DataFlowCall call)` : Flow reached `call` from `c` and
-   *    this dispatch target of `call` implies a reduced set of dispatch origins
-   *    to which data may flow if it should reach a `return` statement.
-   */
-  abstract class CallContext extends TCallContext {
-    abstract string toString();
-
-    /** Holds if this call context is relevant for `callable`. */
-    abstract predicate relevantFor(DataFlowCallable callable);
-  }
-
-  class CallContextAny extends CallContext, TAnyCallContext {
-    override string toString() { result = "CcAny" }
-
-    override predicate relevantFor(DataFlowCallable callable) { any() }
-  }
-
-  abstract class CallContextCall extends CallContext { }
-
-  class CallContextSpecificCall extends CallContextCall, TSpecificCall {
-    override string toString() {
-      exists(DataFlowCall call | this = TSpecificCall(call) | result = "CcCall(" + call + ")")
-    }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      recordDataFlowCallSite(getCall(), callable)
-    }
-
-    DataFlowCall getCall() { this = TSpecificCall(result) }
-  }
-
-  class CallContextSomeCall extends CallContextCall, TSomeCall {
-    override string toString() { result = "CcSomeCall" }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      exists(ParameterNode p | p.getEnclosingCallable() = callable)
-    }
-  }
-
-  class CallContextReturn extends CallContext, TReturn {
-    override string toString() {
-      exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
-    }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      exists(DataFlowCall call | this = TReturn(_, call) and call.getEnclosingCallable() = callable)
-    }
-  }
-
-  /**
-   * A call context that is relevant for pruning local flow.
-   */
-  abstract class LocalCallContext extends TLocalFlowCallContext {
-    abstract string toString();
-
-    /** Holds if this call context is relevant for `callable`. */
-    abstract predicate relevantFor(DataFlowCallable callable);
-  }
-
-  class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
-    override string toString() { result = "LocalCcAny" }
-
-    override predicate relevantFor(DataFlowCallable callable) { any() }
-  }
-
-  class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
-    LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
-
-    DataFlowCall call;
-
-    DataFlowCall getCall() { result = call }
-
-    override string toString() { result = "LocalCcCall(" + call + ")" }
-
-    override predicate relevantFor(DataFlowCallable callable) { relevantLocalCCtx(call, callable) }
-  }
-
-  private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
-    exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
-  }
-
-  /**
-   * Gets the local call context given the call context and the callable that
-   * the contexts apply to.
-   */
-  LocalCallContext getLocalCallContext(CallContext ctx, DataFlowCallable callable) {
-    ctx.relevantFor(callable) and
-    if relevantLocalCCtx(ctx.(CallContextSpecificCall).getCall(), callable)
-    then result.(LocalCallContextSpecificCall).getCall() = ctx.(CallContextSpecificCall).getCall()
-    else result instanceof LocalCallContextAny
-  }
-
-  /**
-   * A node from which flow can return to the caller. This is either a regular
-   * `ReturnNode` or a `PostUpdateNode` corresponding to the value of a parameter.
-   */
-  class ReturnNodeExt extends Node {
-    ReturnNodeExt() {
-      this instanceof ReturnNode or
-      parameterValueFlowsToUpdate(_, this)
-    }
-
-    /** Gets the kind of this returned value. */
-    ReturnKindExt getKind() {
-      result = TValueReturn(this.(ReturnNode).getKind())
-      or
-      exists(ParameterNode p, int pos |
-        parameterValueFlowsToUpdate(p, this) and
-        p.isParameterOf(_, pos) and
-        result = TParamUpdate(pos)
-      )
-    }
-  }
-
-  private newtype TReturnKindExt =
+  cached
+  newtype TLocalFlowCallContext =
+    TAnyLocalCall() or
+    TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
+
+  cached
+  newtype TReturnKindExt =
     TValueReturn(ReturnKind kind) or
-    TParamUpdate(int pos) {
-      exists(ParameterNode p | parameterValueFlowsToUpdate(p, _) and p.isParameterOf(_, pos))
-    }
-
-  /**
-   * An extended return kind. A return kind describes how data can be returned
-   * from a callable. This can either be through a returned value or an updated
-   * parameter.
-   */
-  abstract class ReturnKindExt extends TReturnKindExt {
-    /** Gets a textual representation of this return kind. */
-    abstract string toString();
-
-    /** Gets a node corresponding to data flow out of `call`. */
-    abstract Node getAnOutNode(DataFlowCall call);
-  }
-
-  class ValueReturnKind extends ReturnKindExt, TValueReturn {
-    private ReturnKind kind;
-
-    ValueReturnKind() { this = TValueReturn(kind) }
-
-    ReturnKind getKind() { result = kind }
-
-    override string toString() { result = kind.toString() }
-
-    override Node getAnOutNode(DataFlowCall call) { result = getAnOutNode(call, this.getKind()) }
-  }
-
-  class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
-    private int pos;
-
-    ParamUpdateReturnKind() { this = TParamUpdate(pos) }
-
-    int getPosition() { result = pos }
-
-    override string toString() { result = "param update " + pos }
-
-    override Node getAnOutNode(DataFlowCall call) {
-      exists(ArgumentNode arg |
-        result.(PostUpdateNode).getPreUpdateNode() = arg and
-        arg.argumentOf(call, this.getPosition())
-      )
-    }
-  }
-
-  /** A callable tagged with a relevant return kind. */
-  class ReturnPosition extends TReturnPosition0 {
-    private DataFlowCallable c;
-    private ReturnKindExt kind;
-
-    ReturnPosition() { this = TReturnPosition0(c, kind) }
-
-    /** Gets the callable. */
-    DataFlowCallable getCallable() { result = c }
-
-    /** Gets the return kind. */
-    ReturnKindExt getKind() { result = kind }
-
-    /** Gets a textual representation of this return position. */
-    string toString() { result = "[" + kind + "] " + c }
-  }
-
-  pragma[noinline]
-  DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
-    result = ret.getEnclosingCallable()
-  }
-
-  pragma[noinline]
-  ReturnPosition getReturnPosition(ReturnNodeExt ret) {
-    exists(DataFlowCallable c, ReturnKindExt k | returnPosition(ret, c, k) |
-      result = TReturnPosition0(c, k)
-    )
-  }
-
-  bindingset[cc, callable]
-  predicate resolveReturn(CallContext cc, DataFlowCallable callable, DataFlowCall call) {
-    cc instanceof CallContextAny and callable = viableCallable(call)
-    or
-    exists(DataFlowCallable c0, DataFlowCall call0 |
-      call0.getEnclosingCallable() = callable and
-      cc = TReturn(c0, call0) and
-      c0 = prunedViableImplInCallContextReverse(call0, call)
-    )
-  }
-
-  bindingset[call, cc]
-  DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
-    exists(DataFlowCall ctx | cc = TSpecificCall(ctx) |
-      if reducedViableImplInCallContext(call, _, ctx)
-      then result = prunedViableImplInCallContext(call, ctx)
-      else result = viableCallable(call)
-    )
-    or
-    result = viableCallable(call) and cc instanceof CallContextSomeCall
-    or
-    result = viableCallable(call) and cc instanceof CallContextAny
-    or
-    result = viableCallable(call) and cc instanceof CallContextReturn
-  }
-
-  newtype TSummary =
-    TSummaryVal() or
-    TSummaryTaint() or
-    TSummaryReadVal(Content f) or
-    TSummaryReadTaint(Content f) or
-    TSummaryTaintStore(Content f)
-
-  /**
-   * A summary of flow through a callable. This can either be value-preserving
-   * if no additional steps are used, taint-flow if at least one additional step
-   * is used, or any one of those combined with a store or a read. Summaries
-   * recorded at a return node are restricted to include at least one additional
-   * step, as the value-based summaries are calculated independent of the
-   * configuration.
-   */
-  class Summary extends TSummary {
-    string toString() {
-      result = "Val" and this = TSummaryVal()
-      or
-      result = "Taint" and this = TSummaryTaint()
-      or
-      exists(Content f |
-        result = "ReadVal " + f.toString() and this = TSummaryReadVal(f)
-        or
-        result = "ReadTaint " + f.toString() and this = TSummaryReadTaint(f)
-        or
-        result = "TaintStore " + f.toString() and this = TSummaryTaintStore(f)
-      )
-    }
-
-    /** Gets the summary that results from extending this with an additional step. */
-    Summary additionalStep() {
-      this = TSummaryVal() and result = TSummaryTaint()
-      or
-      this = TSummaryTaint() and result = TSummaryTaint()
-      or
-      exists(Content f | this = TSummaryReadVal(f) and result = TSummaryReadTaint(f))
-      or
-      exists(Content f | this = TSummaryReadTaint(f) and result = TSummaryReadTaint(f))
-    }
-
-    /** Gets the summary that results from extending this with a read. */
-    Summary readStep(Content f) { this = TSummaryVal() and result = TSummaryReadVal(f) }
-
-    /** Gets the summary that results from extending this with a store. */
-    Summary storeStep(Content f) { this = TSummaryTaint() and result = TSummaryTaintStore(f) }
-
-    /** Gets the summary that results from extending this with `step`. */
-    bindingset[this, step]
-    Summary compose(Summary step) {
-      this = TSummaryVal() and result = step
-      or
-      this = TSummaryTaint() and
-      (step = TSummaryTaint() or step = TSummaryTaintStore(_)) and
-      result = step
-      or
-      exists(Content f |
-        this = TSummaryReadVal(f) and step = TSummaryTaint() and result = TSummaryReadTaint(f)
-      )
-      or
-      this = TSummaryReadTaint(_) and step = TSummaryTaint() and result = this
-    }
-
-    /** Holds if this summary does not include any taint steps. */
-    predicate isPartial() {
-      this = TSummaryVal() or
-      this = TSummaryReadVal(_)
-    }
-  }
-
-  pragma[noinline]
-  DataFlowType getErasedNodeType(Node n) { result = getErasedRepr(n.getType()) }
-
-  pragma[noinline]
-  DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
+    TParamUpdate(int pos) { exists(ParameterNode p | p.isParameterOf(_, pos)) }
 }
+
+/**
+ * A `Node` at which a cast can occur such that the type should be checked.
+ */
+class CastingNode extends Node {
+  CastingNode() {
+    this instanceof ParameterNode or
+    this instanceof CastNode or
+    this instanceof OutNode or
+    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
+  }
+}
+
+newtype TContentOption =
+  TContentNone() or
+  TContentSome(Content f)
+
+class ContentOption extends TContentOption {
+  Content getContent() { this = TContentSome(result) }
+
+  predicate hasContent() { exists(this.getContent()) }
+
+  string toString() {
+    result = this.getContent().toString()
+    or
+    not this.hasContent() and
+    result = ""
+  }
+}
+
+/**
+ * A call context to restrict the targets of virtual dispatch, prune local flow,
+ * and match the call sites of flow into a method with flow out of a method.
+ *
+ * There are four cases:
+ * - `TAnyCallContext()` : No restrictions on method flow.
+ * - `TSpecificCall(DataFlowCall call)` : Flow entered through the
+ *    given `call`. This call improves the set of viable
+ *    dispatch targets for at least one method call in the current callable
+ *    or helps prune unreachable nodes in the current callable.
+ * - `TSomeCall()` : Flow entered through a parameter. The
+ *    originating call does not improve the set of dispatch targets for any
+ *    method call in the current callable and was therefore not recorded.
+ * - `TReturn(Callable c, DataFlowCall call)` : Flow reached `call` from `c` and
+ *    this dispatch target of `call` implies a reduced set of dispatch origins
+ *    to which data may flow if it should reach a `return` statement.
+ */
+abstract class CallContext extends TCallContext {
+  abstract string toString();
+
+  /** Holds if this call context is relevant for `callable`. */
+  abstract predicate relevantFor(DataFlowCallable callable);
+}
+
+class CallContextAny extends CallContext, TAnyCallContext {
+  override string toString() { result = "CcAny" }
+
+  override predicate relevantFor(DataFlowCallable callable) { any() }
+}
+
+abstract class CallContextCall extends CallContext { }
+
+class CallContextSpecificCall extends CallContextCall, TSpecificCall {
+  override string toString() {
+    exists(DataFlowCall call | this = TSpecificCall(call) | result = "CcCall(" + call + ")")
+  }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    recordDataFlowCallSite(getCall(), callable)
+  }
+
+  DataFlowCall getCall() { this = TSpecificCall(result) }
+}
+
+class CallContextSomeCall extends CallContextCall, TSomeCall {
+  override string toString() { result = "CcSomeCall" }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    exists(ParameterNode p | p.getEnclosingCallable() = callable)
+  }
+}
+
+class CallContextReturn extends CallContext, TReturn {
+  override string toString() {
+    exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
+  }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    exists(DataFlowCall call | this = TReturn(_, call) and call.getEnclosingCallable() = callable)
+  }
+}
+
+/**
+ * A call context that is relevant for pruning local flow.
+ */
+abstract class LocalCallContext extends TLocalFlowCallContext {
+  abstract string toString();
+
+  /** Holds if this call context is relevant for `callable`. */
+  abstract predicate relevantFor(DataFlowCallable callable);
+}
+
+class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
+  override string toString() { result = "LocalCcAny" }
+
+  override predicate relevantFor(DataFlowCallable callable) { any() }
+}
+
+class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
+  LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
+
+  DataFlowCall call;
+
+  DataFlowCall getCall() { result = call }
+
+  override string toString() { result = "LocalCcCall(" + call + ")" }
+
+  override predicate relevantFor(DataFlowCallable callable) { relevantLocalCCtx(call, callable) }
+}
+
+private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
+  exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
+}
+
+/**
+ * Gets the local call context given the call context and the callable that
+ * the contexts apply to.
+ */
+LocalCallContext getLocalCallContext(CallContext ctx, DataFlowCallable callable) {
+  ctx.relevantFor(callable) and
+  if relevantLocalCCtx(ctx.(CallContextSpecificCall).getCall(), callable)
+  then result.(LocalCallContextSpecificCall).getCall() = ctx.(CallContextSpecificCall).getCall()
+  else result instanceof LocalCallContextAny
+}
+
+/**
+ * A node from which flow can return to the caller. This is either a regular
+ * `ReturnNode` or a `PostUpdateNode` corresponding to the value of a parameter.
+ */
+class ReturnNodeExt extends Node {
+  ReturnNodeExt() {
+    this instanceof ReturnNode or
+    parameterValueFlowsToPreUpdate(_, this)
+  }
+
+  /** Gets the kind of this returned value. */
+  ReturnKindExt getKind() {
+    result = TValueReturn(this.(ReturnNode).getKind())
+    or
+    exists(ParameterNode p, int pos |
+      parameterValueFlowsToPreUpdate(p, this) and
+      p.isParameterOf(_, pos) and
+      result = TParamUpdate(pos)
+    )
+  }
+}
+
+/**
+ * An extended return kind. A return kind describes how data can be returned
+ * from a callable. This can either be through a returned value or an updated
+ * parameter.
+ */
+abstract class ReturnKindExt extends TReturnKindExt {
+  /** Gets a textual representation of this return kind. */
+  abstract string toString();
+
+  /** Gets a node corresponding to data flow out of `call`. */
+  abstract Node getAnOutNode(DataFlowCall call);
+}
+
+class ValueReturnKind extends ReturnKindExt, TValueReturn {
+  private ReturnKind kind;
+
+  ValueReturnKind() { this = TValueReturn(kind) }
+
+  ReturnKind getKind() { result = kind }
+
+  override string toString() { result = kind.toString() }
+
+  override Node getAnOutNode(DataFlowCall call) { result = getAnOutNode(call, this.getKind()) }
+}
+
+class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
+  private int pos;
+
+  ParamUpdateReturnKind() { this = TParamUpdate(pos) }
+
+  int getPosition() { result = pos }
+
+  override string toString() { result = "param update " + pos }
+
+  override PostUpdateNode getAnOutNode(DataFlowCall call) {
+    exists(ArgumentNode arg |
+      result.getPreUpdateNode() = arg and
+      arg.argumentOf(call, this.getPosition())
+    )
+  }
+}
+
+/** A callable tagged with a relevant return kind. */
+class ReturnPosition extends TReturnPosition0 {
+  private DataFlowCallable c;
+  private ReturnKindExt kind;
+
+  ReturnPosition() { this = TReturnPosition0(c, kind) }
+
+  /** Gets the callable. */
+  DataFlowCallable getCallable() { result = c }
+
+  /** Gets the return kind. */
+  ReturnKindExt getKind() { result = kind }
+
+  /** Gets a textual representation of this return position. */
+  string toString() { result = "[" + kind + "] " + c }
+}
+
+pragma[noinline]
+private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
+  result = ret.getEnclosingCallable()
+}
+
+pragma[noinline]
+ReturnPosition getReturnPosition(ReturnNodeExt ret) {
+  result = TReturnPosition0(returnNodeGetEnclosingCallable(ret), ret.getKind())
+}
+
+bindingset[cc, callable]
+predicate resolveReturn(CallContext cc, DataFlowCallable callable, DataFlowCall call) {
+  cc instanceof CallContextAny and callable = viableCallable(call)
+  or
+  exists(DataFlowCallable c0, DataFlowCall call0 |
+    call0.getEnclosingCallable() = callable and
+    cc = TReturn(c0, call0) and
+    c0 = prunedViableImplInCallContextReverse(call0, call)
+  )
+}
+
+bindingset[call, cc]
+DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
+  exists(DataFlowCall ctx | cc = TSpecificCall(ctx) |
+    if reducedViableImplInCallContext(call, _, ctx)
+    then result = prunedViableImplInCallContext(call, ctx)
+    else result = viableCallable(call)
+  )
+  or
+  result = viableCallable(call) and cc instanceof CallContextSomeCall
+  or
+  result = viableCallable(call) and cc instanceof CallContextAny
+  or
+  result = viableCallable(call) and cc instanceof CallContextReturn
+}
+
+newtype TSummary =
+  TSummaryVal() or
+  TSummaryTaint() or
+  TSummaryReadVal(Content f) or
+  TSummaryReadTaint(Content f) or
+  TSummaryTaintStore(Content f)
+
+/**
+ * A summary of flow through a callable. This can either be value-preserving
+ * if no additional steps are used, taint-flow if at least one additional step
+ * is used, or any one of those combined with a store or a read. Summaries
+ * recorded at a return node are restricted to include at least one additional
+ * step, as the value-based summaries are calculated independent of the
+ * configuration.
+ */
+class Summary extends TSummary {
+  string toString() {
+    result = "Val" and this = TSummaryVal()
+    or
+    result = "Taint" and this = TSummaryTaint()
+    or
+    exists(Content f |
+      result = "ReadVal " + f.toString() and this = TSummaryReadVal(f)
+      or
+      result = "ReadTaint " + f.toString() and this = TSummaryReadTaint(f)
+      or
+      result = "TaintStore " + f.toString() and this = TSummaryTaintStore(f)
+    )
+  }
+
+  /** Gets the summary that results from extending this with an additional step. */
+  Summary additionalStep() {
+    this = TSummaryVal() and result = TSummaryTaint()
+    or
+    this = TSummaryTaint() and result = TSummaryTaint()
+    or
+    exists(Content f | this = TSummaryReadVal(f) and result = TSummaryReadTaint(f))
+    or
+    exists(Content f | this = TSummaryReadTaint(f) and result = TSummaryReadTaint(f))
+  }
+
+  /** Gets the summary that results from extending this with a read. */
+  Summary readStep(Content f) { this = TSummaryVal() and result = TSummaryReadVal(f) }
+
+  /** Gets the summary that results from extending this with a store. */
+  Summary storeStep(Content f) { this = TSummaryTaint() and result = TSummaryTaintStore(f) }
+
+  /** Gets the summary that results from extending this with `step`. */
+  bindingset[this, step]
+  Summary compose(Summary step) {
+    this = TSummaryVal() and result = step
+    or
+    this = TSummaryTaint() and
+    (step = TSummaryTaint() or step = TSummaryTaintStore(_)) and
+    result = step
+    or
+    exists(Content f |
+      this = TSummaryReadVal(f) and step = TSummaryTaint() and result = TSummaryReadTaint(f)
+    )
+    or
+    this = TSummaryReadTaint(_) and step = TSummaryTaint() and result = this
+  }
+
+  /** Holds if this summary does not include any taint steps. */
+  predicate isPartial() {
+    this = TSummaryVal() or
+    this = TSummaryReadVal(_)
+  }
+}
+
+pragma[noinline]
+DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
+
+predicate readDirect = readStep/3;

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -205,4 +205,4 @@ class DataFlowCall extends CallInstruction {
 
 predicate isUnreachableInCall(Node n, DataFlowCall call) { none() } // stub implementation
 
-int flowThroughAccessPathLimit() { none() }
+int accessPathLimit() { result = 5 }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -204,3 +204,5 @@ class DataFlowCall extends CallInstruction {
 }
 
 predicate isUnreachableInCall(Node n, DataFlowCall call) { none() } // stub implementation
+
+int flowThroughAccessPathLimit() { none() }

--- a/csharp/ql/src/semmle/code/csharp/Caching.qll
+++ b/csharp/ql/src/semmle/code/csharp/Caching.qll
@@ -50,7 +50,7 @@ module Stages {
   cached
   module DataFlowStage {
     private import semmle.code.csharp.dataflow.internal.DataFlowPrivate
-    private import semmle.code.csharp.dataflow.internal.DataFlowImplCommon::Public
+    private import semmle.code.csharp.dataflow.internal.DataFlowImplCommon
     private import semmle.code.csharp.dataflow.internal.TaintTrackingPrivate
 
     cached

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -7,7 +7,7 @@
  * on each other without introducing mutual recursion among those configurations.
  */
 
-private import DataFlowImplCommon::Public
+private import DataFlowImplCommon
 private import DataFlowImplSpecific::Private
 import DataFlowImplSpecific::Public
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -2610,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2904,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2928,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -290,7 +290,7 @@ private predicate nodeCandFwd1(Node node, Configuration config) {
     exists(Node mid |
       useFieldFlow(config) and
       nodeCandFwd1(mid, config) and
-      store(mid, _, node) and
+      storeDirect(mid, _, node) and
       not outBarrier(mid, config)
     )
     or
@@ -328,7 +328,7 @@ pragma[nomagic]
 private predicate nodeCandFwd1Read(Content f, Node node, Configuration config) {
   exists(Node mid |
     nodeCandFwd1(mid, config) and
-    read(mid, f, node)
+    readDirect(mid, f, node)
   )
 }
 
@@ -341,7 +341,7 @@ private predicate storeCandFwd1(Content f, Configuration config) {
     not fullBarrier(node, config) and
     useFieldFlow(config) and
     nodeCandFwd1(mid, config) and
-    store(mid, f, node)
+    storeDirect(mid, f, node)
   )
 }
 
@@ -387,7 +387,7 @@ private predicate nodeCand1(Node node, Configuration config) {
     or
     // read
     exists(Node mid, Content f |
-      read(node, f, mid) and
+      readDirect(node, f, mid) and
       storeCandFwd1(f, unbind(config)) and
       nodeCand1(mid, config)
     )
@@ -423,7 +423,7 @@ private predicate readCand1(Content f, Configuration config) {
   exists(Node mid, Node node |
     useFieldFlow(config) and
     nodeCandFwd1(node, unbind(config)) and
-    read(node, f, mid) and
+    readDirect(node, f, mid) and
     storeCandFwd1(f, unbind(config)) and
     nodeCand1(mid, config)
   )
@@ -434,7 +434,7 @@ private predicate nodeCand1Store(Content f, Node node, Configuration config) {
   exists(Node mid |
     nodeCand1(mid, config) and
     storeCandFwd1(f, unbind(config)) and
-    store(node, f, mid)
+    storeDirect(node, f, mid)
   )
 }
 
@@ -493,7 +493,7 @@ private predicate parameterFlow(
 ) {
   parameterThroughFlowCand(p, config) and
   p = node and
-  t1 = getErasedNodeType(node) and
+  t1 = getErasedNodeTypeBound(node) and
   t1 = t2 and
   summary = TSummaryVal()
   or
@@ -502,27 +502,21 @@ private predicate parameterFlow(
     exists(Node mid |
       parameterFlow(p, mid, t1, t2, summary, config) and
       localFlowStep(mid, node, config) and
-      compatibleTypes(t2, getErasedNodeType(node))
+      compatibleTypes(t2, getErasedNodeTypeBound(node))
     )
     or
     exists(Node mid, Summary midsum |
       parameterFlow(p, mid, _, _, midsum, config) and
       additionalLocalFlowStep(mid, node, config) and
-      t1 = getErasedNodeType(node) and
+      t1 = getErasedNodeTypeBound(node) and
       t1 = t2 and
       summary = midsum.additionalStep()
-    )
-    or
-    exists(Node mid |
-      parameterFlow(p, mid, t1, t2, summary, config) and
-      localStoreReadStep(mid, node) and
-      compatibleTypes(t2, getErasedNodeType(node))
     )
     or
     // read step
     exists(Node mid, Content f, Summary midsum |
       parameterFlow(p, mid, _, _, midsum, config) and
-      read(mid, f, node) and
+      readDirect(mid, f, node) and
       readStoreCand1(f, unbind(config)) and
       summary = midsum.readStep(f) and
       t1 = f.getType() and
@@ -532,7 +526,7 @@ private predicate parameterFlow(
     // store step
     exists(Node mid, Content f, Summary midsum |
       parameterFlow(p, mid, t1, /* t1 */ _, midsum, config) and
-      store(mid, f, node) and
+      storeDirect(mid, f, node) and
       readStoreCand1(f, unbind(config)) and
       summary = midsum.storeStep(f) and
       compatibleTypes(t1, f.getType()) and
@@ -542,8 +536,8 @@ private predicate parameterFlow(
     // value flow through a callable
     exists(Node arg |
       parameterFlow(p, arg, t1, t2, summary, config) and
-      argumentValueFlowsThrough(arg, node, _) and
-      compatibleTypes(t2, getErasedNodeType(node))
+      argumentValueFlowsThrough(_, arg, TContentNone(), TContentNone(), node) and
+      compatibleTypes(t2, getErasedNodeTypeBound(node))
     )
     or
     // flow through a callable
@@ -580,9 +574,10 @@ private predicate argumentFlowsThrough0(
   DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, DataFlowType t1, DataFlowType t2,
   Summary summary, Configuration config
 ) {
-  exists(ParameterNode p, ReturnNodeExt ret |
+  exists(ParameterNode p |
     viableParamArgCand(call, p, arg, config) and
-    parameterFlowReturn(p, ret, kind, t1, t2, summary, config)
+    parameterFlowReturn(p, _, kind, t1, t2, summary, config) and
+    compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(p))
   )
 }
 
@@ -598,11 +593,146 @@ private predicate argumentFlowsThrough(
 ) {
   nodeCand1(out, unbind(config)) and
   not inBarrier(out, config) and
-  compatibleTypes(t2, getErasedNodeType(out)) and
+  compatibleTypes(t2, getErasedNodeTypeBound(out)) and
   exists(DataFlowCall call, ReturnKindExt kind |
     argumentFlowsThrough0(call, arg, kind, t1, t2, summary, config) and
     out = kind.getAnOutNode(call)
   )
+}
+
+private newtype TNodeExt =
+  TNormalNode(Node node) { nodeCand1(node, _) } or
+  TReadStoreNode(DataFlowCall call, Node node1, Node node2, Content f1, Content f2) {
+    exists(Configuration config |
+      nodeCand1(node1, config) and
+      argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
+      nodeCand1(node2, unbind(config))
+    )
+  }
+
+/**
+ * An extended data flow node. Either a normal node, or an intermediate node
+ * used to split up a read+store step through a call into first a read step
+ * followed by a store step.
+ *
+ * This is purely an internal implementation detail.
+ */
+abstract private class NodeExt extends TNodeExt {
+  /** Gets the underlying (normal) node, if any. */
+  abstract Node getNode();
+
+  abstract DataFlowType getErasedNodeTypeBound();
+
+  abstract DataFlowCallable getEnclosingCallable();
+
+  abstract predicate isCand1(Configuration config);
+
+  abstract string toString();
+
+  abstract predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  );
+}
+
+/** A `Node` at which a cast can occur such that the type should be checked. */
+abstract private class CastingNodeExt extends NodeExt { }
+
+private class NormalNodeExt extends NodeExt, TNormalNode {
+  override Node getNode() { this = TNormalNode(result) }
+
+  override DataFlowType getErasedNodeTypeBound() {
+    result = getErasedRepr(this.getNode().getTypeBound())
+  }
+
+  override DataFlowCallable getEnclosingCallable() {
+    result = this.getNode().getEnclosingCallable()
+  }
+
+  override predicate isCand1(Configuration config) { nodeCand1(this.getNode(), config) }
+
+  override string toString() { result = this.getNode().toString() }
+
+  override predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    this.getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
+
+private class NormalCastingNodeExt extends CastingNodeExt, NormalNodeExt {
+  NormalCastingNodeExt() { this.getNode() instanceof CastingNode }
+}
+
+private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
+  private DataFlowCall call;
+  private Node node1;
+  private Node node2;
+  private Content f1;
+  private Content f2;
+
+  ReadStoreNodeExt() { this = TReadStoreNode(call, node1, node2, f1, f2) }
+
+  override Node getNode() { none() }
+
+  override DataFlowType getErasedNodeTypeBound() { result = f1.getType() }
+
+  override DataFlowCallable getEnclosingCallable() { result = node1.getEnclosingCallable() }
+
+  override predicate isCand1(Configuration config) {
+    nodeCand1(node1, config) and nodeCand1(node2, config)
+  }
+
+  override string toString() {
+    result = "(inside) " + call.toString() + " [" + f1 + " -> " + f2 + "]"
+  }
+
+  override predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    call.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
+
+pragma[nomagic]
+private predicate readExt(NodeExt node1, Content f, NodeExt node2, boolean through) {
+  readDirect(node1.getNode(), f, node2.getNode()) and
+  through = false
+  or
+  argumentValueFlowsThrough(_, node1.getNode(), TContentSome(f), TContentNone(), node2.getNode()) and
+  through = true
+  or
+  node2 = TReadStoreNode(_, node1.getNode(), _, f, _) and
+  through = true
+}
+
+pragma[nomagic]
+private predicate storeExt(NodeExt node1, Content f, NodeExt node2, boolean through) {
+  storeDirect(node1.getNode(), f, node2.getNode()) and
+  through = false
+  or
+  argumentValueFlowsThrough(_, node1.getNode(), TContentNone(), TContentSome(f), node2.getNode()) and
+  through = true
+  or
+  node1 = TReadStoreNode(_, _, node2.getNode(), _, f) and
+  through = true
+}
+
+private predicate jumpStepExt(NodeExt node1, NodeExt node2, Configuration config) {
+  jumpStep(node1.getNode(), node2.getNode(), config)
+}
+
+private predicate additionalJumpStepExt(NodeExt node1, NodeExt node2, Configuration config) {
+  additionalJumpStep(node1.getNode(), node2.getNode(), config)
+}
+
+private predicate argumentValueFlowsThrough(NodeExt node1, NodeExt node2) {
+  argumentValueFlowsThrough(_, node1.getNode(), TContentNone(), TContentNone(), node2.getNode())
+}
+
+private predicate argumentFlowsThrough(
+  NodeExt arg, NodeExt out, Summary summary, Configuration config
+) {
+  argumentFlowsThrough(arg.getNode(), out.getNode(), _, _, summary, config)
 }
 
 /**
@@ -610,12 +740,19 @@ private predicate argumentFlowsThrough(
  * through a callable.
  */
 pragma[noinline]
-private predicate localFlowStepOrFlowThroughCallable(Node node1, Node node2, Configuration config) {
-  nodeCand1(node1, config) and
-  localFlowStep(node1, node2, config)
-  or
-  nodeCand1(node1, config) and
-  argumentValueFlowsThrough(node1, node2, _)
+private predicate localFlowStepOrFlowThroughCallable(
+  NodeExt node1, NodeExt node2, Configuration config
+) {
+  exists(Node n1, Node n2 |
+    n1 = node1.getNode() and
+    n2 = node2.getNode()
+  |
+    nodeCand1(n1, config) and
+    localFlowStep(n1, n2, config)
+    or
+    nodeCand1(n1, config) and
+    argumentValueFlowsThrough(_, n1, TContentNone(), TContentNone(), n2)
+  )
 }
 
 /**
@@ -625,16 +762,21 @@ private predicate localFlowStepOrFlowThroughCallable(Node node1, Node node2, Con
  */
 pragma[noinline]
 private predicate additionalLocalFlowStepOrFlowThroughCallable(
-  Node node1, Node node2, Configuration config
+  NodeExt node1, NodeExt node2, Configuration config
 ) {
-  nodeCand1(node1, config) and
-  additionalLocalFlowStep(node1, node2, config)
-  or
-  argumentFlowsThrough(node1, node2, _, _, TSummaryTaint(), config)
+  exists(Node n1, Node n2 |
+    n1 = node1.getNode() and
+    n2 = node2.getNode()
+  |
+    nodeCand1(n1, config) and
+    additionalLocalFlowStep(n1, n2, config)
+    or
+    argumentFlowsThrough(n1, n2, _, _, TSummaryTaint(), config)
+  )
 }
 
 pragma[noinline]
-private ReturnPosition getReturnPosition1(Node node, Configuration config) {
+private ReturnPosition getReturnPosition1(ReturnNodeExt node, Configuration config) {
   result = getReturnPosition(node) and
   nodeCand1(node, config)
 }
@@ -658,7 +800,7 @@ private predicate flowOutOfCallable(Node node1, Node node2, Configuration config
  * Holds if data can flow into a callable and that this step is part of a
  * path from a source to a sink.
  */
-private predicate flowIntoCallable(Node node1, Node node2, Configuration config) {
+private predicate flowIntoCallable(ArgumentNode node1, ParameterNode node2, Configuration config) {
   viableParamArgCand(_, node2, node1, config)
 }
 
@@ -688,15 +830,19 @@ private int join(Node n2, Configuration conf) {
  * specified by the configuration.
  */
 private predicate flowOutOfCallable(
-  Node node1, Node node2, boolean allowsFieldFlow, Configuration config
+  NodeExt node1, NodeExt node2, boolean allowsFieldFlow, Configuration config
 ) {
-  flowOutOfCallable(node1, node2, config) and
-  exists(int b, int j |
-    b = branch(node1, config) and
-    j = join(node2, config) and
-    if b.minimum(j) <= config.fieldFlowBranchLimit()
-    then allowsFieldFlow = true
-    else allowsFieldFlow = false
+  exists(Node n1, Node n2 |
+    n1 = node1.getNode() and
+    n2 = node2.getNode() and
+    flowOutOfCallable(n1, n2, config) and
+    exists(int b, int j |
+      b = branch(n1, config) and
+      j = join(n2, config) and
+      if b.minimum(j) <= config.fieldFlowBranchLimit()
+      then allowsFieldFlow = true
+      else allowsFieldFlow = false
+    )
   )
 }
 
@@ -706,15 +852,19 @@ private predicate flowOutOfCallable(
  * the branching is within the limit specified by the configuration.
  */
 private predicate flowIntoCallable(
-  Node node1, Node node2, boolean allowsFieldFlow, Configuration config
+  NodeExt node1, NodeExt node2, boolean allowsFieldFlow, Configuration config
 ) {
-  flowIntoCallable(node1, node2, config) and
-  exists(int b, int j |
-    b = branch(node1, config) and
-    j = join(node2, config) and
-    if b.minimum(j) <= config.fieldFlowBranchLimit()
-    then allowsFieldFlow = true
-    else allowsFieldFlow = false
+  exists(Node n1, Node n2 |
+    n1 = node1.getNode() and
+    n2 = node2.getNode() and
+    flowIntoCallable(n1, n2, config) and
+    exists(int b, int j |
+      b = branch(n1, config) and
+      j = join(n2, config) and
+      if b.minimum(j) <= config.fieldFlowBranchLimit()
+      then allowsFieldFlow = true
+      else allowsFieldFlow = false
+    )
   )
 }
 
@@ -722,50 +872,50 @@ private predicate flowIntoCallable(
  * Holds if `node` is part of a path from a source to a sink in the given
  * configuration taking simple call contexts into consideration.
  */
-private predicate nodeCandFwd2(Node node, boolean fromArg, boolean stored, Configuration config) {
-  nodeCand1(node, config) and
-  config.isSource(node) and
+private predicate nodeCandFwd2(NodeExt node, boolean fromArg, boolean stored, Configuration config) {
+  nodeCand1(node.getNode(), config) and
+  config.isSource(node.getNode()) and
   fromArg = false and
   stored = false
   or
-  nodeCand1(node, unbind(config)) and
+  node.isCand1(unbind(config)) and
   (
-    exists(Node mid |
+    exists(NodeExt mid |
       nodeCandFwd2(mid, fromArg, stored, config) and
       localFlowStepOrFlowThroughCallable(mid, node, config)
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       nodeCandFwd2(mid, fromArg, stored, config) and
       additionalLocalFlowStepOrFlowThroughCallable(mid, node, config) and
       stored = false
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       nodeCandFwd2(mid, _, stored, config) and
-      jumpStep(mid, node, config) and
+      jumpStepExt(mid, node, config) and
       fromArg = false
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       nodeCandFwd2(mid, _, stored, config) and
-      additionalJumpStep(mid, node, config) and
+      additionalJumpStepExt(mid, node, config) and
       fromArg = false and
       stored = false
     )
     or
     // store
-    exists(Node mid, Content f |
+    exists(NodeExt mid, Content f |
       nodeCandFwd2(mid, fromArg, _, config) and
-      store(mid, f, node) and
+      storeExt(mid, f, node, _) and
       readStoreCand1(f, unbind(config)) and
       stored = true
     )
     or
     // taint store
-    exists(Node mid, Content f |
+    exists(NodeExt mid, Content f |
       nodeCandFwd2(mid, fromArg, false, config) and
-      argumentFlowsThrough(mid, node, _, _, TSummaryTaintStore(f), config) and
+      argumentFlowsThrough(mid, node, TSummaryTaintStore(f), config) and
       readStoreCand1(f, unbind(config)) and
       stored = true
     )
@@ -784,14 +934,14 @@ private predicate nodeCandFwd2(Node node, boolean fromArg, boolean stored, Confi
       stored = false
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       nodeCandFwd2(mid, _, stored, config) and
       flowIntoCallable(mid, node, allowsFieldFlow, config) and
       fromArg = true and
       (stored = false or allowsFieldFlow = true)
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       nodeCandFwd2(mid, false, stored, config) and
       flowOutOfCallable(mid, node, allowsFieldFlow, config) and
       fromArg = false and
@@ -805,35 +955,37 @@ private predicate nodeCandFwd2(Node node, boolean fromArg, boolean stored, Confi
  */
 pragma[noinline]
 private predicate storeCandFwd2(Content f, Configuration config) {
-  exists(Node mid, Node node |
+  exists(NodeExt mid, NodeExt node |
     useFieldFlow(config) and
-    nodeCand1(node, unbind(config)) and
+    node.isCand1(unbind(config)) and
     nodeCandFwd2(mid, _, _, config) and
-    store(mid, f, node) and
+    storeExt(mid, f, node, _) and
     readStoreCand1(f, unbind(config))
   )
 }
 
 pragma[nomagic]
-private predicate nodeCandFwd2Read(Content f, Node node, boolean fromArg, Configuration config) {
-  exists(Node mid |
+private predicate nodeCandFwd2Read(Content f, NodeExt node, boolean fromArg, Configuration config) {
+  exists(NodeExt mid |
     nodeCandFwd2(mid, fromArg, true, config) and
-    read(mid, f, node) and
+    readExt(mid, f, node, _) and
     readStoreCand1(f, unbind(config))
   )
 }
 
 pragma[nomagic]
-private predicate nodeCandFwd2ReadTaint(Content f, Node node, boolean fromArg, Configuration config) {
-  exists(Node mid |
+private predicate nodeCandFwd2ReadTaint(
+  Content f, NodeExt node, boolean fromArg, Configuration config
+) {
+  exists(NodeExt mid |
     nodeCandFwd2(mid, fromArg, true, config) and
-    argumentFlowsThrough(mid, node, _, _, TSummaryReadTaint(f), config) and
+    argumentFlowsThrough(mid, node, TSummaryReadTaint(f), config) and
     readStoreCand1(f, unbind(config))
   )
 }
 
 private predicate readCandFwd2(Content f, Configuration config) {
-  exists(Node node |
+  exists(NodeExt node |
     nodeCandFwd2Read(f, node, _, config) or
     nodeCandFwd2ReadTaint(f, node, _, config)
   |
@@ -853,8 +1005,8 @@ private predicate summaryFwd2(Summary s, Configuration config) {
   exists(Content f | s = TSummaryTaintStore(f) | readStoreCandFwd2(f, config))
 }
 
-private predicate argumentFlowsThroughFwd2(Node n1, Node n2, Summary s, Configuration config) {
-  argumentFlowsThrough(n1, n2, _, _, s, config) and
+private predicate argumentFlowsThroughFwd2(NodeExt n1, NodeExt n2, Summary s, Configuration config) {
+  argumentFlowsThrough(n1, n2, s, config) and
   nodeCandFwd2(n1, _, _, config) and
   nodeCandFwd2(n2, _, _, unbind(config)) and
   summaryFwd2(s, unbind(config))
@@ -864,33 +1016,33 @@ private predicate argumentFlowsThroughFwd2(Node n1, Node n2, Summary s, Configur
  * Holds if `node` is part of a path from a source to a sink in the given
  * configuration taking simple call contexts into consideration.
  */
-private predicate nodeCand2(Node node, boolean toReturn, boolean stored, Configuration config) {
+private predicate nodeCand2(NodeExt node, boolean toReturn, boolean stored, Configuration config) {
   nodeCandFwd2(node, _, false, config) and
-  config.isSink(node) and
+  config.isSink(node.getNode()) and
   toReturn = false and
   stored = false
   or
   nodeCandFwd2(node, _, unbindBool(stored), unbind(config)) and
   (
-    exists(Node mid |
+    exists(NodeExt mid |
       localFlowStepOrFlowThroughCallable(node, mid, config) and
       nodeCand2(mid, toReturn, stored, config)
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       additionalLocalFlowStepOrFlowThroughCallable(node, mid, config) and
       nodeCand2(mid, toReturn, stored, config) and
       stored = false
     )
     or
-    exists(Node mid |
-      jumpStep(node, mid, config) and
+    exists(NodeExt mid |
+      jumpStepExt(node, mid, config) and
       nodeCand2(mid, _, stored, config) and
       toReturn = false
     )
     or
-    exists(Node mid |
-      additionalJumpStep(node, mid, config) and
+    exists(NodeExt mid |
+      additionalJumpStepExt(node, mid, config) and
       nodeCand2(mid, _, stored, config) and
       toReturn = false and
       stored = false
@@ -911,29 +1063,29 @@ private predicate nodeCand2(Node node, boolean toReturn, boolean stored, Configu
     )
     or
     // read
-    exists(Node mid, Content f |
-      read(node, f, mid) and
+    exists(NodeExt mid, Content f |
+      readExt(node, f, mid, _) and
       storeCandFwd2(f, unbind(config)) and
       nodeCand2(mid, toReturn, _, config) and
       stored = true
     )
     or
     // read taint
-    exists(Node mid, Content f |
+    exists(NodeExt mid, Content f |
       argumentFlowsThroughFwd2(node, mid, TSummaryReadTaint(f), config) and
       storeCandFwd2(f, unbind(config)) and
       nodeCand2(mid, toReturn, false, config) and
       stored = true
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       flowIntoCallable(node, mid, allowsFieldFlow, config) and
       nodeCand2(mid, false, stored, config) and
       toReturn = false and
       (stored = false or allowsFieldFlow = true)
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       flowOutOfCallable(node, mid, allowsFieldFlow, config) and
       nodeCand2(mid, _, stored, config) and
       toReturn = true and
@@ -947,26 +1099,28 @@ private predicate nodeCand2(Node node, boolean toReturn, boolean stored, Configu
  */
 pragma[noinline]
 private predicate readCand2(Content f, Configuration config) {
-  exists(Node mid, Node node |
+  exists(NodeExt mid, NodeExt node |
     useFieldFlow(config) and
     nodeCandFwd2(node, _, true, unbind(config)) and
-    read(node, f, mid) and
+    readExt(node, f, mid, _) and
     storeCandFwd2(f, unbind(config)) and
     nodeCand2(mid, _, _, config)
   )
 }
 
 pragma[nomagic]
-private predicate nodeCand2Store(Content f, Node node, boolean toReturn, Configuration config) {
-  exists(Node mid |
-    store(node, f, mid) and
+private predicate nodeCand2Store(Content f, NodeExt node, boolean toReturn, Configuration config) {
+  exists(NodeExt mid |
+    storeExt(node, f, mid, _) and
     nodeCand2(mid, toReturn, true, config)
   )
 }
 
 pragma[nomagic]
-private predicate nodeCand2TaintStore(Content f, Node node, boolean toReturn, Configuration config) {
-  exists(Node mid |
+private predicate nodeCand2TaintStore(
+  Content f, NodeExt node, boolean toReturn, Configuration config
+) {
+  exists(NodeExt mid |
     argumentFlowsThroughFwd2(node, mid, TSummaryTaintStore(f), config) and
     nodeCand2(mid, toReturn, true, config)
   )
@@ -974,7 +1128,7 @@ private predicate nodeCand2TaintStore(Content f, Node node, boolean toReturn, Co
 
 pragma[nomagic]
 private predicate storeCand(Content f, Configuration conf) {
-  exists(Node node |
+  exists(NodeExt node |
     nodeCand2Store(f, node, _, conf) or
     nodeCand2TaintStore(f, node, _, conf)
   |
@@ -992,7 +1146,7 @@ private predicate readStoreCand(Content f, Configuration conf) {
   readCand2(f, conf)
 }
 
-private predicate nodeCand(Node node, Configuration config) { nodeCand2(node, _, _, config) }
+private predicate nodeCand(NodeExt node, Configuration config) { nodeCand2(node, _, _, config) }
 
 private predicate summary2(Summary s, Configuration config) {
   s = TSummaryTaint()
@@ -1003,9 +1157,9 @@ private predicate summary2(Summary s, Configuration config) {
 }
 
 private predicate argumentFlowsThrough2(
-  Node n1, Node n2, DataFlowType t1, DataFlowType t2, Summary s, Configuration config
+  NodeExt n1, NodeExt n2, DataFlowType t1, DataFlowType t2, Summary s, Configuration config
 ) {
-  argumentFlowsThrough(n1, n2, t1, t2, s, config) and
+  argumentFlowsThrough(n1.getNode(), n2.getNode(), t1, t2, s, config) and
   nodeCand(n1, config) and
   nodeCand(n2, unbind(config)) and
   summary2(s, unbind(config))
@@ -1016,7 +1170,7 @@ private predicate argumentFlowsThrough2(
  * flow steps in a dataflow path.
  */
 private predicate localFlowEntry(Node node, Configuration config) {
-  nodeCand(node, config) and
+  nodeCand(TNormalNode(node), config) and
   (
     config.isSource(node) or
     jumpStep(_, node, config) or
@@ -1024,7 +1178,7 @@ private predicate localFlowEntry(Node node, Configuration config) {
     node instanceof ParameterNode or
     node instanceof OutNode or
     node instanceof PostUpdateNode or
-    read(_, _, node) or
+    readDirect(_, _, node) or
     node instanceof CastNode
   )
 }
@@ -1034,15 +1188,15 @@ private predicate localFlowEntry(Node node, Configuration config) {
  * flow steps in a dataflow path.
  */
 private predicate localFlowExit(Node node, Configuration config) {
-  exists(Node next | nodeCand(next, config) |
+  exists(Node next | nodeCand(TNormalNode(next), config) |
     jumpStep(node, next, config) or
     additionalJumpStep(node, next, config) or
     flowIntoCallable(node, next, config) or
     flowOutOfCallable(node, next, config) or
-    argumentFlowsThrough2(node, next, _, _, _, config) or
-    argumentValueFlowsThrough(node, next, _) or
-    store(node, _, next) or
-    read(node, _, next)
+    argumentFlowsThrough2(TNormalNode(node), TNormalNode(next), _, _, _, config) or
+    argumentValueFlowsThrough(_, node, TContentNone(), TContentNone(), next) or
+    storeDirect(node, _, next) or
+    readDirect(node, _, next)
   )
   or
   node instanceof CastNode
@@ -1072,13 +1226,13 @@ private predicate localFlowStepPlus(
     node1 != node2 and
     cc.relevantFor(node1.getEnclosingCallable()) and
     not isUnreachableInCall(node1, cc.(LocalCallContextSpecificCall).getCall()) and
-    nodeCand(node2, unbind(config))
+    nodeCand(TNormalNode(node2), unbind(config))
     or
     exists(Node mid |
       localFlowStepPlus(node1, mid, preservesValue, config, cc) and
       localFlowStep(mid, node2, config) and
       not mid instanceof CastNode and
-      nodeCand(node2, unbind(config))
+      nodeCand(TNormalNode(node2), unbind(config))
     )
     or
     exists(Node mid |
@@ -1086,7 +1240,7 @@ private predicate localFlowStepPlus(
       additionalLocalFlowStep(mid, node2, config) and
       not mid instanceof CastNode and
       preservesValue = false and
-      nodeCand(node2, unbind(config))
+      nodeCand(TNormalNode(node2), unbind(config))
     )
   )
 }
@@ -1101,6 +1255,13 @@ private predicate localFlowBigStep(
 ) {
   localFlowStepPlus(node1, node2, preservesValue, config, callContext) and
   localFlowExit(node2, config)
+}
+
+pragma[nomagic]
+private predicate localFlowBigStepExt(
+  NodeExt node1, NodeExt node2, boolean preservesValue, Configuration config
+) {
+  localFlowBigStep(node1.getNode(), node2.getNode(), preservesValue, config, _)
 }
 
 private newtype TAccessPathFront =
@@ -1129,24 +1290,14 @@ private class AccessPathFront extends TAccessPathFront {
 private class AccessPathFrontNil extends AccessPathFront, TFrontNil { }
 
 /**
- * A `Node` at which a cast can occur such that the type should be checked.
- */
-private class CastingNode extends Node {
-  CastingNode() {
-    this instanceof ParameterNode or
-    this instanceof CastNode or
-    this instanceof OutNode or
-    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
-  }
-}
-
-/**
  * Holds if data can flow from a source to `node` with the given `apf`.
  */
-private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, Configuration config) {
+private predicate flowCandFwd(
+  NodeExt node, boolean fromArg, AccessPathFront apf, Configuration config
+) {
   flowCandFwd0(node, fromArg, apf, config) and
-  if node instanceof CastingNode
-  then compatibleTypes(getErasedNodeType(node), apf.getType())
+  if node instanceof CastingNodeExt
+  then compatibleTypes(node.getErasedNodeTypeBound(), apf.getType())
   else any()
 }
 
@@ -1155,92 +1306,91 @@ private predicate flowCandFwd(Node node, boolean fromArg, AccessPathFront apf, C
  * (re-)computed. This is either a source or a node reached through an
  * additional step.
  */
-private class AccessPathFrontNilNode extends Node {
+private class AccessPathFrontNilNode extends NormalNodeExt {
   AccessPathFrontNilNode() {
     nodeCand(this, _) and
     (
-      any(Configuration c).isSource(this)
+      any(Configuration c).isSource(this.getNode())
       or
-      localFlowBigStep(_, this, false, _, _)
+      localFlowBigStepExt(_, this, false, _)
       or
-      additionalJumpStep(_, this, _)
+      additionalJumpStepExt(_, this, _)
     )
   }
 
-  pragma[noinline]
-  private DataFlowType getErasedReprType() { result = getErasedNodeType(this) }
-
   /** Gets the `nil` path front for this node. */
-  AccessPathFrontNil getApf() { result = TFrontNil(this.getErasedReprType()) }
+  AccessPathFrontNil getApf() { result = TFrontNil(this.getErasedNodeTypeBound()) }
 }
 
-private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, Configuration config) {
+private predicate flowCandFwd0(
+  NodeExt node, boolean fromArg, AccessPathFront apf, Configuration config
+) {
   nodeCand2(node, _, false, config) and
-  config.isSource(node) and
+  config.isSource(node.getNode()) and
   fromArg = false and
   apf = node.(AccessPathFrontNilNode).getApf()
   or
   nodeCand(node, unbind(config)) and
   (
-    exists(Node mid |
+    exists(NodeExt mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      localFlowBigStep(mid, node, true, config, _)
+      localFlowBigStepExt(mid, node, true, config)
     )
     or
-    exists(Node mid, AccessPathFrontNil nil |
+    exists(NodeExt mid, AccessPathFrontNil nil |
       flowCandFwd(mid, fromArg, nil, config) and
-      localFlowBigStep(mid, node, false, config, _) and
+      localFlowBigStepExt(mid, node, false, config) and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       flowCandFwd(mid, _, apf, config) and
-      jumpStep(mid, node, config) and
+      jumpStepExt(mid, node, config) and
       fromArg = false
     )
     or
-    exists(Node mid, AccessPathFrontNil nil |
+    exists(NodeExt mid, AccessPathFrontNil nil |
       flowCandFwd(mid, _, nil, config) and
-      additionalJumpStep(mid, node, config) and
+      additionalJumpStepExt(mid, node, config) and
       fromArg = false and
       apf = node.(AccessPathFrontNilNode).getApf()
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       flowCandFwd(mid, _, apf, config) and
       flowIntoCallable(mid, node, allowsFieldFlow, config) and
       fromArg = true and
       (apf instanceof AccessPathFrontNil or allowsFieldFlow = true)
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       flowCandFwd(mid, false, apf, config) and
       flowOutOfCallable(mid, node, allowsFieldFlow, config) and
       fromArg = false and
       (apf instanceof AccessPathFrontNil or allowsFieldFlow = true)
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       flowCandFwd(mid, fromArg, apf, config) and
-      argumentValueFlowsThrough(mid, node, _)
+      argumentValueFlowsThrough(mid, node)
     )
     or
-    exists(Node mid, AccessPathFrontNil nil, DataFlowType t |
+    exists(NodeExt mid, AccessPathFrontNil nil, DataFlowType t |
       flowCandFwd(mid, fromArg, nil, config) and
       argumentFlowsThrough2(mid, node, _, t, TSummaryTaint(), config) and
       apf = TFrontNil(t)
     )
   )
   or
-  exists(Node mid, Content f |
+  exists(NodeExt mid, Content f |
     flowCandFwd(mid, fromArg, _, config) and
-    store(mid, f, node) and
+    storeExt(mid, f, node, _) and
     nodeCand(node, unbind(config)) and
     readStoreCand(f, unbind(config)) and
     apf.headUsesContent(f)
   )
   or
-  exists(Node mid, AccessPathFrontNil nil, Content f |
+  exists(NodeExt mid, AccessPathFrontNil nil, Content f |
     flowCandFwd(mid, fromArg, nil, config) and
     argumentFlowsThrough2(mid, node, _, _, TSummaryTaintStore(f), config) and
     apf.headUsesContent(f)
@@ -1260,9 +1410,9 @@ private predicate flowCandFwd0(Node node, boolean fromArg, AccessPathFront apf, 
 
 pragma[noinline]
 private predicate consCandFwd(Content f, AccessPathFront apf, Configuration config) {
-  exists(Node mid, Node n |
+  exists(NodeExt mid, NodeExt n |
     flowCandFwd(mid, _, apf, config) and
-    store(mid, f, n) and
+    storeExt(mid, f, n, _) and
     nodeCand(n, unbind(config)) and
     readStoreCand(f, unbind(config)) and
     compatibleTypes(apf.getType(), f.getType())
@@ -1270,10 +1420,10 @@ private predicate consCandFwd(Content f, AccessPathFront apf, Configuration conf
 }
 
 pragma[nomagic]
-private predicate flowCandFwdRead(Content f, Node node, boolean fromArg, Configuration config) {
-  exists(Node mid, AccessPathFront apf |
+private predicate flowCandFwdRead(Content f, NodeExt node, boolean fromArg, Configuration config) {
+  exists(NodeExt mid, AccessPathFront apf |
     flowCandFwd(mid, fromArg, apf, config) and
-    read(mid, f, node) and
+    readExt(mid, f, node, _) and
     apf.headUsesContent(f) and
     nodeCand(node, unbind(config))
   )
@@ -1281,9 +1431,9 @@ private predicate flowCandFwdRead(Content f, Node node, boolean fromArg, Configu
 
 pragma[nomagic]
 private predicate flowCandFwdReadTaint(
-  Content f, Node node, boolean fromArg, DataFlowType t, Configuration config
+  Content f, NodeExt node, boolean fromArg, DataFlowType t, Configuration config
 ) {
-  exists(Node mid, AccessPathFront apf |
+  exists(NodeExt mid, AccessPathFront apf |
     flowCandFwd(mid, fromArg, apf, config) and
     argumentFlowsThrough2(mid, node, _, t, TSummaryReadTaint(f), config) and
     apf.headUsesContent(f)
@@ -1291,7 +1441,7 @@ private predicate flowCandFwdReadTaint(
 }
 
 pragma[noinline]
-private predicate flowCandFwdEmptyAp(Node node, Configuration config) {
+private predicate flowCandFwdEmptyAp(NodeExt node, Configuration config) {
   flowCandFwd(node, _, any(AccessPathFrontNil nil), config)
 }
 
@@ -1301,7 +1451,7 @@ private predicate consCandFwdEmptyAp(Content f, Configuration config) {
 }
 
 private predicate argumentFlowsThrough3(
-  Node n1, Node n2, DataFlowType t1, DataFlowType t2, Summary s, Configuration config
+  NodeExt n1, NodeExt n2, DataFlowType t1, DataFlowType t2, Summary s, Configuration config
 ) {
   argumentFlowsThrough2(n1, n2, t1, t2, s, config) and
   flowCandFwdEmptyAp(n1, config) and
@@ -1331,63 +1481,65 @@ private predicate argumentFlowsThrough3(
  * Holds if data can flow from a source to `node` with the given `apf` and
  * from there flow to a sink.
  */
-private predicate flowCand(Node node, boolean toReturn, AccessPathFront apf, Configuration config) {
+private predicate flowCand(NodeExt node, boolean toReturn, AccessPathFront apf, Configuration config) {
   flowCand0(node, toReturn, apf, config) and
   flowCandFwd(node, _, apf, config)
 }
 
-private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Configuration config) {
+private predicate flowCand0(
+  NodeExt node, boolean toReturn, AccessPathFront apf, Configuration config
+) {
   flowCandFwd(node, _, apf, config) and
-  config.isSink(node) and
+  config.isSink(node.getNode()) and
   toReturn = false and
   apf instanceof AccessPathFrontNil
   or
-  exists(Node mid |
-    localFlowBigStep(node, mid, true, config, _) and
+  exists(NodeExt mid |
+    localFlowBigStepExt(node, mid, true, config) and
     flowCand(mid, toReturn, apf, config)
   )
   or
-  exists(Node mid, AccessPathFrontNil nil |
+  exists(NodeExt mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    localFlowBigStep(node, mid, false, config, _) and
+    localFlowBigStepExt(node, mid, false, config) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil
   )
   or
-  exists(Node mid |
-    jumpStep(node, mid, config) and
+  exists(NodeExt mid |
+    jumpStepExt(node, mid, config) and
     flowCand(mid, _, apf, config) and
     toReturn = false
   )
   or
-  exists(Node mid, AccessPathFrontNil nil |
+  exists(NodeExt mid, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
-    additionalJumpStep(node, mid, config) and
+    additionalJumpStepExt(node, mid, config) and
     flowCand(mid, _, nil, config) and
     toReturn = false and
     apf instanceof AccessPathFrontNil
   )
   or
-  exists(Node mid, boolean allowsFieldFlow |
+  exists(NodeExt mid, boolean allowsFieldFlow |
     flowIntoCallable(node, mid, allowsFieldFlow, config) and
     flowCand(mid, false, apf, config) and
     toReturn = false and
     (apf instanceof AccessPathFrontNil or allowsFieldFlow = true)
   )
   or
-  exists(Node mid, boolean allowsFieldFlow |
+  exists(NodeExt mid, boolean allowsFieldFlow |
     flowOutOfCallable(node, mid, allowsFieldFlow, config) and
     flowCand(mid, _, apf, config) and
     toReturn = true and
     (apf instanceof AccessPathFrontNil or allowsFieldFlow = true)
   )
   or
-  exists(Node mid |
-    argumentValueFlowsThrough(node, mid, _) and
+  exists(NodeExt mid |
+    argumentValueFlowsThrough(node, mid) and
     flowCand(mid, toReturn, apf, config)
   )
   or
-  exists(Node mid, AccessPathFrontNil nil |
+  exists(NodeExt mid, AccessPathFrontNil nil |
     argumentFlowsThrough3(node, mid, _, _, TSummaryTaint(), config) and
     flowCand(mid, toReturn, nil, config) and
     apf instanceof AccessPathFrontNil and
@@ -1400,7 +1552,7 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
     consCand(f, apf, config)
   )
   or
-  exists(Node mid, Content f, AccessPathFront apf0, AccessPathFrontNil nil |
+  exists(NodeExt mid, Content f, AccessPathFront apf0, AccessPathFrontNil nil |
     flowCandFwd(node, _, apf, config) and
     apf instanceof AccessPathFrontNil and
     argumentFlowsThrough3(node, mid, _, _, TSummaryTaintStore(f), config) and
@@ -1415,7 +1567,7 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
     apf.headUsesContent(f)
   )
   or
-  exists(Node mid, AccessPathFrontNil nil1, AccessPathFrontNil nil2, Content f |
+  exists(NodeExt mid, AccessPathFrontNil nil1, AccessPathFrontNil nil2, Content f |
     argumentFlowsThrough3(node, mid, _, _, TSummaryReadTaint(f), config) and
     flowCand(mid, toReturn, nil1, config) and
     consCandFwd(f, nil2, unbind(config)) and
@@ -1425,20 +1577,20 @@ private predicate flowCand0(Node node, boolean toReturn, AccessPathFront apf, Co
 
 pragma[nomagic]
 private predicate flowCandRead(
-  Node node, Content f, boolean toReturn, AccessPathFront apf0, Configuration config
+  NodeExt node, Content f, boolean toReturn, AccessPathFront apf0, Configuration config
 ) {
-  exists(Node mid |
-    read(node, f, mid) and
+  exists(NodeExt mid |
+    readExt(node, f, mid, _) and
     flowCand(mid, toReturn, apf0, config)
   )
 }
 
 pragma[nomagic]
 private predicate flowCandStore(
-  Node node, Content f, boolean toReturn, AccessPathFront apf0, Configuration config
+  NodeExt node, Content f, boolean toReturn, AccessPathFront apf0, Configuration config
 ) {
-  exists(Node mid |
-    store(node, f, mid) and
+  exists(NodeExt mid |
+    storeExt(node, f, mid, _) and
     flowCand(mid, toReturn, apf0, config)
   )
 }
@@ -1446,7 +1598,7 @@ private predicate flowCandStore(
 pragma[nomagic]
 private predicate consCand(Content f, AccessPathFront apf, Configuration config) {
   consCandFwd(f, apf, config) and
-  exists(Node n, AccessPathFront apf0 |
+  exists(NodeExt n, AccessPathFront apf0 |
     flowCandFwd(n, _, apf0, config) and
     apf0.headUsesContent(f) and
     flowCandRead(n, f, _, apf, config)
@@ -1481,6 +1633,13 @@ abstract private class AccessPath extends TAccessPath {
     or
     this = TConsCons(_, _, result)
   }
+
+  /**
+   * Holds if the length of this access path does not exceed the value
+   * of `flowThroughAccessPathLimit()`, if any.
+   */
+  pragma[noinline]
+  predicate isValidForFlowThrough() { not this.len() > flowThroughAccessPathLimit() }
 
   DataFlowType getType() {
     this = TNil(result)
@@ -1550,100 +1709,101 @@ private class AccessPathConsCons extends AccessPathCons, TConsCons {
   }
 }
 
-/** Holds if `ap0` corresponds to the cons of `f` and `ap`. */
-private predicate pop(AccessPath ap0, Content f, AccessPath ap) { ap0.pop(f, ap) }
+/** Gets the access path obtained by popping `f` from `ap`, if any. */
+private AccessPath pop(Content f, AccessPath ap) { ap.pop(f, result) }
 
 /** Holds if `ap0` corresponds to the cons of `f` and `ap` and `apf` is the front of `ap`. */
 pragma[noinline]
 private predicate popWithFront(AccessPath ap0, Content f, AccessPathFront apf, AccessPath ap) {
-  pop(ap0, f, ap) and apf = ap.getFront()
+  ap = pop(f, ap0) and apf = ap.getFront()
 }
 
-/** Holds if `ap` corresponds to the cons of `f` and `ap0`. */
-private predicate push(AccessPath ap0, Content f, AccessPath ap) { pop(ap, f, ap0) }
+/** Gets the access path obtained by pushing `f` onto `ap`. */
+private AccessPath push(Content f, AccessPath ap) { ap = pop(f, result) }
 
 /**
  * A node that requires an empty access path and should have its tracked type
  * (re-)computed. This is either a source or a node reached through an
  * additional step.
  */
-private class AccessPathNilNode extends Node {
+private class AccessPathNilNode extends NormalNodeExt {
   AccessPathNilNode() { flowCand(this.(AccessPathFrontNilNode), _, _, _) }
 
-  pragma[noinline]
-  private DataFlowType getErasedReprType() { result = getErasedNodeType(this) }
-
   /** Gets the `nil` path for this node. */
-  AccessPathNil getAp() { result = TNil(this.getErasedReprType()) }
+  AccessPathNil getAp() { result = TNil(this.getErasedNodeTypeBound()) }
 }
 
 /**
  * Holds if data can flow from a source to `node` with the given `ap`.
  */
 private predicate flowFwd(
-  Node node, boolean fromArg, AccessPathFront apf, AccessPath ap, Configuration config
+  NodeExt node, boolean fromArg, AccessPathFront apf, AccessPath ap, Configuration config
 ) {
   flowFwd0(node, fromArg, apf, ap, config) and
-  flowCand(node, _, apf, config)
+  flowCand(node, _, apf, config) and
+  if node instanceof CastingNodeExt
+  then compatibleTypes(node.getErasedNodeTypeBound(), ap.getType())
+  else any()
 }
 
 private predicate flowFwd0(
-  Node node, boolean fromArg, AccessPathFront apf, AccessPath ap, Configuration config
+  NodeExt node, boolean fromArg, AccessPathFront apf, AccessPath ap, Configuration config
 ) {
   flowCand(node, _, _, config) and
-  config.isSource(node) and
+  config.isSource(node.getNode()) and
   fromArg = false and
   ap = node.(AccessPathNilNode).getAp() and
   apf = ap.(AccessPathNil).getFront()
   or
   flowCand(node, _, _, unbind(config)) and
   (
-    exists(Node mid |
+    exists(NodeExt mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      localFlowBigStep(mid, node, true, config, _)
+      localFlowBigStepExt(mid, node, true, config)
     )
     or
-    exists(Node mid, AccessPathNil nil |
+    exists(NodeExt mid, AccessPathNil nil |
       flowFwd(mid, fromArg, _, nil, config) and
-      localFlowBigStep(mid, node, false, config, _) and
+      localFlowBigStepExt(mid, node, false, config) and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       flowFwd(mid, _, apf, ap, config) and
-      jumpStep(mid, node, config) and
+      jumpStepExt(mid, node, config) and
       fromArg = false
     )
     or
-    exists(Node mid, AccessPathNil nil |
+    exists(NodeExt mid, AccessPathNil nil |
       flowFwd(mid, _, _, nil, config) and
-      additionalJumpStep(mid, node, config) and
+      additionalJumpStepExt(mid, node, config) and
       fromArg = false and
       ap = node.(AccessPathNilNode).getAp() and
       apf = ap.(AccessPathNil).getFront()
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       flowFwd(mid, _, apf, ap, config) and
       flowIntoCallable(mid, node, allowsFieldFlow, config) and
       fromArg = true and
       (ap instanceof AccessPathNil or allowsFieldFlow = true)
     )
     or
-    exists(Node mid, boolean allowsFieldFlow |
+    exists(NodeExt mid, boolean allowsFieldFlow |
       flowFwd(mid, false, apf, ap, config) and
       flowOutOfCallable(mid, node, allowsFieldFlow, config) and
       fromArg = false and
       (ap instanceof AccessPathNil or allowsFieldFlow = true)
     )
     or
-    exists(Node mid |
+    exists(NodeExt mid |
       flowFwd(mid, fromArg, apf, ap, config) and
-      argumentValueFlowsThrough(mid, node, _)
+      argumentValueFlowsThrough(mid, node) and
+      ap.isValidForFlowThrough()
     )
     or
-    exists(Node mid, AccessPathNil nil, DataFlowType t |
+    exists(NodeExt mid, AccessPathNil nil, DataFlowType t |
       flowFwd(mid, fromArg, _, nil, config) and
       argumentFlowsThrough3(mid, node, _, t, TSummaryTaint(), config) and
       ap = TNil(t) and
@@ -1653,7 +1813,7 @@ private predicate flowFwd0(
   or
   exists(Content f, AccessPath ap0 |
     flowFwdStore(node, f, ap0, apf, fromArg, config) and
-    push(ap0, f, ap)
+    ap = push(f, ap0)
   )
   or
   exists(Content f, AccessPath ap0 |
@@ -1661,7 +1821,7 @@ private predicate flowFwd0(
     popWithFront(ap0, f, apf, ap)
   )
   or
-  exists(Content f, Node mid, AccessPathFront apf0, DataFlowType t |
+  exists(Content f, NodeExt mid, AccessPathFront apf0, DataFlowType t |
     flowFwd(mid, fromArg, apf0, any(AccessPathConsNil consnil), config) and
     argumentFlowsThrough3(mid, node, _, t, TSummaryReadTaint(f), config) and
     apf0.headUsesContent(f) and
@@ -1673,14 +1833,17 @@ private predicate flowFwd0(
 
 pragma[nomagic]
 private predicate flowFwdStore(
-  Node node, Content f, AccessPath ap0, AccessPathFront apf, boolean fromArg, Configuration config
+  NodeExt node, Content f, AccessPath ap0, AccessPathFront apf, boolean fromArg,
+  Configuration config
 ) {
-  exists(Node mid, AccessPathFront apf0 |
+  exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, apf0, apf, config)
+    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+  |
+    through = false or ap0.isValidForFlowThrough()
   )
   or
-  exists(Node mid, DataFlowType t |
+  exists(NodeExt mid, DataFlowType t |
     flowFwd(mid, fromArg, _, any(AccessPathNil nil), config) and
     argumentFlowsThrough3(mid, node, t, _, TSummaryTaintStore(f), config) and
     consCand(f, TFrontNil(t), unbind(config)) and
@@ -1691,9 +1854,10 @@ private predicate flowFwdStore(
 }
 
 private predicate flowFwdStoreAux(
-  Node mid, Content f, Node node, AccessPathFront apf0, AccessPathFront apf, Configuration config
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
+  Configuration config
 ) {
-  store(mid, f, node) and
+  storeExt(mid, f, node, through) and
   consCand(f, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
@@ -1701,13 +1865,15 @@ private predicate flowFwdStoreAux(
 
 pragma[nomagic]
 private predicate flowFwdRead(
-  Node node, Content f, AccessPath ap0, boolean fromArg, Configuration config
+  NodeExt node, Content f, AccessPath ap0, boolean fromArg, Configuration config
 ) {
-  exists(Node mid, AccessPathFront apf0 |
+  exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    read(mid, f, node) and
+    readExt(mid, f, node, through) and
     apf0.headUsesContent(f) and
     flowCand(node, _, _, unbind(config))
+  |
+    through = false or ap0.isValidForFlowThrough()
   )
 }
 
@@ -1715,150 +1881,169 @@ private predicate flowFwdRead(
  * Holds if data can flow from a source to `node` with the given `ap` and
  * from there flow to a sink.
  */
-private predicate flow(Node node, boolean toReturn, AccessPath ap, Configuration config) {
+private predicate flow(NodeExt node, boolean toReturn, AccessPath ap, Configuration config) {
   flow0(node, toReturn, ap, config) and
   flowFwd(node, _, _, ap, config)
 }
 
-private predicate flow0(Node node, boolean toReturn, AccessPath ap, Configuration config) {
+private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configuration config) {
   flowFwd(node, _, _, ap, config) and
-  config.isSink(node) and
+  config.isSink(node.getNode()) and
   toReturn = false and
   ap instanceof AccessPathNil
   or
-  exists(Node mid |
-    localFlowBigStep(node, mid, true, config, _) and
+  exists(NodeExt mid |
+    localFlowBigStepExt(node, mid, true, config) and
     flow(mid, toReturn, ap, config)
   )
   or
-  exists(Node mid, AccessPathNil nil |
+  exists(NodeExt mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    localFlowBigStep(node, mid, false, config, _) and
+    localFlowBigStepExt(node, mid, false, config) and
     flow(mid, toReturn, nil, config) and
     ap instanceof AccessPathNil
   )
   or
-  exists(Node mid |
-    jumpStep(node, mid, config) and
+  exists(NodeExt mid |
+    jumpStepExt(node, mid, config) and
     flow(mid, _, ap, config) and
     toReturn = false
   )
   or
-  exists(Node mid, AccessPathNil nil |
+  exists(NodeExt mid, AccessPathNil nil |
     flowFwd(node, _, _, ap, config) and
-    additionalJumpStep(node, mid, config) and
+    additionalJumpStepExt(node, mid, config) and
     flow(mid, _, nil, config) and
     toReturn = false and
     ap instanceof AccessPathNil
   )
   or
-  exists(Node mid, boolean allowsFieldFlow |
+  exists(NodeExt mid, boolean allowsFieldFlow |
     flowIntoCallable(node, mid, allowsFieldFlow, config) and
     flow(mid, false, ap, config) and
     toReturn = false and
     (ap instanceof AccessPathNil or allowsFieldFlow = true)
   )
   or
-  exists(Node mid, boolean allowsFieldFlow |
+  exists(NodeExt mid, boolean allowsFieldFlow |
     flowOutOfCallable(node, mid, allowsFieldFlow, config) and
     flow(mid, _, ap, config) and
     toReturn = true and
     (ap instanceof AccessPathNil or allowsFieldFlow = true)
   )
   or
-  exists(Node mid |
-    argumentValueFlowsThrough(node, mid, _) and
-    flow(mid, toReturn, ap, config)
+  exists(NodeExt mid |
+    argumentValueFlowsThrough(node, mid) and
+    flow(mid, toReturn, ap, config) and
+    ap.isValidForFlowThrough()
   )
   or
-  exists(Node mid, AccessPathNil ap0 |
+  exists(NodeExt mid, AccessPathNil ap0 |
     argumentFlowsThrough3(node, mid, _, _, TSummaryTaint(), config) and
     flow(mid, toReturn, ap0, config) and
     ap instanceof AccessPathNil and
     flowFwd(node, _, _, ap, config)
   )
   or
-  exists(Content f, AccessPath ap0 |
-    flowStore(node, f, toReturn, ap0, config) and
-    pop(ap0, f, ap)
+  exists(NodeExt mid, AccessPath ap0 |
+    storeFwd(node, _, mid, ap, ap0, config) and
+    flow(mid, toReturn, ap0, config)
   )
   or
   exists(Content f, AccessPath ap0 |
     flowTaintStore(node, f, toReturn, ap0, config) and
-    pop(ap0, f, any(AccessPathNil nil)) and
+    pop(f, ap0) instanceof AccessPathNil and
     ap instanceof AccessPathNil and
     flowFwd(node, _, _, ap, config)
   )
   or
-  exists(Content f, AccessPath ap0 |
-    flowRead(node, f, toReturn, ap0, config) and
-    push(ap0, f, ap)
+  exists(NodeExt mid, AccessPath ap0 |
+    readFwd(node, _, mid, ap, ap0, config) and
+    flow(mid, toReturn, ap0, config)
   )
   or
-  exists(Node mid, Content f |
+  exists(NodeExt mid, Content f |
     argumentFlowsThrough3(node, mid, _, _, TSummaryReadTaint(f), config) and
     flow(mid, toReturn, any(AccessPathNil nil1), config) and
-    push(any(AccessPathNil nil2), f, ap) and
+    ap = push(f, any(AccessPathNil nil2)) and
     flowFwd(node, _, _, ap, config)
   )
 }
 
 pragma[nomagic]
-private predicate flowStore(
-  Node node, Content f, boolean toReturn, AccessPath ap0, Configuration config
+private predicate storeFwd(
+  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  exists(Node mid |
-    store(node, f, mid) and
-    flow(mid, toReturn, ap0, config)
-  )
+  storeExt(node1, f, node2, _) and
+  flowFwdStore(node2, f, ap, _, _, config) and
+  ap0 = push(f, ap)
 }
 
 pragma[nomagic]
 private predicate flowTaintStore(
-  Node node, Content f, boolean toReturn, AccessPath ap0, Configuration config
+  NodeExt node, Content f, boolean toReturn, AccessPath ap0, Configuration config
 ) {
-  exists(Node mid |
+  exists(NodeExt mid |
     argumentFlowsThrough3(node, mid, _, _, TSummaryTaintStore(f), config) and
     flow(mid, toReturn, ap0, config)
   )
 }
 
 pragma[nomagic]
-private predicate flowRead(
-  Node node, Content f, boolean toReturn, AccessPath ap0, Configuration config
+private predicate readFwd(
+  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  exists(Node mid |
-    read(node, f, mid) and
-    flow(mid, toReturn, ap0, config)
-  )
+  readExt(node1, f, node2, _) and
+  flowFwdRead(node2, f, ap, _, config) and
+  ap0 = pop(f, ap)
 }
 
 bindingset[conf, result]
 private Configuration unbind(Configuration conf) { result >= conf and result <= conf }
 
-private predicate flow(Node n, Configuration config) { flow(n, _, _, config) }
+private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxNil(ParameterNode p) {
-    exists(Configuration conf, ReturnNodeExt ret |
-      flow(p, true, TNil(_), conf) and
-      parameterFlowReturn(p, ret, _, _, _,
-        any(Summary s | s = TSummaryTaint() or s = TSummaryTaintStore(_)), conf) and
-      flow(ret, unbind(conf))
-    )
-  } or
-  TSummaryCtxConsNil(ParameterNode p, Content f) {
-    exists(Configuration conf, ReturnNodeExt ret |
-      flow(p, true, TConsNil(f, _), conf) and
-      parameterFlowReturn(p, ret, _, _, _, TSummaryReadTaint(f), conf) and
-      flow(ret, unbind(conf))
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
+      exists(Summary summary |
+        parameterFlowReturn(p, ret, _, _, _, summary, config) and
+        flow(ret, unbind(config))
+      |
+        // taint through
+        summary = TSummaryTaint() and
+        ap instanceof AccessPathNil
+        or
+        // taint setter
+        summary = TSummaryTaintStore(_) and
+        ap instanceof AccessPathNil
+        or
+        // taint getter
+        summary = TSummaryReadTaint(ap.(AccessPathConsNil).getHead())
+      )
+      or
+      exists(ContentOption contentIn |
+        parameterValueFlowReturn(p, ret, _, contentIn, _) and
+        flow(ret, unbind(config)) and
+        ap.isValidForFlowThrough()
+      |
+        // value through/setter
+        contentIn = TContentNone()
+        or
+        // value getter (+ setter)
+        contentIn = TContentSome(ap.getHead())
+      )
     )
   }
 
 /**
  * A context for generating flow summaries. This represents flow entry through
  * a specific parameter with an access path of a specific shape.
+ *
+ * Summaries are only created for parameters that may flow through, and
+ * access paths may be limited via the language specific predicate
+ * `flowThroughAccessPathLimit()`.
  */
 private class SummaryCtx extends TSummaryCtx {
   string toString() { result = "SummaryCtx" }
@@ -1867,47 +2052,6 @@ private class SummaryCtx extends TSummaryCtx {
 /** A summary context from which no flow summary can be generated. */
 private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
 
-/** Gets the summary context for a given flow entry, if potentially necessary. */
-private SummaryCtx getSummaryCtx(ParameterNode p, AccessPath ap) {
-  result = TSummaryCtxNil(p) and flow(p, true, ap, _) and ap instanceof AccessPathNil
-  or
-  exists(Content f |
-    result = TSummaryCtxConsNil(p, f) and flow(p, true, ap, _) and ap = TConsNil(f, _)
-  )
-}
-
-/**
- * Holds if flow from a parameter specified by `sc` that flows to `ret` with a
- * resulting access path `ap` is compatible with a summary found by `parameterFlowReturn`.
- */
-private predicate summaryCompatible(
-  SummaryCtx sc, ReturnNodeExt ret, AccessPath ap, Configuration conf
-) {
-  exists(ParameterNode p |
-    sc = TSummaryCtxNil(p) and
-    flow(p, true, TNil(_), conf) and
-    parameterFlowReturn(p, ret, _, _, _, TSummaryTaint(), conf) and
-    flow(ret, true, ap, conf) and
-    ap instanceof AccessPathNil
-  )
-  or
-  exists(ParameterNode p, Content f |
-    sc = TSummaryCtxNil(p) and
-    flow(p, true, TNil(_), conf) and
-    parameterFlowReturn(p, ret, _, _, _, TSummaryTaintStore(f), conf) and
-    flow(ret, true, ap, conf) and
-    ap = TConsNil(f, _)
-  )
-  or
-  exists(ParameterNode p, Content f |
-    sc = TSummaryCtxConsNil(p, f) and
-    flow(p, true, TConsNil(f, _), conf) and
-    parameterFlowReturn(p, ret, _, _, _, TSummaryReadTaint(f), conf) and
-    flow(ret, true, ap, conf) and
-    ap instanceof AccessPathNil
-  )
-}
-
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
     // A PathNode is introduced by a source ...
@@ -1915,34 +2059,43 @@ private newtype TPathNode =
     config.isSource(node) and
     cc instanceof CallContextAny and
     sc instanceof SummaryCtxNone and
-    ap = node.(AccessPathNilNode).getAp()
+    ap = any(AccessPathNilNode nil | nil.getNode() = node).getAp()
     or
     // ... or a step from an existing PathNode to another node.
     exists(PathNodeMid mid |
       pathStep(mid, node, cc, sc, ap) and
       config = mid.getConfiguration() and
-      flow(node, _, ap, unbind(config))
+      flow(TNormalNode(node), _, ap, unbind(config))
     )
   } or
   TPathNodeSink(Node node, Configuration config) {
-    // The AccessPath on a sink is empty.
     config.isSink(node) and
-    flow(node, config)
+    flow(node, unbind(config)) and
+    (
+      // A sink that is also a source ...
+      config.isSource(node)
+      or
+      // ... or a sink that can be reached from a source
+      exists(PathNodeMid mid |
+        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+        config = mid.getConfiguration()
+      )
+    )
   }
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.
  * Only those `PathNode`s that are reachable from a source are generated.
  */
-abstract class PathNode extends TPathNode {
+class PathNode extends TPathNode {
   /** Gets a textual representation of this element. */
-  string toString() { result = getNode().toString() + ppAp() }
+  string toString() { none() }
 
   /**
    * Gets a textual representation of this element, including a textual
    * representation of the call context.
    */
-  string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
+  string toStringWithContext() { none() }
 
   /**
    * Holds if this element is at the specified location.
@@ -1954,24 +2107,23 @@ abstract class PathNode extends TPathNode {
   predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    none()
   }
 
   /** Gets the underlying `Node`. */
-  abstract Node getNode();
+  Node getNode() { none() }
 
   /** Gets the associated configuration. */
-  abstract Configuration getConfiguration();
-
-  /** Gets a successor. */
-  deprecated final PathNode getSucc() { result = this.getASuccessor() }
+  Configuration getConfiguration() { none() }
 
   /** Gets a successor of this node, if any. */
-  abstract PathNode getASuccessor();
+  PathNode getASuccessor() { none() }
 
   /** Holds if this node is a source. */
-  abstract predicate isSource();
+  predicate isSource() { none() }
+}
 
+abstract private class PathNodeImpl extends PathNode {
   private string ppAp() {
     this instanceof PathNodeSink and result = ""
     or
@@ -1984,6 +2136,16 @@ abstract class PathNode extends TPathNode {
     this instanceof PathNodeSink and result = ""
     or
     result = " <" + this.(PathNodeMid).getCallContext().toString() + ">"
+  }
+
+  override string toString() { result = this.getNode().toString() + ppAp() }
+
+  override string toStringWithContext() { result = this.getNode().toString() + ppAp() + ppCtx() }
+
+  override predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    this.getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -2012,7 +2174,7 @@ module PathGraph {
  * An intermediate flow graph node. This is a triple consisting of a `Node`,
  * a `CallContext`, and a `Configuration`.
  */
-private class PathNodeMid extends PathNode, TPathNodeMid {
+private class PathNodeMid extends PathNodeImpl, TPathNodeMid {
   Node node;
   CallContext cc;
   SummaryCtx sc;
@@ -2036,7 +2198,7 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
     result.getConfiguration() = unbind(this.getConfiguration())
   }
 
-  override PathNode getASuccessor() {
+  override PathNodeImpl getASuccessor() {
     // an intermediate step to another intermediate node
     result = getSuccMid()
     or
@@ -2063,7 +2225,7 @@ private class PathNodeMid extends PathNode, TPathNodeMid {
  * intermediate nodes in order to uniquely correspond to a given sink by
  * excluding the `CallContext`.
  */
-private class PathNodeSink extends PathNode, TPathNodeSink {
+private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
   Node node;
   Configuration config;
 
@@ -2096,7 +2258,7 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
     or
     localFlowBigStep(midnode, node, false, conf, localCC) and
     ap0 instanceof AccessPathNil and
-    ap = node.(AccessPathNilNode).getAp()
+    ap = any(AccessPathNilNode nil | nil.getNode() = node).getAp()
   )
   or
   jumpStep(mid.getNode(), node, mid.getConfiguration()) and
@@ -2108,11 +2270,12 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   cc instanceof CallContextAny and
   sc instanceof SummaryCtxNone and
   mid.getAp() instanceof AccessPathNil and
-  ap = node.(AccessPathNilNode).getAp()
+  ap = any(AccessPathNilNode nil | nil.getNode() = node).getAp()
   or
-  contentReadStep(mid, node, ap) and cc = mid.getCallContext() and sc = mid.getSummaryCtx()
+  exists(Content f, AccessPath ap0 | pathReadStep(mid, node, ap0, f, cc) and ap = pop(f, ap0)) and
+  sc = mid.getSummaryCtx()
   or
-  exists(Content f, AccessPath ap0 | contentStoreStep(mid, node, ap0, f, cc) and push(ap0, f, ap)) and
+  exists(Content f, AccessPath ap0 | pathStoreStep(mid, node, ap0, f, cc) and ap = push(f, ap0)) and
   sc = mid.getSummaryCtx()
   or
   pathIntoCallable(mid, node, _, cc, sc, _) and ap = mid.getAp()
@@ -2120,25 +2283,33 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-  or
-  valuePathThroughCallable(mid, node, cc) and ap = mid.getAp() and sc = mid.getSummaryCtx()
 }
 
-pragma[noinline]
-private predicate contentReadStep(PathNodeMid mid, Node node, AccessPath ap) {
-  exists(Content f, AccessPath ap0 |
-    ap0 = mid.getAp() and
-    read(mid.getNode(), f, node) and
-    pop(ap0, f, ap)
-  )
+pragma[nomagic]
+private predicate readCand(Node node1, Content f, Node node2, Configuration config) {
+  readDirect(node1, f, node2) and
+  flow(node2, config)
 }
 
-pragma[noinline]
-private predicate contentStoreStep(
+pragma[nomagic]
+private predicate pathReadStep(PathNodeMid mid, Node node, AccessPath ap0, Content f, CallContext cc) {
+  ap0 = mid.getAp() and
+  readCand(mid.getNode(), f, node, mid.getConfiguration()) and
+  cc = mid.getCallContext()
+}
+
+pragma[nomagic]
+private predicate storeCand(Node node1, Content f, Node node2, Configuration config) {
+  storeDirect(node1, f, node2) and
+  flow(node2, config)
+}
+
+pragma[nomagic]
+private predicate pathStoreStep(
   PathNodeMid mid, Node node, AccessPath ap0, Content f, CallContext cc
 ) {
   ap0 = mid.getAp() and
-  store(mid.getNode(), f, node) and
+  storeCand(mid.getNode(), f, node, mid.getConfiguration()) and
   cc = mid.getCallContext()
 }
 
@@ -2150,16 +2321,27 @@ private predicate pathOutOfCallable0(PathNodeMid mid, ReturnPosition pos, CallCo
 
 pragma[nomagic]
 private predicate pathOutOfCallable1(
-  PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc
+  PathNodeMid mid, DataFlowCall call, ReturnKindExt kind, CallContext cc, AccessPath ap,
+  Configuration config
 ) {
   exists(ReturnPosition pos, DataFlowCallable c, CallContext innercc |
     pathOutOfCallable0(mid, pos, innercc) and
     c = pos.getCallable() and
     kind = pos.getKind() and
-    resolveReturn(innercc, c, call)
+    resolveReturn(innercc, c, call) and
+    ap = mid.getAp() and
+    config = mid.getConfiguration()
   |
     if reducedViableImplInReturn(c, call) then cc = TReturn(c, call) else cc = TAnyCallContext()
   )
+}
+
+pragma[noinline]
+private Node getAnOutNodeCand(
+  ReturnKindExt kind, DataFlowCall call, AccessPath ap, Configuration config
+) {
+  result = kind.getAnOutNode(call) and
+  flow(TNormalNode(result), _, ap, config)
 }
 
 /**
@@ -2168,8 +2350,10 @@ private predicate pathOutOfCallable1(
  */
 pragma[noinline]
 private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
-  exists(ReturnKindExt kind, DataFlowCall call | pathOutOfCallable1(mid, call, kind, cc) |
-    out = kind.getAnOutNode(call)
+  exists(ReturnKindExt kind, DataFlowCall call, AccessPath ap, Configuration config |
+    pathOutOfCallable1(mid, call, kind, cc, ap, config)
+  |
+    out = getAnOutNodeCand(kind, call, ap, config)
   )
 }
 
@@ -2189,9 +2373,11 @@ private predicate pathIntoArg(
 }
 
 pragma[noinline]
-private predicate parameterCand(DataFlowCallable callable, int i, Configuration config) {
+private predicate parameterCand(
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
+) {
   exists(ParameterNode p |
-    flow(p, config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2203,7 +2389,7 @@ private predicate pathIntoCallable0(
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
-  parameterCand(callable, any(int j | j <= i and j >= i), mid.getConfiguration())
+  parameterCand(callable, any(int j | j <= i and j >= i), ap, mid.getConfiguration())
 }
 
 /**
@@ -2219,9 +2405,10 @@ private predicate pathIntoCallable(
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
-      sc = getSummaryCtx(p, ap)
+      sc = TSummaryCtxSome(p, ap)
       or
-      sc instanceof SummaryCtxNone and not exists(getSummaryCtx(p, ap))
+      not exists(TSummaryCtxSome(p, ap)) and
+      sc = TSummaryCtxNone()
     )
   |
     if recordDataFlowCallSite(call, callable)
@@ -2230,29 +2417,32 @@ private predicate pathIntoCallable(
   )
 }
 
-/** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
+/**
+ * Holds if data may flow from a parameter `p` with access path `apIn`, to a
+ * return of kind `kind` with access path `apOut`.
+ */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, SummaryCtx sc, AccessPath ap, Configuration config
+  ParameterNode p, ReturnKindExt kind, CallContextCall cc, AccessPath apIn, AccessPath apOut,
+  Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
-    sc = mid.getSummaryCtx() and
+    TSummaryCtxSome(p, apIn) = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp() and
-    summaryCompatible(sc, ret, ap, config)
+    apOut = mid.getAp()
   )
 }
 
 pragma[nomagic]
 private predicate pathThroughCallable0(
-  DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPath ap
+  DataFlowCall call, PathNodeMid mid, ReturnKindExt kind, CallContext cc, AccessPath apOut
 ) {
-  exists(ParameterNode p, CallContext innercc, SummaryCtx sc |
-    pathIntoCallable(mid, p, cc, innercc, sc, call) and
-    paramFlowsThrough(kind, innercc, sc, ap, unbind(mid.getConfiguration()))
+  exists(ParameterNode p, CallContext innercc, AccessPath apIn |
+    pathIntoCallable(mid, p, cc, innercc, TSummaryCtxSome(p, apIn), call) and
+    paramFlowsThrough(p, kind, innercc, apIn, apOut, unbind(mid.getConfiguration()))
   )
 }
 
@@ -2264,24 +2454,7 @@ pragma[noinline]
 private predicate pathThroughCallable(PathNodeMid mid, Node out, CallContext cc, AccessPath ap) {
   exists(DataFlowCall call, ReturnKindExt kind |
     pathThroughCallable0(call, mid, kind, cc, ap) and
-    out = kind.getAnOutNode(call)
-  )
-}
-
-pragma[noinline]
-private predicate valuePathThroughCallable0(
-  DataFlowCall call, PathNodeMid mid, ReturnKind kind, CallContext cc
-) {
-  exists(ParameterNode p, CallContext innercc |
-    pathIntoCallable(mid, p, cc, innercc, _, call) and
-    parameterValueFlowsThrough(p, kind, innercc)
-  )
-}
-
-private predicate valuePathThroughCallable(PathNodeMid mid, OutNode out, CallContext cc) {
-  exists(DataFlowCall call, ReturnKind kind |
-    valuePathThroughCallable0(call, mid, kind, cc) and
-    out = getAnOutNode(call, kind)
+    out = getAnOutNodeCand(kind, call, ap, mid.getConfiguration())
   )
 }
 
@@ -2447,7 +2620,7 @@ private module FlowExploration {
       cc instanceof CallContextAny and
       sc1 = TSummaryCtx1None() and
       sc2 = TSummaryCtx2None() and
-      ap = TPartialNil(getErasedNodeType(node)) and
+      ap = TPartialNil(getErasedNodeTypeBound(node)) and
       not fullBarrier(node, config) and
       exists(config.explorationLimit())
       or
@@ -2464,7 +2637,7 @@ private module FlowExploration {
       partialPathStep(mid, node, cc, sc1, sc2, ap, config) and
       not fullBarrier(node, config) and
       if node instanceof CastingNode
-      then compatibleTypes(getErasedNodeType(node), ap.getType())
+      then compatibleTypes(getErasedNodeTypeBound(node), ap.getType())
       else any()
     )
   }
@@ -2474,13 +2647,13 @@ private module FlowExploration {
    */
   class PartialPathNode extends TPartialPathNode {
     /** Gets a textual representation of this element. */
-    string toString() { result = getNode().toString() + ppAp() }
+    string toString() { result = this.getNode().toString() + this.ppAp() }
 
     /**
      * Gets a textual representation of this element, including a textual
      * representation of the call context.
      */
-    string toStringWithContext() { result = getNode().toString() + ppAp() + ppCtx() }
+    string toStringWithContext() { result = this.getNode().toString() + this.ppAp() + this.ppCtx() }
 
     /**
      * Holds if this element is at the specified location.
@@ -2492,17 +2665,17 @@ private module FlowExploration {
     predicate hasLocationInfo(
       string filepath, int startline, int startcolumn, int endline, int endcolumn
     ) {
-      getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+      this.getNode().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
     }
 
     /** Gets the underlying `Node`. */
-    abstract Node getNode();
+    Node getNode() { none() }
 
     /** Gets the associated configuration. */
-    abstract Configuration getConfiguration();
+    Configuration getConfiguration() { none() }
 
     /** Gets a successor of this node, if any. */
-    abstract PartialPathNode getASuccessor();
+    PartialPathNode getASuccessor() { none() }
 
     /**
      * Gets the approximate distance to the nearest source measured in number
@@ -2553,12 +2726,10 @@ private module FlowExploration {
 
     override Configuration getConfiguration() { result = config }
 
-    private PartialPathNodePriv getSuccMid() {
+    override PartialPathNodePriv getASuccessor() {
       partialPathStep(this, result.getNode(), result.getCallContext(), result.getSummaryCtx1(),
         result.getSummaryCtx2(), result.getAp(), result.getConfiguration())
     }
-
-    override PartialPathNode getASuccessor() { result = getSuccMid() }
   }
 
   private predicate partialPathStep(
@@ -2579,7 +2750,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       mid.getAp() instanceof PartialAccessPathNil and
-      ap = TPartialNil(getErasedNodeType(node)) and
+      ap = TPartialNil(getErasedNodeTypeBound(node)) and
       config = mid.getConfiguration()
     )
     or
@@ -2595,7 +2766,7 @@ private module FlowExploration {
     sc1 = TSummaryCtx1None() and
     sc2 = TSummaryCtx2None() and
     mid.getAp() instanceof PartialAccessPathNil and
-    ap = TPartialNil(getErasedNodeType(node)) and
+    ap = TPartialNil(getErasedNodeTypeBound(node)) and
     config = mid.getConfiguration()
     or
     partialPathStoreStep(mid, _, _, node, ap) and
@@ -2620,10 +2791,6 @@ private module FlowExploration {
     partialPathThroughCallable(mid, node, cc, ap, config) and
     sc1 = mid.getSummaryCtx1() and
     sc2 = mid.getSummaryCtx2()
-    or
-    valuePartialPathThroughCallable(mid, node, cc, ap, config) and
-    sc1 = mid.getSummaryCtx1() and
-    sc2 = mid.getSummaryCtx2()
   }
 
   bindingset[result, i]
@@ -2634,7 +2801,7 @@ private module FlowExploration {
     PartialPathNodePriv mid, PartialAccessPath ap1, Content f, Node node, PartialAccessPath ap2
   ) {
     ap1 = mid.getAp() and
-    store(mid.getNode(), f, node) and
+    storeDirect(mid.getNode(), f, node) and
     ap2.getHead() = f and
     ap2.len() = unbindInt(ap1.len() + 1) and
     compatibleTypes(ap1.getType(), f.getType())
@@ -2656,7 +2823,7 @@ private module FlowExploration {
     Configuration config
   ) {
     ap = mid.getAp() and
-    read(mid.getNode(), f, node) and
+    readStep(mid.getNode(), f, node) and
     ap.getHead() = f and
     config = mid.getConfiguration() and
     cc = mid.getCallContext()
@@ -2775,26 +2942,6 @@ private module FlowExploration {
     exists(DataFlowCall call, ReturnKindExt kind |
       partialPathThroughCallable0(call, mid, kind, cc, ap, config) and
       out = kind.getAnOutNode(call)
-    )
-  }
-
-  pragma[noinline]
-  private predicate valuePartialPathThroughCallable0(
-    DataFlowCall call, PartialPathNodePriv mid, ReturnKind kind, CallContext cc,
-    PartialAccessPath ap, Configuration config
-  ) {
-    exists(ParameterNode p, CallContext innercc |
-      partialPathIntoCallable(mid, p, cc, innercc, _, _, call, ap, config) and
-      parameterValueFlowsThrough(p, kind, innercc)
-    )
-  }
-
-  private predicate valuePartialPathThroughCallable(
-    PartialPathNodePriv mid, OutNode out, CallContext cc, PartialAccessPath ap, Configuration config
-  ) {
-    exists(DataFlowCall call, ReturnKind kind |
-      valuePartialPathThroughCallable0(call, mid, kind, cc, ap, config) and
-      out = getAnOutNode(call, kind)
     )
   }
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -1,14 +1,7 @@
 private import DataFlowImplSpecific::Private
-import DataFlowImplSpecific::Public
-
-private ReturnNode getAReturnNodeOfKind(ReturnKind kind) { result.getKind() = kind }
+private import DataFlowImplSpecific::Public
 
 module Public {
-  import ImplCommon
-  import FlowThrough_v2
-}
-
-private module ImplCommon {
   import Cached
 
   cached
@@ -34,543 +27,476 @@ private module ImplCommon {
       )
     }
 
-    /*
-     * The `FlowThrough_*` modules take a `step` relation as input and provide
-     * an `argumentValueFlowsThrough` relation as output.
-     *
-     * `FlowThrough_v1` includes just `simpleLocalFlowStep`, which is then used
-     * to detect getters and setters.
-     * `FlowThrough_v2` then includes a little bit of local field flow on top
-     * of `simpleLocalFlowStep`.
-     */
-
-    private module FlowThrough_v1 {
-      private predicate step = simpleLocalFlowStep/2;
-
+    /** Provides predicates for calculating flow-through summaries. */
+    private module FlowThrough {
       /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, not taking call contexts into account.
+       * The first flow-through approximation:
+       *
+       * - Input/output access paths are abstracted with a Boolean parameter
+       *   that indicates (non-)emptiness.
        */
-      private predicate parameterValueFlowCand(ParameterNode p, Node node) {
-        p = node
-        or
-        exists(Node mid |
-          parameterValueFlowCand(p, mid) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlowCand(p, arg) and
-          argumentValueFlowsThroughCand(arg, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-      }
+      private module Cand {
+        /**
+         * Holds if `p` can flow to `node` in the same callable using only
+         * value-preserving steps.
+         *
+         * `read` indicates whether it is contents of `p` that can flow to `node`,
+         * and `stored` indicates whether it flows to contents of `node`.
+         */
+        pragma[nomagic]
+        private predicate parameterValueFlowCand(
+          ParameterNode p, Node node, boolean read, boolean stored
+        ) {
+          p = node and
+          read = false and
+          stored = false
+          or
+          // local flow
+          exists(Node mid |
+            parameterValueFlowCand(p, mid, read, stored) and
+            simpleLocalFlowStep(mid, node)
+          )
+          or
+          // read
+          exists(Node mid, boolean readMid, boolean storedMid |
+            parameterValueFlowCand(p, mid, readMid, storedMid) and
+            readStep(mid, _, node) and
+            stored = false
+          |
+            // value neither read nor stored prior to read
+            readMid = false and
+            storedMid = false and
+            read = true
+            or
+            // value (possibly read and then) stored prior to read (same content)
+            read = readMid and
+            storedMid = true
+          )
+          or
+          // store
+          exists(Node mid |
+            parameterValueFlowCand(p, mid, read, false) and
+            storeStep(mid, _, node) and
+            stored = true
+          )
+          or
+          // flow through: no prior read or store
+          exists(ArgumentNode arg |
+            parameterValueFlowArgCand(p, arg, false, false) and
+            argumentValueFlowsThroughCand(arg, node, read, stored)
+          )
+          or
+          // flow through: no read or store inside method
+          exists(ArgumentNode arg |
+            parameterValueFlowArgCand(p, arg, read, stored) and
+            argumentValueFlowsThroughCand(arg, node, false, false)
+          )
+          or
+          // flow through: possible prior read and prior store with compatible
+          // flow-through method
+          exists(ArgumentNode arg, boolean mid |
+            parameterValueFlowArgCand(p, arg, read, mid) and
+            argumentValueFlowsThroughCand(arg, node, mid, stored)
+          )
+        }
 
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, not taking call contexts
-       * into account.
-       */
-      private predicate parameterValueFlowsThroughCand(ParameterNode p, ReturnKind kind) {
-        parameterValueFlowCand(p, getAReturnNodeOfKind(kind))
-      }
+        pragma[nomagic]
+        private predicate parameterValueFlowArgCand(
+          ParameterNode p, ArgumentNode arg, boolean read, boolean stored
+        ) {
+          parameterValueFlowCand(p, arg, read, stored)
+        }
 
-      pragma[nomagic]
-      private predicate argumentValueFlowsThroughCand0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind
-      ) {
-        exists(ParameterNode param | viableParamArg(call, param, arg) |
-          parameterValueFlowsThroughCand(param, kind)
-        )
-      }
+        pragma[nomagic]
+        predicate parameterValueFlowsToPreUpdateCand(ParameterNode p, PostUpdateNode n) {
+          parameterValueFlowCand(p, n.getPreUpdateNode(), false, false)
+        }
 
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * not taking call contexts into account.
-       */
-      private predicate argumentValueFlowsThroughCand(ArgumentNode arg, OutNode out) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThroughCand0(call, arg, kind)
-        |
-          out = getAnOutNode(call, kind) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
+        pragma[nomagic]
+        private predicate parameterValueFlowsToPostUpdateCand(
+          ParameterNode p, PostUpdateNode n, boolean read
+        ) {
+          parameterValueFlowCand(p, n, read, true)
+        }
 
-      /**
-       * Holds if `arg` is the `i`th argument of `call` inside the callable
-       * `enclosing`, and `arg` may flow through `call`.
-       */
-      pragma[noinline]
-      private predicate argumentOf(
-        DataFlowCall call, int i, ArgumentNode arg, DataFlowCallable enclosing
-      ) {
-        arg.argumentOf(call, i) and
-        argumentValueFlowsThroughCand(arg, _) and
-        enclosing = arg.getEnclosingCallable()
-      }
+        /**
+         * Holds if `p` can flow to a return node of kind `kind` in the same
+         * callable using only value-preserving steps, not taking call contexts
+         * into account.
+         *
+         * `read` indicates whether it is contents of `p` that can flow to the return
+         * node, and `stored` indicates whether it flows to contents of the return
+         * node.
+         */
+        predicate parameterValueFlowReturnCand(
+          ParameterNode p, ReturnKindExt kind, boolean read, boolean stored
+        ) {
+          exists(ReturnNode ret |
+            parameterValueFlowCand(p, ret, read, stored) and
+            kind = TValueReturn(ret.getKind())
+          )
+          or
+          exists(ParameterNode p2, int pos2, PostUpdateNode n |
+            parameterValueFlowsToPostUpdateCand(p, n, read) and
+            parameterValueFlowsToPreUpdateCand(p2, n) and
+            p2.isParameterOf(_, pos2) and
+            kind = TParamUpdate(pos2) and
+            p != p2 and
+            stored = true
+          )
+        }
 
-      pragma[noinline]
-      private predicate viableParamArg0(
-        int i, ArgumentNode arg, CallContext outercc, DataFlowCall call
-      ) {
-        exists(DataFlowCallable c | argumentOf(call, i, arg, c) |
+        pragma[nomagic]
+        private predicate argumentValueFlowsThroughCand0(
+          DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, boolean read, boolean stored
+        ) {
+          exists(ParameterNode param | viableParamArg(call, param, arg) |
+            parameterValueFlowReturnCand(param, kind, read, stored)
+          )
+        }
+
+        /**
+         * Holds if `arg` flows to `out` through a call using only value-preserving steps,
+         * not taking call contexts into account.
+         *
+         * `read` indicates whether it is contents of `arg` that can flow to `out`, and
+         * `stored` indicates whether it flows to contents of `out`.
+         */
+        predicate argumentValueFlowsThroughCand(
+          ArgumentNode arg, Node out, boolean read, boolean stored
+        ) {
+          exists(DataFlowCall call, ReturnKindExt kind |
+            argumentValueFlowsThroughCand0(call, arg, kind, read, stored) and
+            out = kind.getAnOutNode(call)
+          )
+        }
+
+        predicate cand(ParameterNode p, Node n) {
+          parameterValueFlowCand(p, n, _, _) and
           (
-            outercc = TAnyCallContext()
+            parameterValueFlowReturnCand(p, _, _, _)
             or
-            outercc = TSomeCall()
+            parameterValueFlowsToPreUpdateCand(p, _)
+          )
+        }
+      }
+
+      private module LocalFlowBigStep {
+        private predicate localFlowEntry(Node n) {
+          Cand::cand(_, n) and
+          (
+            n instanceof ParameterNode or
+            n instanceof OutNode or
+            n instanceof PostUpdateNode or
+            readStep(_, _, n) or
+            n instanceof CastNode
+          )
+        }
+
+        private predicate localFlowExit(Node n) {
+          Cand::cand(_, n) and
+          (
+            n instanceof ArgumentNode
             or
-            exists(DataFlowCall other | outercc = TSpecificCall(other) |
-              recordDataFlowCallSite(other, c)
+            n instanceof ReturnNode
+            or
+            Cand::parameterValueFlowsToPreUpdateCand(_, n)
+            or
+            storeStep(n, _, _)
+            or
+            readStep(n, _, _)
+            or
+            n instanceof CastNode
+            or
+            n =
+              any(PostUpdateNode pun | Cand::parameterValueFlowsToPreUpdateCand(_, pun))
+                  .getPreUpdateNode()
+          )
+        }
+
+        pragma[nomagic]
+        private predicate localFlowStepPlus(Node node1, Node node2) {
+          localFlowEntry(node1) and
+          simpleLocalFlowStep(node1, node2) and
+          node1 != node2 and
+          Cand::cand(_, node2)
+          or
+          exists(Node mid |
+            localFlowStepPlus(node1, mid) and
+            simpleLocalFlowStep(mid, node2) and
+            not mid instanceof CastNode and
+            Cand::cand(_, node2)
+          )
+        }
+
+        pragma[nomagic]
+        predicate localFlowBigStep(Node node1, Node node2) {
+          localFlowStepPlus(node1, node2) and
+          localFlowExit(node2)
+        }
+      }
+
+      /**
+       * The final flow-through calculation:
+       *
+       * - Input/output access paths are abstracted with a `ContentOption` parameter
+       *   that represents the head of the access path.
+       * - Types are checked using the `compatibleTypes()` relation.
+       */
+      module Final {
+        /**
+         * Holds if `p` can flow to `node` in the same callable using only
+         * value-preserving steps, not taking call contexts into account.
+         *
+         * `contentIn` describes the content of `p` that can flow to `node`
+         * (if any), and `contentOut` describes the content of `node` that
+         * it flows to (if any).
+         */
+        predicate parameterValueFlow(
+          ParameterNode p, Node node, ContentOption contentIn, ContentOption contentOut
+        ) {
+          parameterValueFlow0(p, node, contentIn, contentOut) and
+          Cand::cand(p, node) and
+          if node instanceof CastingNode
+          then
+            // normal flow through
+            contentIn = TContentNone() and
+            contentOut = TContentNone() and
+            compatibleTypes(getErasedNodeTypeBound(p), getErasedNodeTypeBound(node))
+            or
+            // getter
+            exists(Content fIn |
+              contentIn.getContent() = fIn and
+              contentOut = TContentNone() and
+              compatibleTypes(fIn.getType(), getErasedNodeTypeBound(node))
             )
-          ) and
-          not isUnreachableInCall(arg, outercc.(CallContextSpecificCall).getCall())
-        )
+            or
+            // setter
+            exists(Content fOut |
+              contentIn = TContentNone() and
+              contentOut.getContent() = fOut and
+              compatibleTypes(getErasedNodeTypeBound(p), fOut.getType()) and
+              compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(node))
+            )
+            or
+            // getter+setter
+            exists(Content fIn, Content fOut |
+              contentIn.getContent() = fIn and
+              contentOut.getContent() = fOut and
+              compatibleTypes(fIn.getType(), fOut.getType()) and
+              compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(node))
+            )
+          else any()
+        }
+
+        pragma[nomagic]
+        private predicate parameterValueFlow0(
+          ParameterNode p, Node node, ContentOption contentIn, ContentOption contentOut
+        ) {
+          p = node and
+          Cand::cand(p, _) and
+          contentIn = TContentNone() and
+          contentOut = TContentNone()
+          or
+          // local flow
+          exists(Node mid |
+            parameterValueFlow(p, mid, contentIn, contentOut) and
+            LocalFlowBigStep::localFlowBigStep(mid, node)
+          )
+          or
+          // read
+          exists(Node mid, Content f, ContentOption contentInMid, ContentOption contentOutMid |
+            parameterValueFlow(p, mid, contentInMid, contentOutMid) and
+            readStep(mid, f, node)
+          |
+            // value neither read nor stored prior to read
+            contentInMid = TContentNone() and
+            contentOutMid = TContentNone() and
+            contentIn.getContent() = f and
+            contentOut = TContentNone() and
+            Cand::parameterValueFlowReturnCand(p, _, true, _)
+            or
+            // value (possibly read and then) stored prior to read (same content)
+            contentIn = contentInMid and
+            contentOutMid.getContent() = f and
+            contentOut = TContentNone()
+          )
+          or
+          // store
+          exists(Node mid, Content f |
+            parameterValueFlow(p, mid, contentIn, TContentNone()) and
+            storeStep(mid, f, node) and
+            contentOut.getContent() = f
+          )
+          or
+          // flow through: no prior read or store
+          exists(ArgumentNode arg |
+            parameterValueFlowArg(p, arg, TContentNone(), TContentNone()) and
+            argumentValueFlowsThrough(arg, node, contentIn, contentOut)
+          )
+          or
+          // flow through: no read or store inside method
+          exists(ArgumentNode arg |
+            parameterValueFlowArg(p, arg, contentIn, contentOut) and
+            argumentValueFlowsThrough(arg, node, TContentNone(), TContentNone())
+          )
+          or
+          // flow through: possible prior read and prior store with compatible
+          // flow-through method
+          exists(ArgumentNode arg, ContentOption contentMid |
+            parameterValueFlowArg(p, arg, contentIn, contentMid) and
+            argumentValueFlowsThrough(arg, node, contentMid, contentOut)
+          )
+        }
+
+        pragma[nomagic]
+        private predicate parameterValueFlowArg(
+          ParameterNode p, ArgumentNode arg, ContentOption contentIn, ContentOption contentOut
+        ) {
+          parameterValueFlow(p, arg, contentIn, contentOut) and
+          Cand::argumentValueFlowsThroughCand(arg, _, _, _)
+        }
+
+        pragma[nomagic]
+        predicate parameterValueFlowsToPostUpdate(
+          ParameterNode p, PostUpdateNode n, ContentOption contentIn, ContentOption contentOut
+        ) {
+          parameterValueFlow(p, n, contentIn, contentOut) and
+          contentOut.hasContent()
+        }
+
+        pragma[nomagic]
+        predicate argumentValueFlowsThrough0(
+          DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, ContentOption contentIn,
+          ContentOption contentOut
+        ) {
+          exists(ParameterNode param | viableParamArg(call, param, arg) |
+            parameterValueFlowReturn(param, _, kind, contentIn, contentOut)
+          )
+        }
+
+        /**
+         * Holds if `arg` flows to `out` through a call using only value-preserving steps,
+         * not taking call contexts into account.
+         *
+         * `contentIn` describes the content of `arg` that can flow to `out` (if any), and
+         * `contentOut` describes the content of `out` that it flows to (if any).
+         */
+        private predicate argumentValueFlowsThrough(
+          ArgumentNode arg, Node out, ContentOption contentIn, ContentOption contentOut
+        ) {
+          exists(DataFlowCall call, ReturnKindExt kind |
+            argumentValueFlowsThrough0(call, arg, kind, contentIn, contentOut) and
+            out = kind.getAnOutNode(call)
+          )
+        }
       }
 
-      pragma[noinline]
-      private predicate viableParamArg1(
-        ParameterNode p, DataFlowCallable callable, int i, ArgumentNode arg, CallContext outercc,
-        DataFlowCall call
-      ) {
-        viableParamArg0(i, arg, outercc, call) and
-        callable = resolveCall(call, outercc) and
-        p.isParameterOf(callable, any(int j | j <= i and j >= i))
-      }
-
-      /**
-       * Holds if `arg` is a possible argument to `p`, in the call `call`, and
-       * `arg` may flow through `call`. The possible contexts before and after
-       * entering the callable are `outercc` and `innercc`, respectively.
-       */
-      private predicate viableParamArg(
-        DataFlowCall call, ParameterNode p, ArgumentNode arg, CallContext outercc,
-        CallContextCall innercc
-      ) {
-        exists(int i, DataFlowCallable callable |
-          viableParamArg1(p, callable, i, arg, outercc, call)
-        |
-          if recordDataFlowCallSite(call, callable)
-          then innercc = TSpecificCall(call)
-          else innercc = TSomeCall()
-        )
-      }
-
-      private CallContextCall getAValidCallContextForParameter(ParameterNode p) {
-        result = TSomeCall()
-        or
-        exists(DataFlowCall call, DataFlowCallable callable |
-          result = TSpecificCall(call) and
-          p.isParameterOf(callable, _) and
-          recordDataFlowCallSite(call, callable)
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlow(ParameterNode p, Node node, CallContextCall cc) {
-        p = node and
-        parameterValueFlowsThroughCand(p, _) and
-        cc = getAValidCallContextForParameter(p)
-        or
-        exists(Node mid |
-          parameterValueFlow(p, mid, cc) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlow(p, arg, cc) and
-          argumentValueFlowsThrough(arg, node, cc) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlowsThrough(
-        ParameterNode p, ReturnKind kind, CallContextCall cc
-      ) {
-        parameterValueFlow(p, getAReturnNodeOfKind(kind), cc)
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThrough0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind, CallContext cc
-      ) {
-        exists(ParameterNode param, CallContext innercc |
-          viableParamArg(call, param, arg, cc, innercc) and
-          parameterValueFlowsThrough(param, kind, innercc)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * in call context cc.
-       */
-      predicate argumentValueFlowsThrough(ArgumentNode arg, OutNode out, CallContext cc) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThrough0(call, arg, kind, cc)
-        |
-          out = getAnOutNode(call, kind) and
-          not isUnreachableInCall(out, cc.(CallContextSpecificCall).getCall()) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
+      import Final
     }
 
     /**
-     * Holds if `p` can flow to the pre-update node of `n` in the same callable
-     * using only value-preserving steps.
+     * Holds if `p` can flow to the pre-update node associated with post-update
+     * node `n`, in the same callable, using only value-preserving steps.
      */
     cached
-    predicate parameterValueFlowsToUpdate(ParameterNode p, PostUpdateNode n) {
-      parameterValueFlowNoCtx(p, n.getPreUpdateNode())
+    predicate parameterValueFlowsToPreUpdate(ParameterNode p, PostUpdateNode n) {
+      FlowThrough::parameterValueFlow(p, n.getPreUpdateNode(), TContentNone(), TContentNone())
     }
 
     /**
-     * Holds if data can flow from `node1` to `node2` in one local step or a step
-     * through a value-preserving method.
+     * Holds if `p` can flow to a return node of kind `kind` in the same
+     * callable using only value-preserving steps.
+     *
+     * `contentIn` describes the content of `p` that can flow to the return
+     * node (if any), and `contentOut` describes the content of the return
+     * node that it flows to (if any).
      */
-    private predicate localValueStep(Node node1, Node node2) {
-      simpleLocalFlowStep(node1, node2) or
-      FlowThrough_v1::argumentValueFlowsThrough(node1, node2, _)
-    }
-
-    /**
-     * Holds if `p` can flow to `node` in the same callable allowing local flow
-     * steps and value flow through methods. Call contexts are only accounted
-     * for in the nested calls.
-     */
-    private predicate parameterValueFlowNoCtx(ParameterNode p, Node node) {
-      p = node
+    cached
+    predicate parameterValueFlowReturn(
+      ParameterNode p, Node ret, ReturnKindExt kind, ContentOption contentIn,
+      ContentOption contentOut
+    ) {
+      ret =
+        any(ReturnNode n |
+          FlowThrough::parameterValueFlow(p, n, contentIn, contentOut) and
+          kind = TValueReturn(n.getKind())
+        )
       or
-      exists(Node mid |
-        parameterValueFlowNoCtx(p, mid) and
-        localValueStep(mid, node) and
-        compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
+      ret =
+        any(PostUpdateNode n |
+          exists(ParameterNode p2, int pos2 |
+            FlowThrough::parameterValueFlowsToPostUpdate(p, n, contentIn, contentOut) and
+            parameterValueFlowsToPreUpdate(p2, n) and
+            p2.isParameterOf(_, pos2) and
+            kind = TParamUpdate(pos2) and
+            p != p2
+          )
+        )
+    }
+
+    /**
+     * Holds if `arg` flows to `out` through `call` using only value-preserving steps.
+     *
+     * `contentIn` describes the content of `arg` that can flow to `out` (if any), and
+     * `contentOut` describes the content of `out` that it flows to (if any).
+     */
+    cached
+    predicate argumentValueFlowsThrough(
+      DataFlowCall call, ArgumentNode arg, ContentOption contentIn, ContentOption contentOut,
+      Node out
+    ) {
+      exists(ReturnKindExt kind |
+        FlowThrough::argumentValueFlowsThrough0(call, arg, kind, contentIn, contentOut) and
+        out = kind.getAnOutNode(call)
+      |
+        // normal flow through
+        contentIn = TContentNone() and
+        contentOut = TContentNone() and
+        compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
+        or
+        // getter
+        exists(Content fIn |
+          contentIn.getContent() = fIn and
+          contentOut = TContentNone() and
+          compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
+        )
+        or
+        // setter
+        exists(Content fOut |
+          contentIn = TContentNone() and
+          contentOut.getContent() = fOut and
+          compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType())
+        )
+        or
+        // getter+setter
+        exists(Content fIn, Content fOut |
+          contentIn.getContent() = fIn and
+          contentOut.getContent() = fOut and
+          compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
+        )
       )
     }
-
-    /*
-     * Calculation of `predicate store(Node node1, Content f, Node node2)`:
-     * There are four cases:
-     * - The base case: A direct local assignment given by `storeStep`.
-     * - A call to a method or constructor with two arguments, `arg1` and `arg2`,
-     *   such that the call has the side-effect `arg2.f = arg1`.
-     * - A call to a method that returns an object in which an argument has been
-     *   stored.
-     * - A reverse step through a read when the result of the read has been
-     *   stored into. This handles cases like `x.f1.f2 = y`.
-     * `storeViaSideEffect` covers the first two cases, and `storeReturn` covers
-     * the third case.
-     */
 
     /**
      * Holds if data can flow from `node1` to `node2` via a direct assignment to
-     * `f` or via a call that acts as a setter.
+     * `f`.
+     *
+     * This includes reverse steps through reads when the result of the read has
+     * been stored into, in order to handle cases like `x.f1.f2 = y`.
      */
     cached
-    predicate store(Node node1, Content f, Node node2) {
-      storeViaSideEffect(node1, f, node2) or
-      storeReturn(node1, f, node2) or
-      read(node2.(PostUpdateNode).getPreUpdateNode(), f, node1.(PostUpdateNode).getPreUpdateNode())
-    }
-
-    private predicate storeViaSideEffect(Node node1, Content f, PostUpdateNode node2) {
+    predicate storeDirect(Node node1, Content f, Node node2) {
       storeStep(node1, f, node2) and readStep(_, f, _)
       or
-      exists(DataFlowCall call, int i1, int i2 |
-        setterCall(call, i1, i2, f) and
-        node1.(ArgumentNode).argumentOf(call, i1) and
-        node2.getPreUpdateNode().(ArgumentNode).argumentOf(call, i2) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getContainerType())
-      )
-    }
-
-    pragma[nomagic]
-    private predicate setterInParam(ParameterNode p1, Content f, ParameterNode p2) {
-      exists(Node n1, PostUpdateNode n2 |
-        parameterValueFlowNoCtx(p1, n1) and
-        storeViaSideEffect(n1, f, n2) and
-        parameterValueFlowNoCtx(p2, n2.getPreUpdateNode()) and
-        p1 != p2
-      )
-    }
-
-    pragma[nomagic]
-    private predicate setterCall(DataFlowCall call, int i1, int i2, Content f) {
-      exists(DataFlowCallable callable, ParameterNode p1, ParameterNode p2 |
-        setterInParam(p1, f, p2) and
-        callable = viableCallable(call) and
-        p1.isParameterOf(callable, i1) and
-        p2.isParameterOf(callable, i2)
-      )
-    }
-
-    pragma[noinline]
-    private predicate storeReturn0(DataFlowCall call, ReturnKind kind, ArgumentNode arg, Content f) {
-      exists(ParameterNode p |
-        viableParamArg(call, p, arg) and
-        setterReturn(p, f, kind)
-      )
-    }
-
-    private predicate storeReturn(Node node1, Content f, Node node2) {
-      exists(DataFlowCall call, ReturnKind kind |
-        storeReturn0(call, kind, node1, f) and
-        node2 = getAnOutNode(call, kind) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getContainerType())
-      )
-    }
-
-    private predicate setterReturn(ParameterNode p, Content f, ReturnKind kind) {
       exists(Node n1, Node n2 |
-        parameterValueFlowNoCtx(p, n1) and
-        store(n1, f, n2) and
-        localValueStep*(n2, getAReturnNodeOfKind(kind))
-      )
-    }
-
-    pragma[noinline]
-    private predicate read0(DataFlowCall call, ReturnKind kind, ArgumentNode arg, Content f) {
-      exists(ParameterNode p |
-        viableParamArg(call, p, arg) and
-        getter(p, f, kind)
-      )
-    }
-
-    /**
-     * Holds if data can flow from `node1` to `node2` via a direct read of `f` or
-     * via a getter.
-     */
-    cached
-    predicate read(Node node1, Content f, Node node2) {
-      readStep(node1, f, node2)
-      or
-      exists(DataFlowCall call, ReturnKind kind |
-        read0(call, kind, node1, f) and
-        node2 = getAnOutNode(call, kind) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getContainerType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getType())
-      )
-    }
-
-    private predicate getter(ParameterNode p, Content f, ReturnKind kind) {
-      exists(Node n1, Node n2 |
-        parameterValueFlowNoCtx(p, n1) and
-        read(n1, f, n2) and
-        localValueStep*(n2, getAReturnNodeOfKind(kind))
-      )
-    }
-
-    cached
-    predicate localStoreReadStep(Node node1, Node node2) {
-      exists(Node mid1, Node mid2, Content f |
-        store(node1, f, mid1) and
-        localValueStep*(mid1, mid2) and
-        read(mid2, f, node2) and
-        compatibleTypes(getErasedNodeTypeBound(node1), getErasedNodeTypeBound(node2))
-      )
-    }
-
-    cached
-    module FlowThrough_v2 {
-      private predicate step(Node node1, Node node2) {
-        simpleLocalFlowStep(node1, node2) or
-        localStoreReadStep(node1, node2)
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, not taking call contexts into account.
-       */
-      private predicate parameterValueFlowCand(ParameterNode p, Node node) {
-        p = node
+        n1 = node1.(PostUpdateNode).getPreUpdateNode() and
+        n2 = node2.(PostUpdateNode).getPreUpdateNode()
+      |
+        argumentValueFlowsThrough(_, n2, TContentSome(f), TContentNone(), n1)
         or
-        exists(Node mid |
-          parameterValueFlowCand(p, mid) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlowCand(p, arg) and
-          argumentValueFlowsThroughCand(arg, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, not taking call contexts
-       * into account.
-       */
-      private predicate parameterValueFlowsThroughCand(ParameterNode p, ReturnKind kind) {
-        parameterValueFlowCand(p, getAReturnNodeOfKind(kind))
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThroughCand0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind
-      ) {
-        exists(ParameterNode param | viableParamArg(call, param, arg) |
-          parameterValueFlowsThroughCand(param, kind)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * not taking call contexts into account.
-       */
-      private predicate argumentValueFlowsThroughCand(ArgumentNode arg, OutNode out) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThroughCand0(call, arg, kind)
-        |
-          out = getAnOutNode(call, kind) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-
-      /**
-       * Holds if `arg` is the `i`th argument of `call` inside the callable
-       * `enclosing`, and `arg` may flow through `call`.
-       */
-      pragma[noinline]
-      private predicate argumentOf(
-        DataFlowCall call, int i, ArgumentNode arg, DataFlowCallable enclosing
-      ) {
-        arg.argumentOf(call, i) and
-        argumentValueFlowsThroughCand(arg, _) and
-        enclosing = arg.getEnclosingCallable()
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg0(
-        int i, ArgumentNode arg, CallContext outercc, DataFlowCall call
-      ) {
-        exists(DataFlowCallable c | argumentOf(call, i, arg, c) |
-          (
-            outercc = TAnyCallContext()
-            or
-            outercc = TSomeCall()
-            or
-            exists(DataFlowCall other | outercc = TSpecificCall(other) |
-              recordDataFlowCallSite(other, c)
-            )
-          ) and
-          not isUnreachableInCall(arg, outercc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg1(
-        ParameterNode p, DataFlowCallable callable, int i, ArgumentNode arg, CallContext outercc,
-        DataFlowCall call
-      ) {
-        viableParamArg0(i, arg, outercc, call) and
-        callable = resolveCall(call, outercc) and
-        p.isParameterOf(callable, any(int j | j <= i and j >= i))
-      }
-
-      /**
-       * Holds if `arg` is a possible argument to `p`, in the call `call`, and
-       * `arg` may flow through `call`. The possible contexts before and after
-       * entering the callable are `outercc` and `innercc`, respectively.
-       */
-      private predicate viableParamArg(
-        DataFlowCall call, ParameterNode p, ArgumentNode arg, CallContext outercc,
-        CallContextCall innercc
-      ) {
-        exists(int i, DataFlowCallable callable |
-          viableParamArg1(p, callable, i, arg, outercc, call)
-        |
-          if recordDataFlowCallSite(call, callable)
-          then innercc = TSpecificCall(call)
-          else innercc = TSomeCall()
-        )
-      }
-
-      private CallContextCall getAValidCallContextForParameter(ParameterNode p) {
-        result = TSomeCall()
-        or
-        exists(DataFlowCall call, DataFlowCallable callable |
-          result = TSpecificCall(call) and
-          p.isParameterOf(callable, _) and
-          recordDataFlowCallSite(call, callable)
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlow(ParameterNode p, Node node, CallContextCall cc) {
-        p = node and
-        parameterValueFlowsThroughCand(p, _) and
-        cc = getAValidCallContextForParameter(p)
-        or
-        exists(Node mid |
-          parameterValueFlow(p, mid, cc) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlow(p, arg, cc) and
-          argumentValueFlowsThrough(arg, node, cc) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, in call context `cc`.
-       */
-      cached
-      predicate parameterValueFlowsThrough(ParameterNode p, ReturnKind kind, CallContextCall cc) {
-        parameterValueFlow(p, getAReturnNodeOfKind(kind), cc)
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThrough0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind, CallContext cc
-      ) {
-        exists(ParameterNode param, CallContext innercc |
-          viableParamArg(call, param, arg, cc, innercc) and
-          parameterValueFlowsThrough(param, kind, innercc)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * in call context cc.
-       */
-      cached
-      predicate argumentValueFlowsThrough(ArgumentNode arg, OutNode out, CallContext cc) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThrough0(call, arg, kind, cc)
-        |
-          out = getAnOutNode(call, kind) and
-          not isUnreachableInCall(out, cc.(CallContextSpecificCall).getCall()) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
+        readStep(n2, f, n1)
+      )
     }
 
     /**
@@ -593,18 +519,51 @@ private module ImplCommon {
 
     cached
     newtype TReturnPosition =
-      TReturnPosition0(DataFlowCallable c, ReturnKindExt kind) { returnPosition(_, c, kind) }
+      TReturnPosition0(DataFlowCallable c, ReturnKindExt kind) {
+        exists(ReturnNodeExt ret |
+          c = returnNodeGetEnclosingCallable(ret) and
+          kind = ret.getKind()
+        )
+      }
 
     cached
     newtype TLocalFlowCallContext =
       TAnyLocalCall() or
       TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
+
+    cached
+    newtype TReturnKindExt =
+      TValueReturn(ReturnKind kind) or
+      TParamUpdate(int pos) { exists(ParameterNode p | p.isParameterOf(_, pos)) }
   }
 
-  pragma[noinline]
-  private predicate returnPosition(ReturnNodeExt ret, DataFlowCallable c, ReturnKindExt kind) {
-    c = returnNodeGetEnclosingCallable(ret) and
-    kind = ret.getKind()
+  /**
+   * A `Node` at which a cast can occur such that the type should be checked.
+   */
+  class CastingNode extends Node {
+    CastingNode() {
+      this instanceof ParameterNode or
+      this instanceof CastNode or
+      this instanceof OutNode or
+      this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
+    }
+  }
+
+  newtype TContentOption =
+    TContentNone() or
+    TContentSome(Content f)
+
+  class ContentOption extends TContentOption {
+    Content getContent() { this = TContentSome(result) }
+
+    predicate hasContent() { exists(this.getContent()) }
+
+    string toString() {
+      result = this.getContent().toString()
+      or
+      not this.hasContent() and
+      result = ""
+    }
   }
 
   /**
@@ -719,7 +678,7 @@ private module ImplCommon {
   class ReturnNodeExt extends Node {
     ReturnNodeExt() {
       this instanceof ReturnNode or
-      parameterValueFlowsToUpdate(_, this)
+      parameterValueFlowsToPreUpdate(_, this)
     }
 
     /** Gets the kind of this returned value. */
@@ -727,18 +686,12 @@ private module ImplCommon {
       result = TValueReturn(this.(ReturnNode).getKind())
       or
       exists(ParameterNode p, int pos |
-        parameterValueFlowsToUpdate(p, this) and
+        parameterValueFlowsToPreUpdate(p, this) and
         p.isParameterOf(_, pos) and
         result = TParamUpdate(pos)
       )
     }
   }
-
-  private newtype TReturnKindExt =
-    TValueReturn(ReturnKind kind) or
-    TParamUpdate(int pos) {
-      exists(ParameterNode p | parameterValueFlowsToUpdate(p, _) and p.isParameterOf(_, pos))
-    }
 
   /**
    * An extended return kind. A return kind describes how data can be returned
@@ -774,9 +727,9 @@ private module ImplCommon {
 
     override string toString() { result = "param update " + pos }
 
-    override Node getAnOutNode(DataFlowCall call) {
+    override PostUpdateNode getAnOutNode(DataFlowCall call) {
       exists(ArgumentNode arg |
-        result.(PostUpdateNode).getPreUpdateNode() = arg and
+        result.getPreUpdateNode() = arg and
         arg.argumentOf(call, this.getPosition())
       )
     }
@@ -800,15 +753,13 @@ private module ImplCommon {
   }
 
   pragma[noinline]
-  DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
+  private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
     result = ret.getEnclosingCallable()
   }
 
   pragma[noinline]
   ReturnPosition getReturnPosition(ReturnNodeExt ret) {
-    exists(DataFlowCallable c, ReturnKindExt k | returnPosition(ret, c, k) |
-      result = TReturnPosition0(c, k)
-    )
+    result = TReturnPosition0(returnNodeGetEnclosingCallable(ret), ret.getKind())
   }
 
   bindingset[cc, callable]
@@ -908,8 +859,7 @@ private module ImplCommon {
   }
 
   pragma[noinline]
-  DataFlowType getErasedNodeType(Node n) { result = getErasedRepr(n.getType()) }
-
-  pragma[noinline]
   DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
+
+  predicate readDirect = readStep/3;
 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -383,17 +383,28 @@ private module Cached {
           contentOut = TContentNone() and
           compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
           or
-          // getter(+setter)
+          // getter
           exists(Content fIn |
             contentIn.getContent() = fIn and
-            compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
+            contentOut = TContentNone() and
+            compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType()) and
+            compatibleTypes(fIn.getType(), getErasedNodeTypeBound(out))
           )
           or
           // setter
           exists(Content fOut |
             contentIn = TContentNone() and
             contentOut.getContent() = fOut and
-            compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType())
+            compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(out))
+          )
+          or
+          // getter+setter
+          exists(Content fIn, Content fOut |
+            contentIn.getContent() = fIn and
+            contentOut.getContent() = fOut and
+            compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(out))
           )
         )
       }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -754,8 +754,14 @@ private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
 }
 
 pragma[noinline]
+private ReturnPosition getReturnPosition0(ReturnNodeExt ret, ReturnKindExt kind) {
+  result.getCallable() = returnNodeGetEnclosingCallable(ret) and
+  kind = result.getKind()
+}
+
+pragma[noinline]
 ReturnPosition getReturnPosition(ReturnNodeExt ret) {
-  result = TReturnPosition0(returnNodeGetEnclosingCallable(ret), ret.getKind())
+  result = getReturnPosition0(ret, ret.getKind())
 }
 
 bindingset[cc, callable]

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplCommon.qll
@@ -1,865 +1,860 @@
 private import DataFlowImplSpecific::Private
 private import DataFlowImplSpecific::Public
+import Cached
 
-module Public {
-  import Cached
+cached
+private module Cached {
+  /**
+   * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
+   * The instance parameter is considered to have index `-1`.
+   */
+  pragma[nomagic]
+  private predicate viableParam(DataFlowCall call, int i, ParameterNode p) {
+    p.isParameterOf(viableCallable(call), i)
+  }
+
+  /**
+   * Holds if `arg` is a possible argument to `p` in `call`, taking virtual
+   * dispatch into account.
+   */
+  cached
+  predicate viableParamArg(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
+    exists(int i |
+      viableParam(call, i, p) and
+      arg.argumentOf(call, i)
+    )
+  }
+
+  /** Provides predicates for calculating flow-through summaries. */
+  private module FlowThrough {
+    /**
+     * The first flow-through approximation:
+     *
+     * - Input/output access paths are abstracted with a Boolean parameter
+     *   that indicates (non-)emptiness.
+     */
+    private module Cand {
+      /**
+       * Holds if `p` can flow to `node` in the same callable using only
+       * value-preserving steps.
+       *
+       * `read` indicates whether it is contents of `p` that can flow to `node`,
+       * and `stored` indicates whether it flows to contents of `node`.
+       */
+      pragma[nomagic]
+      private predicate parameterValueFlowCand(
+        ParameterNode p, Node node, boolean read, boolean stored
+      ) {
+        p = node and
+        read = false and
+        stored = false
+        or
+        // local flow
+        exists(Node mid |
+          parameterValueFlowCand(p, mid, read, stored) and
+          simpleLocalFlowStep(mid, node)
+        )
+        or
+        // read
+        exists(Node mid, boolean readMid, boolean storedMid |
+          parameterValueFlowCand(p, mid, readMid, storedMid) and
+          readStep(mid, _, node) and
+          stored = false
+        |
+          // value neither read nor stored prior to read
+          readMid = false and
+          storedMid = false and
+          read = true
+          or
+          // value (possibly read and then) stored prior to read (same content)
+          read = readMid and
+          storedMid = true
+        )
+        or
+        // store
+        exists(Node mid |
+          parameterValueFlowCand(p, mid, read, false) and
+          storeStep(mid, _, node) and
+          stored = true
+        )
+        or
+        // flow through: no prior read or store
+        exists(ArgumentNode arg |
+          parameterValueFlowArgCand(p, arg, false, false) and
+          argumentValueFlowsThroughCand(arg, node, read, stored)
+        )
+        or
+        // flow through: no read or store inside method
+        exists(ArgumentNode arg |
+          parameterValueFlowArgCand(p, arg, read, stored) and
+          argumentValueFlowsThroughCand(arg, node, false, false)
+        )
+        or
+        // flow through: possible prior read and prior store with compatible
+        // flow-through method
+        exists(ArgumentNode arg, boolean mid |
+          parameterValueFlowArgCand(p, arg, read, mid) and
+          argumentValueFlowsThroughCand(arg, node, mid, stored)
+        )
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowArgCand(
+        ParameterNode p, ArgumentNode arg, boolean read, boolean stored
+      ) {
+        parameterValueFlowCand(p, arg, read, stored)
+      }
+
+      pragma[nomagic]
+      predicate parameterValueFlowsToPreUpdateCand(ParameterNode p, PostUpdateNode n) {
+        parameterValueFlowCand(p, n.getPreUpdateNode(), false, false)
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowsToPostUpdateCand(
+        ParameterNode p, PostUpdateNode n, boolean read
+      ) {
+        parameterValueFlowCand(p, n, read, true)
+      }
+
+      /**
+       * Holds if `p` can flow to a return node of kind `kind` in the same
+       * callable using only value-preserving steps, not taking call contexts
+       * into account.
+       *
+       * `read` indicates whether it is contents of `p` that can flow to the return
+       * node, and `stored` indicates whether it flows to contents of the return
+       * node.
+       */
+      predicate parameterValueFlowReturnCand(
+        ParameterNode p, ReturnKindExt kind, boolean read, boolean stored
+      ) {
+        exists(ReturnNode ret |
+          parameterValueFlowCand(p, ret, read, stored) and
+          kind = TValueReturn(ret.getKind())
+        )
+        or
+        exists(ParameterNode p2, int pos2, PostUpdateNode n |
+          parameterValueFlowsToPostUpdateCand(p, n, read) and
+          parameterValueFlowsToPreUpdateCand(p2, n) and
+          p2.isParameterOf(_, pos2) and
+          kind = TParamUpdate(pos2) and
+          p != p2 and
+          stored = true
+        )
+      }
+
+      pragma[nomagic]
+      private predicate argumentValueFlowsThroughCand0(
+        DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, boolean read, boolean stored
+      ) {
+        exists(ParameterNode param | viableParamArg(call, param, arg) |
+          parameterValueFlowReturnCand(param, kind, read, stored)
+        )
+      }
+
+      /**
+       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
+       * not taking call contexts into account.
+       *
+       * `read` indicates whether it is contents of `arg` that can flow to `out`, and
+       * `stored` indicates whether it flows to contents of `out`.
+       */
+      predicate argumentValueFlowsThroughCand(
+        ArgumentNode arg, Node out, boolean read, boolean stored
+      ) {
+        exists(DataFlowCall call, ReturnKindExt kind |
+          argumentValueFlowsThroughCand0(call, arg, kind, read, stored) and
+          out = kind.getAnOutNode(call)
+        )
+      }
+
+      predicate cand(ParameterNode p, Node n) {
+        parameterValueFlowCand(p, n, _, _) and
+        (
+          parameterValueFlowReturnCand(p, _, _, _)
+          or
+          parameterValueFlowsToPreUpdateCand(p, _)
+        )
+      }
+    }
+
+    private module LocalFlowBigStep {
+      private predicate localFlowEntry(Node n) {
+        Cand::cand(_, n) and
+        (
+          n instanceof ParameterNode or
+          n instanceof OutNode or
+          n instanceof PostUpdateNode or
+          readStep(_, _, n) or
+          n instanceof CastNode
+        )
+      }
+
+      private predicate localFlowExit(Node n) {
+        Cand::cand(_, n) and
+        (
+          n instanceof ArgumentNode
+          or
+          n instanceof ReturnNode
+          or
+          Cand::parameterValueFlowsToPreUpdateCand(_, n)
+          or
+          storeStep(n, _, _)
+          or
+          readStep(n, _, _)
+          or
+          n instanceof CastNode
+          or
+          n =
+            any(PostUpdateNode pun | Cand::parameterValueFlowsToPreUpdateCand(_, pun))
+                .getPreUpdateNode()
+        )
+      }
+
+      pragma[nomagic]
+      private predicate localFlowStepPlus(Node node1, Node node2) {
+        localFlowEntry(node1) and
+        simpleLocalFlowStep(node1, node2) and
+        node1 != node2 and
+        Cand::cand(_, node2)
+        or
+        exists(Node mid |
+          localFlowStepPlus(node1, mid) and
+          simpleLocalFlowStep(mid, node2) and
+          not mid instanceof CastNode and
+          Cand::cand(_, node2)
+        )
+      }
+
+      pragma[nomagic]
+      predicate localFlowBigStep(Node node1, Node node2) {
+        localFlowStepPlus(node1, node2) and
+        localFlowExit(node2)
+      }
+    }
+
+    /**
+     * The final flow-through calculation:
+     *
+     * - Input/output access paths are abstracted with a `ContentOption` parameter
+     *   that represents the head of the access path.
+     * - Types are checked using the `compatibleTypes()` relation.
+     */
+    module Final {
+      /**
+       * Holds if `p` can flow to `node` in the same callable using only
+       * value-preserving steps, not taking call contexts into account.
+       *
+       * `contentIn` describes the content of `p` that can flow to `node`
+       * (if any), and `contentOut` describes the content of `node` that
+       * it flows to (if any).
+       */
+      predicate parameterValueFlow(
+        ParameterNode p, Node node, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow0(p, node, contentIn, contentOut) and
+        Cand::cand(p, node) and
+        if node instanceof CastingNode
+        then
+          // normal flow through
+          contentIn = TContentNone() and
+          contentOut = TContentNone() and
+          compatibleTypes(getErasedNodeTypeBound(p), getErasedNodeTypeBound(node))
+          or
+          // getter
+          exists(Content fIn |
+            contentIn.getContent() = fIn and
+            contentOut = TContentNone() and
+            compatibleTypes(fIn.getType(), getErasedNodeTypeBound(node))
+          )
+          or
+          // setter
+          exists(Content fOut |
+            contentIn = TContentNone() and
+            contentOut.getContent() = fOut and
+            compatibleTypes(getErasedNodeTypeBound(p), fOut.getType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(node))
+          )
+          or
+          // getter+setter
+          exists(Content fIn, Content fOut |
+            contentIn.getContent() = fIn and
+            contentOut.getContent() = fOut and
+            compatibleTypes(fIn.getType(), fOut.getType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(node))
+          )
+        else any()
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlow0(
+        ParameterNode p, Node node, ContentOption contentIn, ContentOption contentOut
+      ) {
+        p = node and
+        Cand::cand(p, _) and
+        contentIn = TContentNone() and
+        contentOut = TContentNone()
+        or
+        // local flow
+        exists(Node mid |
+          parameterValueFlow(p, mid, contentIn, contentOut) and
+          LocalFlowBigStep::localFlowBigStep(mid, node)
+        )
+        or
+        // read
+        exists(Node mid, Content f, ContentOption contentInMid, ContentOption contentOutMid |
+          parameterValueFlow(p, mid, contentInMid, contentOutMid) and
+          readStep(mid, f, node)
+        |
+          // value neither read nor stored prior to read
+          contentInMid = TContentNone() and
+          contentOutMid = TContentNone() and
+          contentIn.getContent() = f and
+          contentOut = TContentNone() and
+          Cand::parameterValueFlowReturnCand(p, _, true, _)
+          or
+          // value (possibly read and then) stored prior to read (same content)
+          contentIn = contentInMid and
+          contentOutMid.getContent() = f and
+          contentOut = TContentNone()
+        )
+        or
+        // store
+        exists(Node mid, Content f |
+          parameterValueFlow(p, mid, contentIn, TContentNone()) and
+          storeStep(mid, f, node) and
+          contentOut.getContent() = f
+        )
+        or
+        // flow through: no prior read or store
+        exists(ArgumentNode arg |
+          parameterValueFlowArg(p, arg, TContentNone(), TContentNone()) and
+          argumentValueFlowsThrough(arg, node, contentIn, contentOut)
+        )
+        or
+        // flow through: no read or store inside method
+        exists(ArgumentNode arg |
+          parameterValueFlowArg(p, arg, contentIn, contentOut) and
+          argumentValueFlowsThrough(arg, node, TContentNone(), TContentNone())
+        )
+        or
+        // flow through: possible prior read and prior store with compatible
+        // flow-through method
+        exists(ArgumentNode arg, ContentOption contentMid |
+          parameterValueFlowArg(p, arg, contentIn, contentMid) and
+          argumentValueFlowsThrough(arg, node, contentMid, contentOut)
+        )
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowArg(
+        ParameterNode p, ArgumentNode arg, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow(p, arg, contentIn, contentOut) and
+        Cand::argumentValueFlowsThroughCand(arg, _, _, _)
+      }
+
+      pragma[nomagic]
+      predicate parameterValueFlowsToPostUpdate(
+        ParameterNode p, PostUpdateNode n, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow(p, n, contentIn, contentOut) and
+        contentOut.hasContent()
+      }
+
+      pragma[nomagic]
+      predicate argumentValueFlowsThrough0(
+        DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, ContentOption contentIn,
+        ContentOption contentOut
+      ) {
+        exists(ParameterNode param | viableParamArg(call, param, arg) |
+          parameterValueFlowReturn(param, _, kind, contentIn, contentOut)
+        )
+      }
+
+      /**
+       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
+       * not taking call contexts into account.
+       *
+       * `contentIn` describes the content of `arg` that can flow to `out` (if any), and
+       * `contentOut` describes the content of `out` that it flows to (if any).
+       */
+      private predicate argumentValueFlowsThrough(
+        ArgumentNode arg, Node out, ContentOption contentIn, ContentOption contentOut
+      ) {
+        exists(DataFlowCall call, ReturnKindExt kind |
+          argumentValueFlowsThrough0(call, arg, kind, contentIn, contentOut) and
+          out = kind.getAnOutNode(call)
+        )
+      }
+    }
+
+    import Final
+  }
+
+  /**
+   * Holds if `p` can flow to the pre-update node associated with post-update
+   * node `n`, in the same callable, using only value-preserving steps.
+   */
+  cached
+  predicate parameterValueFlowsToPreUpdate(ParameterNode p, PostUpdateNode n) {
+    FlowThrough::parameterValueFlow(p, n.getPreUpdateNode(), TContentNone(), TContentNone())
+  }
+
+  /**
+   * Holds if `p` can flow to a return node of kind `kind` in the same
+   * callable using only value-preserving steps.
+   *
+   * `contentIn` describes the content of `p` that can flow to the return
+   * node (if any), and `contentOut` describes the content of the return
+   * node that it flows to (if any).
+   */
+  cached
+  predicate parameterValueFlowReturn(
+    ParameterNode p, Node ret, ReturnKindExt kind, ContentOption contentIn, ContentOption contentOut
+  ) {
+    ret =
+      any(ReturnNode n |
+        FlowThrough::parameterValueFlow(p, n, contentIn, contentOut) and
+        kind = TValueReturn(n.getKind())
+      )
+    or
+    ret =
+      any(PostUpdateNode n |
+        exists(ParameterNode p2, int pos2 |
+          FlowThrough::parameterValueFlowsToPostUpdate(p, n, contentIn, contentOut) and
+          parameterValueFlowsToPreUpdate(p2, n) and
+          p2.isParameterOf(_, pos2) and
+          kind = TParamUpdate(pos2) and
+          p != p2
+        )
+      )
+  }
+
+  /**
+   * Holds if `arg` flows to `out` through `call` using only value-preserving steps.
+   *
+   * `contentIn` describes the content of `arg` that can flow to `out` (if any), and
+   * `contentOut` describes the content of `out` that it flows to (if any).
+   */
+  cached
+  predicate argumentValueFlowsThrough(
+    DataFlowCall call, ArgumentNode arg, ContentOption contentIn, ContentOption contentOut, Node out
+  ) {
+    exists(ReturnKindExt kind |
+      FlowThrough::argumentValueFlowsThrough0(call, arg, kind, contentIn, contentOut) and
+      out = kind.getAnOutNode(call)
+    |
+      // normal flow through
+      contentIn = TContentNone() and
+      contentOut = TContentNone() and
+      compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
+      or
+      // getter
+      exists(Content fIn |
+        contentIn.getContent() = fIn and
+        contentOut = TContentNone() and
+        compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
+      )
+      or
+      // setter
+      exists(Content fOut |
+        contentIn = TContentNone() and
+        contentOut.getContent() = fOut and
+        compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType())
+      )
+      or
+      // getter+setter
+      exists(Content fIn, Content fOut |
+        contentIn.getContent() = fIn and
+        contentOut.getContent() = fOut and
+        compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
+      )
+    )
+  }
+
+  /**
+   * Holds if data can flow from `node1` to `node2` via a direct assignment to
+   * `f`.
+   *
+   * This includes reverse steps through reads when the result of the read has
+   * been stored into, in order to handle cases like `x.f1.f2 = y`.
+   */
+  cached
+  predicate storeDirect(Node node1, Content f, Node node2) {
+    storeStep(node1, f, node2) and readStep(_, f, _)
+    or
+    exists(Node n1, Node n2 |
+      n1 = node1.(PostUpdateNode).getPreUpdateNode() and
+      n2 = node2.(PostUpdateNode).getPreUpdateNode()
+    |
+      argumentValueFlowsThrough(_, n2, TContentSome(f), TContentNone(), n1)
+      or
+      readStep(n2, f, n1)
+    )
+  }
+
+  /**
+   * Holds if the call context `call` either improves virtual dispatch in
+   * `callable` or if it allows us to prune unreachable nodes in `callable`.
+   */
+  cached
+  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+    reducedViableImplInCallContext(_, callable, call)
+    or
+    exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
+  }
 
   cached
-  private module Cached {
-    /**
-     * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
-     * The instance parameter is considered to have index `-1`.
-     */
-    pragma[nomagic]
-    private predicate viableParam(DataFlowCall call, int i, ParameterNode p) {
-      p.isParameterOf(viableCallable(call), i)
-    }
+  newtype TCallContext =
+    TAnyCallContext() or
+    TSpecificCall(DataFlowCall call) { recordDataFlowCallSite(call, _) } or
+    TSomeCall() or
+    TReturn(DataFlowCallable c, DataFlowCall call) { reducedViableImplInReturn(c, call) }
 
-    /**
-     * Holds if `arg` is a possible argument to `p` in `call`, taking virtual
-     * dispatch into account.
-     */
-    cached
-    predicate viableParamArg(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
-      exists(int i |
-        viableParam(call, i, p) and
-        arg.argumentOf(call, i)
+  cached
+  newtype TReturnPosition =
+    TReturnPosition0(DataFlowCallable c, ReturnKindExt kind) {
+      exists(ReturnNodeExt ret |
+        c = returnNodeGetEnclosingCallable(ret) and
+        kind = ret.getKind()
       )
     }
 
-    /** Provides predicates for calculating flow-through summaries. */
-    private module FlowThrough {
-      /**
-       * The first flow-through approximation:
-       *
-       * - Input/output access paths are abstracted with a Boolean parameter
-       *   that indicates (non-)emptiness.
-       */
-      private module Cand {
-        /**
-         * Holds if `p` can flow to `node` in the same callable using only
-         * value-preserving steps.
-         *
-         * `read` indicates whether it is contents of `p` that can flow to `node`,
-         * and `stored` indicates whether it flows to contents of `node`.
-         */
-        pragma[nomagic]
-        private predicate parameterValueFlowCand(
-          ParameterNode p, Node node, boolean read, boolean stored
-        ) {
-          p = node and
-          read = false and
-          stored = false
-          or
-          // local flow
-          exists(Node mid |
-            parameterValueFlowCand(p, mid, read, stored) and
-            simpleLocalFlowStep(mid, node)
-          )
-          or
-          // read
-          exists(Node mid, boolean readMid, boolean storedMid |
-            parameterValueFlowCand(p, mid, readMid, storedMid) and
-            readStep(mid, _, node) and
-            stored = false
-          |
-            // value neither read nor stored prior to read
-            readMid = false and
-            storedMid = false and
-            read = true
-            or
-            // value (possibly read and then) stored prior to read (same content)
-            read = readMid and
-            storedMid = true
-          )
-          or
-          // store
-          exists(Node mid |
-            parameterValueFlowCand(p, mid, read, false) and
-            storeStep(mid, _, node) and
-            stored = true
-          )
-          or
-          // flow through: no prior read or store
-          exists(ArgumentNode arg |
-            parameterValueFlowArgCand(p, arg, false, false) and
-            argumentValueFlowsThroughCand(arg, node, read, stored)
-          )
-          or
-          // flow through: no read or store inside method
-          exists(ArgumentNode arg |
-            parameterValueFlowArgCand(p, arg, read, stored) and
-            argumentValueFlowsThroughCand(arg, node, false, false)
-          )
-          or
-          // flow through: possible prior read and prior store with compatible
-          // flow-through method
-          exists(ArgumentNode arg, boolean mid |
-            parameterValueFlowArgCand(p, arg, read, mid) and
-            argumentValueFlowsThroughCand(arg, node, mid, stored)
-          )
-        }
-
-        pragma[nomagic]
-        private predicate parameterValueFlowArgCand(
-          ParameterNode p, ArgumentNode arg, boolean read, boolean stored
-        ) {
-          parameterValueFlowCand(p, arg, read, stored)
-        }
-
-        pragma[nomagic]
-        predicate parameterValueFlowsToPreUpdateCand(ParameterNode p, PostUpdateNode n) {
-          parameterValueFlowCand(p, n.getPreUpdateNode(), false, false)
-        }
-
-        pragma[nomagic]
-        private predicate parameterValueFlowsToPostUpdateCand(
-          ParameterNode p, PostUpdateNode n, boolean read
-        ) {
-          parameterValueFlowCand(p, n, read, true)
-        }
-
-        /**
-         * Holds if `p` can flow to a return node of kind `kind` in the same
-         * callable using only value-preserving steps, not taking call contexts
-         * into account.
-         *
-         * `read` indicates whether it is contents of `p` that can flow to the return
-         * node, and `stored` indicates whether it flows to contents of the return
-         * node.
-         */
-        predicate parameterValueFlowReturnCand(
-          ParameterNode p, ReturnKindExt kind, boolean read, boolean stored
-        ) {
-          exists(ReturnNode ret |
-            parameterValueFlowCand(p, ret, read, stored) and
-            kind = TValueReturn(ret.getKind())
-          )
-          or
-          exists(ParameterNode p2, int pos2, PostUpdateNode n |
-            parameterValueFlowsToPostUpdateCand(p, n, read) and
-            parameterValueFlowsToPreUpdateCand(p2, n) and
-            p2.isParameterOf(_, pos2) and
-            kind = TParamUpdate(pos2) and
-            p != p2 and
-            stored = true
-          )
-        }
-
-        pragma[nomagic]
-        private predicate argumentValueFlowsThroughCand0(
-          DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, boolean read, boolean stored
-        ) {
-          exists(ParameterNode param | viableParamArg(call, param, arg) |
-            parameterValueFlowReturnCand(param, kind, read, stored)
-          )
-        }
-
-        /**
-         * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-         * not taking call contexts into account.
-         *
-         * `read` indicates whether it is contents of `arg` that can flow to `out`, and
-         * `stored` indicates whether it flows to contents of `out`.
-         */
-        predicate argumentValueFlowsThroughCand(
-          ArgumentNode arg, Node out, boolean read, boolean stored
-        ) {
-          exists(DataFlowCall call, ReturnKindExt kind |
-            argumentValueFlowsThroughCand0(call, arg, kind, read, stored) and
-            out = kind.getAnOutNode(call)
-          )
-        }
-
-        predicate cand(ParameterNode p, Node n) {
-          parameterValueFlowCand(p, n, _, _) and
-          (
-            parameterValueFlowReturnCand(p, _, _, _)
-            or
-            parameterValueFlowsToPreUpdateCand(p, _)
-          )
-        }
-      }
-
-      private module LocalFlowBigStep {
-        private predicate localFlowEntry(Node n) {
-          Cand::cand(_, n) and
-          (
-            n instanceof ParameterNode or
-            n instanceof OutNode or
-            n instanceof PostUpdateNode or
-            readStep(_, _, n) or
-            n instanceof CastNode
-          )
-        }
-
-        private predicate localFlowExit(Node n) {
-          Cand::cand(_, n) and
-          (
-            n instanceof ArgumentNode
-            or
-            n instanceof ReturnNode
-            or
-            Cand::parameterValueFlowsToPreUpdateCand(_, n)
-            or
-            storeStep(n, _, _)
-            or
-            readStep(n, _, _)
-            or
-            n instanceof CastNode
-            or
-            n =
-              any(PostUpdateNode pun | Cand::parameterValueFlowsToPreUpdateCand(_, pun))
-                  .getPreUpdateNode()
-          )
-        }
-
-        pragma[nomagic]
-        private predicate localFlowStepPlus(Node node1, Node node2) {
-          localFlowEntry(node1) and
-          simpleLocalFlowStep(node1, node2) and
-          node1 != node2 and
-          Cand::cand(_, node2)
-          or
-          exists(Node mid |
-            localFlowStepPlus(node1, mid) and
-            simpleLocalFlowStep(mid, node2) and
-            not mid instanceof CastNode and
-            Cand::cand(_, node2)
-          )
-        }
-
-        pragma[nomagic]
-        predicate localFlowBigStep(Node node1, Node node2) {
-          localFlowStepPlus(node1, node2) and
-          localFlowExit(node2)
-        }
-      }
-
-      /**
-       * The final flow-through calculation:
-       *
-       * - Input/output access paths are abstracted with a `ContentOption` parameter
-       *   that represents the head of the access path.
-       * - Types are checked using the `compatibleTypes()` relation.
-       */
-      module Final {
-        /**
-         * Holds if `p` can flow to `node` in the same callable using only
-         * value-preserving steps, not taking call contexts into account.
-         *
-         * `contentIn` describes the content of `p` that can flow to `node`
-         * (if any), and `contentOut` describes the content of `node` that
-         * it flows to (if any).
-         */
-        predicate parameterValueFlow(
-          ParameterNode p, Node node, ContentOption contentIn, ContentOption contentOut
-        ) {
-          parameterValueFlow0(p, node, contentIn, contentOut) and
-          Cand::cand(p, node) and
-          if node instanceof CastingNode
-          then
-            // normal flow through
-            contentIn = TContentNone() and
-            contentOut = TContentNone() and
-            compatibleTypes(getErasedNodeTypeBound(p), getErasedNodeTypeBound(node))
-            or
-            // getter
-            exists(Content fIn |
-              contentIn.getContent() = fIn and
-              contentOut = TContentNone() and
-              compatibleTypes(fIn.getType(), getErasedNodeTypeBound(node))
-            )
-            or
-            // setter
-            exists(Content fOut |
-              contentIn = TContentNone() and
-              contentOut.getContent() = fOut and
-              compatibleTypes(getErasedNodeTypeBound(p), fOut.getType()) and
-              compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(node))
-            )
-            or
-            // getter+setter
-            exists(Content fIn, Content fOut |
-              contentIn.getContent() = fIn and
-              contentOut.getContent() = fOut and
-              compatibleTypes(fIn.getType(), fOut.getType()) and
-              compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(node))
-            )
-          else any()
-        }
-
-        pragma[nomagic]
-        private predicate parameterValueFlow0(
-          ParameterNode p, Node node, ContentOption contentIn, ContentOption contentOut
-        ) {
-          p = node and
-          Cand::cand(p, _) and
-          contentIn = TContentNone() and
-          contentOut = TContentNone()
-          or
-          // local flow
-          exists(Node mid |
-            parameterValueFlow(p, mid, contentIn, contentOut) and
-            LocalFlowBigStep::localFlowBigStep(mid, node)
-          )
-          or
-          // read
-          exists(Node mid, Content f, ContentOption contentInMid, ContentOption contentOutMid |
-            parameterValueFlow(p, mid, contentInMid, contentOutMid) and
-            readStep(mid, f, node)
-          |
-            // value neither read nor stored prior to read
-            contentInMid = TContentNone() and
-            contentOutMid = TContentNone() and
-            contentIn.getContent() = f and
-            contentOut = TContentNone() and
-            Cand::parameterValueFlowReturnCand(p, _, true, _)
-            or
-            // value (possibly read and then) stored prior to read (same content)
-            contentIn = contentInMid and
-            contentOutMid.getContent() = f and
-            contentOut = TContentNone()
-          )
-          or
-          // store
-          exists(Node mid, Content f |
-            parameterValueFlow(p, mid, contentIn, TContentNone()) and
-            storeStep(mid, f, node) and
-            contentOut.getContent() = f
-          )
-          or
-          // flow through: no prior read or store
-          exists(ArgumentNode arg |
-            parameterValueFlowArg(p, arg, TContentNone(), TContentNone()) and
-            argumentValueFlowsThrough(arg, node, contentIn, contentOut)
-          )
-          or
-          // flow through: no read or store inside method
-          exists(ArgumentNode arg |
-            parameterValueFlowArg(p, arg, contentIn, contentOut) and
-            argumentValueFlowsThrough(arg, node, TContentNone(), TContentNone())
-          )
-          or
-          // flow through: possible prior read and prior store with compatible
-          // flow-through method
-          exists(ArgumentNode arg, ContentOption contentMid |
-            parameterValueFlowArg(p, arg, contentIn, contentMid) and
-            argumentValueFlowsThrough(arg, node, contentMid, contentOut)
-          )
-        }
-
-        pragma[nomagic]
-        private predicate parameterValueFlowArg(
-          ParameterNode p, ArgumentNode arg, ContentOption contentIn, ContentOption contentOut
-        ) {
-          parameterValueFlow(p, arg, contentIn, contentOut) and
-          Cand::argumentValueFlowsThroughCand(arg, _, _, _)
-        }
-
-        pragma[nomagic]
-        predicate parameterValueFlowsToPostUpdate(
-          ParameterNode p, PostUpdateNode n, ContentOption contentIn, ContentOption contentOut
-        ) {
-          parameterValueFlow(p, n, contentIn, contentOut) and
-          contentOut.hasContent()
-        }
-
-        pragma[nomagic]
-        predicate argumentValueFlowsThrough0(
-          DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, ContentOption contentIn,
-          ContentOption contentOut
-        ) {
-          exists(ParameterNode param | viableParamArg(call, param, arg) |
-            parameterValueFlowReturn(param, _, kind, contentIn, contentOut)
-          )
-        }
-
-        /**
-         * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-         * not taking call contexts into account.
-         *
-         * `contentIn` describes the content of `arg` that can flow to `out` (if any), and
-         * `contentOut` describes the content of `out` that it flows to (if any).
-         */
-        private predicate argumentValueFlowsThrough(
-          ArgumentNode arg, Node out, ContentOption contentIn, ContentOption contentOut
-        ) {
-          exists(DataFlowCall call, ReturnKindExt kind |
-            argumentValueFlowsThrough0(call, arg, kind, contentIn, contentOut) and
-            out = kind.getAnOutNode(call)
-          )
-        }
-      }
-
-      import Final
-    }
-
-    /**
-     * Holds if `p` can flow to the pre-update node associated with post-update
-     * node `n`, in the same callable, using only value-preserving steps.
-     */
-    cached
-    predicate parameterValueFlowsToPreUpdate(ParameterNode p, PostUpdateNode n) {
-      FlowThrough::parameterValueFlow(p, n.getPreUpdateNode(), TContentNone(), TContentNone())
-    }
-
-    /**
-     * Holds if `p` can flow to a return node of kind `kind` in the same
-     * callable using only value-preserving steps.
-     *
-     * `contentIn` describes the content of `p` that can flow to the return
-     * node (if any), and `contentOut` describes the content of the return
-     * node that it flows to (if any).
-     */
-    cached
-    predicate parameterValueFlowReturn(
-      ParameterNode p, Node ret, ReturnKindExt kind, ContentOption contentIn,
-      ContentOption contentOut
-    ) {
-      ret =
-        any(ReturnNode n |
-          FlowThrough::parameterValueFlow(p, n, contentIn, contentOut) and
-          kind = TValueReturn(n.getKind())
-        )
-      or
-      ret =
-        any(PostUpdateNode n |
-          exists(ParameterNode p2, int pos2 |
-            FlowThrough::parameterValueFlowsToPostUpdate(p, n, contentIn, contentOut) and
-            parameterValueFlowsToPreUpdate(p2, n) and
-            p2.isParameterOf(_, pos2) and
-            kind = TParamUpdate(pos2) and
-            p != p2
-          )
-        )
-    }
-
-    /**
-     * Holds if `arg` flows to `out` through `call` using only value-preserving steps.
-     *
-     * `contentIn` describes the content of `arg` that can flow to `out` (if any), and
-     * `contentOut` describes the content of `out` that it flows to (if any).
-     */
-    cached
-    predicate argumentValueFlowsThrough(
-      DataFlowCall call, ArgumentNode arg, ContentOption contentIn, ContentOption contentOut,
-      Node out
-    ) {
-      exists(ReturnKindExt kind |
-        FlowThrough::argumentValueFlowsThrough0(call, arg, kind, contentIn, contentOut) and
-        out = kind.getAnOutNode(call)
-      |
-        // normal flow through
-        contentIn = TContentNone() and
-        contentOut = TContentNone() and
-        compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
-        or
-        // getter
-        exists(Content fIn |
-          contentIn.getContent() = fIn and
-          contentOut = TContentNone() and
-          compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
-        )
-        or
-        // setter
-        exists(Content fOut |
-          contentIn = TContentNone() and
-          contentOut.getContent() = fOut and
-          compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType())
-        )
-        or
-        // getter+setter
-        exists(Content fIn, Content fOut |
-          contentIn.getContent() = fIn and
-          contentOut.getContent() = fOut and
-          compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
-        )
-      )
-    }
-
-    /**
-     * Holds if data can flow from `node1` to `node2` via a direct assignment to
-     * `f`.
-     *
-     * This includes reverse steps through reads when the result of the read has
-     * been stored into, in order to handle cases like `x.f1.f2 = y`.
-     */
-    cached
-    predicate storeDirect(Node node1, Content f, Node node2) {
-      storeStep(node1, f, node2) and readStep(_, f, _)
-      or
-      exists(Node n1, Node n2 |
-        n1 = node1.(PostUpdateNode).getPreUpdateNode() and
-        n2 = node2.(PostUpdateNode).getPreUpdateNode()
-      |
-        argumentValueFlowsThrough(_, n2, TContentSome(f), TContentNone(), n1)
-        or
-        readStep(n2, f, n1)
-      )
-    }
-
-    /**
-     * Holds if the call context `call` either improves virtual dispatch in
-     * `callable` or if it allows us to prune unreachable nodes in `callable`.
-     */
-    cached
-    predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
-      reducedViableImplInCallContext(_, callable, call)
-      or
-      exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
-    }
-
-    cached
-    newtype TCallContext =
-      TAnyCallContext() or
-      TSpecificCall(DataFlowCall call) { recordDataFlowCallSite(call, _) } or
-      TSomeCall() or
-      TReturn(DataFlowCallable c, DataFlowCall call) { reducedViableImplInReturn(c, call) }
-
-    cached
-    newtype TReturnPosition =
-      TReturnPosition0(DataFlowCallable c, ReturnKindExt kind) {
-        exists(ReturnNodeExt ret |
-          c = returnNodeGetEnclosingCallable(ret) and
-          kind = ret.getKind()
-        )
-      }
-
-    cached
-    newtype TLocalFlowCallContext =
-      TAnyLocalCall() or
-      TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
-
-    cached
-    newtype TReturnKindExt =
-      TValueReturn(ReturnKind kind) or
-      TParamUpdate(int pos) { exists(ParameterNode p | p.isParameterOf(_, pos)) }
-  }
-
-  /**
-   * A `Node` at which a cast can occur such that the type should be checked.
-   */
-  class CastingNode extends Node {
-    CastingNode() {
-      this instanceof ParameterNode or
-      this instanceof CastNode or
-      this instanceof OutNode or
-      this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
-    }
-  }
-
-  newtype TContentOption =
-    TContentNone() or
-    TContentSome(Content f)
-
-  class ContentOption extends TContentOption {
-    Content getContent() { this = TContentSome(result) }
-
-    predicate hasContent() { exists(this.getContent()) }
-
-    string toString() {
-      result = this.getContent().toString()
-      or
-      not this.hasContent() and
-      result = ""
-    }
-  }
-
-  /**
-   * A call context to restrict the targets of virtual dispatch, prune local flow,
-   * and match the call sites of flow into a method with flow out of a method.
-   *
-   * There are four cases:
-   * - `TAnyCallContext()` : No restrictions on method flow.
-   * - `TSpecificCall(DataFlowCall call)` : Flow entered through the
-   *    given `call`. This call improves the set of viable
-   *    dispatch targets for at least one method call in the current callable
-   *    or helps prune unreachable nodes in the current callable.
-   * - `TSomeCall()` : Flow entered through a parameter. The
-   *    originating call does not improve the set of dispatch targets for any
-   *    method call in the current callable and was therefore not recorded.
-   * - `TReturn(Callable c, DataFlowCall call)` : Flow reached `call` from `c` and
-   *    this dispatch target of `call` implies a reduced set of dispatch origins
-   *    to which data may flow if it should reach a `return` statement.
-   */
-  abstract class CallContext extends TCallContext {
-    abstract string toString();
-
-    /** Holds if this call context is relevant for `callable`. */
-    abstract predicate relevantFor(DataFlowCallable callable);
-  }
-
-  class CallContextAny extends CallContext, TAnyCallContext {
-    override string toString() { result = "CcAny" }
-
-    override predicate relevantFor(DataFlowCallable callable) { any() }
-  }
-
-  abstract class CallContextCall extends CallContext { }
-
-  class CallContextSpecificCall extends CallContextCall, TSpecificCall {
-    override string toString() {
-      exists(DataFlowCall call | this = TSpecificCall(call) | result = "CcCall(" + call + ")")
-    }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      recordDataFlowCallSite(getCall(), callable)
-    }
-
-    DataFlowCall getCall() { this = TSpecificCall(result) }
-  }
-
-  class CallContextSomeCall extends CallContextCall, TSomeCall {
-    override string toString() { result = "CcSomeCall" }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      exists(ParameterNode p | p.getEnclosingCallable() = callable)
-    }
-  }
-
-  class CallContextReturn extends CallContext, TReturn {
-    override string toString() {
-      exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
-    }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      exists(DataFlowCall call | this = TReturn(_, call) and call.getEnclosingCallable() = callable)
-    }
-  }
-
-  /**
-   * A call context that is relevant for pruning local flow.
-   */
-  abstract class LocalCallContext extends TLocalFlowCallContext {
-    abstract string toString();
-
-    /** Holds if this call context is relevant for `callable`. */
-    abstract predicate relevantFor(DataFlowCallable callable);
-  }
-
-  class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
-    override string toString() { result = "LocalCcAny" }
-
-    override predicate relevantFor(DataFlowCallable callable) { any() }
-  }
-
-  class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
-    LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
-
-    DataFlowCall call;
-
-    DataFlowCall getCall() { result = call }
-
-    override string toString() { result = "LocalCcCall(" + call + ")" }
-
-    override predicate relevantFor(DataFlowCallable callable) { relevantLocalCCtx(call, callable) }
-  }
-
-  private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
-    exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
-  }
-
-  /**
-   * Gets the local call context given the call context and the callable that
-   * the contexts apply to.
-   */
-  LocalCallContext getLocalCallContext(CallContext ctx, DataFlowCallable callable) {
-    ctx.relevantFor(callable) and
-    if relevantLocalCCtx(ctx.(CallContextSpecificCall).getCall(), callable)
-    then result.(LocalCallContextSpecificCall).getCall() = ctx.(CallContextSpecificCall).getCall()
-    else result instanceof LocalCallContextAny
-  }
-
-  /**
-   * A node from which flow can return to the caller. This is either a regular
-   * `ReturnNode` or a `PostUpdateNode` corresponding to the value of a parameter.
-   */
-  class ReturnNodeExt extends Node {
-    ReturnNodeExt() {
-      this instanceof ReturnNode or
-      parameterValueFlowsToPreUpdate(_, this)
-    }
-
-    /** Gets the kind of this returned value. */
-    ReturnKindExt getKind() {
-      result = TValueReturn(this.(ReturnNode).getKind())
-      or
-      exists(ParameterNode p, int pos |
-        parameterValueFlowsToPreUpdate(p, this) and
-        p.isParameterOf(_, pos) and
-        result = TParamUpdate(pos)
-      )
-    }
-  }
-
-  /**
-   * An extended return kind. A return kind describes how data can be returned
-   * from a callable. This can either be through a returned value or an updated
-   * parameter.
-   */
-  abstract class ReturnKindExt extends TReturnKindExt {
-    /** Gets a textual representation of this return kind. */
-    abstract string toString();
-
-    /** Gets a node corresponding to data flow out of `call`. */
-    abstract Node getAnOutNode(DataFlowCall call);
-  }
-
-  class ValueReturnKind extends ReturnKindExt, TValueReturn {
-    private ReturnKind kind;
-
-    ValueReturnKind() { this = TValueReturn(kind) }
-
-    ReturnKind getKind() { result = kind }
-
-    override string toString() { result = kind.toString() }
-
-    override Node getAnOutNode(DataFlowCall call) { result = getAnOutNode(call, this.getKind()) }
-  }
-
-  class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
-    private int pos;
-
-    ParamUpdateReturnKind() { this = TParamUpdate(pos) }
-
-    int getPosition() { result = pos }
-
-    override string toString() { result = "param update " + pos }
-
-    override PostUpdateNode getAnOutNode(DataFlowCall call) {
-      exists(ArgumentNode arg |
-        result.getPreUpdateNode() = arg and
-        arg.argumentOf(call, this.getPosition())
-      )
-    }
-  }
-
-  /** A callable tagged with a relevant return kind. */
-  class ReturnPosition extends TReturnPosition0 {
-    private DataFlowCallable c;
-    private ReturnKindExt kind;
-
-    ReturnPosition() { this = TReturnPosition0(c, kind) }
-
-    /** Gets the callable. */
-    DataFlowCallable getCallable() { result = c }
-
-    /** Gets the return kind. */
-    ReturnKindExt getKind() { result = kind }
-
-    /** Gets a textual representation of this return position. */
-    string toString() { result = "[" + kind + "] " + c }
-  }
-
-  pragma[noinline]
-  private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
-    result = ret.getEnclosingCallable()
-  }
-
-  pragma[noinline]
-  ReturnPosition getReturnPosition(ReturnNodeExt ret) {
-    result = TReturnPosition0(returnNodeGetEnclosingCallable(ret), ret.getKind())
-  }
-
-  bindingset[cc, callable]
-  predicate resolveReturn(CallContext cc, DataFlowCallable callable, DataFlowCall call) {
-    cc instanceof CallContextAny and callable = viableCallable(call)
-    or
-    exists(DataFlowCallable c0, DataFlowCall call0 |
-      call0.getEnclosingCallable() = callable and
-      cc = TReturn(c0, call0) and
-      c0 = prunedViableImplInCallContextReverse(call0, call)
-    )
-  }
-
-  bindingset[call, cc]
-  DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
-    exists(DataFlowCall ctx | cc = TSpecificCall(ctx) |
-      if reducedViableImplInCallContext(call, _, ctx)
-      then result = prunedViableImplInCallContext(call, ctx)
-      else result = viableCallable(call)
-    )
-    or
-    result = viableCallable(call) and cc instanceof CallContextSomeCall
-    or
-    result = viableCallable(call) and cc instanceof CallContextAny
-    or
-    result = viableCallable(call) and cc instanceof CallContextReturn
-  }
-
-  newtype TSummary =
-    TSummaryVal() or
-    TSummaryTaint() or
-    TSummaryReadVal(Content f) or
-    TSummaryReadTaint(Content f) or
-    TSummaryTaintStore(Content f)
-
-  /**
-   * A summary of flow through a callable. This can either be value-preserving
-   * if no additional steps are used, taint-flow if at least one additional step
-   * is used, or any one of those combined with a store or a read. Summaries
-   * recorded at a return node are restricted to include at least one additional
-   * step, as the value-based summaries are calculated independent of the
-   * configuration.
-   */
-  class Summary extends TSummary {
-    string toString() {
-      result = "Val" and this = TSummaryVal()
-      or
-      result = "Taint" and this = TSummaryTaint()
-      or
-      exists(Content f |
-        result = "ReadVal " + f.toString() and this = TSummaryReadVal(f)
-        or
-        result = "ReadTaint " + f.toString() and this = TSummaryReadTaint(f)
-        or
-        result = "TaintStore " + f.toString() and this = TSummaryTaintStore(f)
-      )
-    }
-
-    /** Gets the summary that results from extending this with an additional step. */
-    Summary additionalStep() {
-      this = TSummaryVal() and result = TSummaryTaint()
-      or
-      this = TSummaryTaint() and result = TSummaryTaint()
-      or
-      exists(Content f | this = TSummaryReadVal(f) and result = TSummaryReadTaint(f))
-      or
-      exists(Content f | this = TSummaryReadTaint(f) and result = TSummaryReadTaint(f))
-    }
-
-    /** Gets the summary that results from extending this with a read. */
-    Summary readStep(Content f) { this = TSummaryVal() and result = TSummaryReadVal(f) }
-
-    /** Gets the summary that results from extending this with a store. */
-    Summary storeStep(Content f) { this = TSummaryTaint() and result = TSummaryTaintStore(f) }
-
-    /** Gets the summary that results from extending this with `step`. */
-    bindingset[this, step]
-    Summary compose(Summary step) {
-      this = TSummaryVal() and result = step
-      or
-      this = TSummaryTaint() and
-      (step = TSummaryTaint() or step = TSummaryTaintStore(_)) and
-      result = step
-      or
-      exists(Content f |
-        this = TSummaryReadVal(f) and step = TSummaryTaint() and result = TSummaryReadTaint(f)
-      )
-      or
-      this = TSummaryReadTaint(_) and step = TSummaryTaint() and result = this
-    }
-
-    /** Holds if this summary does not include any taint steps. */
-    predicate isPartial() {
-      this = TSummaryVal() or
-      this = TSummaryReadVal(_)
-    }
-  }
-
-  pragma[noinline]
-  DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
-
-  predicate readDirect = readStep/3;
+  cached
+  newtype TLocalFlowCallContext =
+    TAnyLocalCall() or
+    TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
+
+  cached
+  newtype TReturnKindExt =
+    TValueReturn(ReturnKind kind) or
+    TParamUpdate(int pos) { exists(ParameterNode p | p.isParameterOf(_, pos)) }
 }
+
+/**
+ * A `Node` at which a cast can occur such that the type should be checked.
+ */
+class CastingNode extends Node {
+  CastingNode() {
+    this instanceof ParameterNode or
+    this instanceof CastNode or
+    this instanceof OutNode or
+    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
+  }
+}
+
+newtype TContentOption =
+  TContentNone() or
+  TContentSome(Content f)
+
+class ContentOption extends TContentOption {
+  Content getContent() { this = TContentSome(result) }
+
+  predicate hasContent() { exists(this.getContent()) }
+
+  string toString() {
+    result = this.getContent().toString()
+    or
+    not this.hasContent() and
+    result = ""
+  }
+}
+
+/**
+ * A call context to restrict the targets of virtual dispatch, prune local flow,
+ * and match the call sites of flow into a method with flow out of a method.
+ *
+ * There are four cases:
+ * - `TAnyCallContext()` : No restrictions on method flow.
+ * - `TSpecificCall(DataFlowCall call)` : Flow entered through the
+ *    given `call`. This call improves the set of viable
+ *    dispatch targets for at least one method call in the current callable
+ *    or helps prune unreachable nodes in the current callable.
+ * - `TSomeCall()` : Flow entered through a parameter. The
+ *    originating call does not improve the set of dispatch targets for any
+ *    method call in the current callable and was therefore not recorded.
+ * - `TReturn(Callable c, DataFlowCall call)` : Flow reached `call` from `c` and
+ *    this dispatch target of `call` implies a reduced set of dispatch origins
+ *    to which data may flow if it should reach a `return` statement.
+ */
+abstract class CallContext extends TCallContext {
+  abstract string toString();
+
+  /** Holds if this call context is relevant for `callable`. */
+  abstract predicate relevantFor(DataFlowCallable callable);
+}
+
+class CallContextAny extends CallContext, TAnyCallContext {
+  override string toString() { result = "CcAny" }
+
+  override predicate relevantFor(DataFlowCallable callable) { any() }
+}
+
+abstract class CallContextCall extends CallContext { }
+
+class CallContextSpecificCall extends CallContextCall, TSpecificCall {
+  override string toString() {
+    exists(DataFlowCall call | this = TSpecificCall(call) | result = "CcCall(" + call + ")")
+  }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    recordDataFlowCallSite(getCall(), callable)
+  }
+
+  DataFlowCall getCall() { this = TSpecificCall(result) }
+}
+
+class CallContextSomeCall extends CallContextCall, TSomeCall {
+  override string toString() { result = "CcSomeCall" }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    exists(ParameterNode p | p.getEnclosingCallable() = callable)
+  }
+}
+
+class CallContextReturn extends CallContext, TReturn {
+  override string toString() {
+    exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
+  }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    exists(DataFlowCall call | this = TReturn(_, call) and call.getEnclosingCallable() = callable)
+  }
+}
+
+/**
+ * A call context that is relevant for pruning local flow.
+ */
+abstract class LocalCallContext extends TLocalFlowCallContext {
+  abstract string toString();
+
+  /** Holds if this call context is relevant for `callable`. */
+  abstract predicate relevantFor(DataFlowCallable callable);
+}
+
+class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
+  override string toString() { result = "LocalCcAny" }
+
+  override predicate relevantFor(DataFlowCallable callable) { any() }
+}
+
+class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
+  LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
+
+  DataFlowCall call;
+
+  DataFlowCall getCall() { result = call }
+
+  override string toString() { result = "LocalCcCall(" + call + ")" }
+
+  override predicate relevantFor(DataFlowCallable callable) { relevantLocalCCtx(call, callable) }
+}
+
+private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
+  exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
+}
+
+/**
+ * Gets the local call context given the call context and the callable that
+ * the contexts apply to.
+ */
+LocalCallContext getLocalCallContext(CallContext ctx, DataFlowCallable callable) {
+  ctx.relevantFor(callable) and
+  if relevantLocalCCtx(ctx.(CallContextSpecificCall).getCall(), callable)
+  then result.(LocalCallContextSpecificCall).getCall() = ctx.(CallContextSpecificCall).getCall()
+  else result instanceof LocalCallContextAny
+}
+
+/**
+ * A node from which flow can return to the caller. This is either a regular
+ * `ReturnNode` or a `PostUpdateNode` corresponding to the value of a parameter.
+ */
+class ReturnNodeExt extends Node {
+  ReturnNodeExt() {
+    this instanceof ReturnNode or
+    parameterValueFlowsToPreUpdate(_, this)
+  }
+
+  /** Gets the kind of this returned value. */
+  ReturnKindExt getKind() {
+    result = TValueReturn(this.(ReturnNode).getKind())
+    or
+    exists(ParameterNode p, int pos |
+      parameterValueFlowsToPreUpdate(p, this) and
+      p.isParameterOf(_, pos) and
+      result = TParamUpdate(pos)
+    )
+  }
+}
+
+/**
+ * An extended return kind. A return kind describes how data can be returned
+ * from a callable. This can either be through a returned value or an updated
+ * parameter.
+ */
+abstract class ReturnKindExt extends TReturnKindExt {
+  /** Gets a textual representation of this return kind. */
+  abstract string toString();
+
+  /** Gets a node corresponding to data flow out of `call`. */
+  abstract Node getAnOutNode(DataFlowCall call);
+}
+
+class ValueReturnKind extends ReturnKindExt, TValueReturn {
+  private ReturnKind kind;
+
+  ValueReturnKind() { this = TValueReturn(kind) }
+
+  ReturnKind getKind() { result = kind }
+
+  override string toString() { result = kind.toString() }
+
+  override Node getAnOutNode(DataFlowCall call) { result = getAnOutNode(call, this.getKind()) }
+}
+
+class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
+  private int pos;
+
+  ParamUpdateReturnKind() { this = TParamUpdate(pos) }
+
+  int getPosition() { result = pos }
+
+  override string toString() { result = "param update " + pos }
+
+  override PostUpdateNode getAnOutNode(DataFlowCall call) {
+    exists(ArgumentNode arg |
+      result.getPreUpdateNode() = arg and
+      arg.argumentOf(call, this.getPosition())
+    )
+  }
+}
+
+/** A callable tagged with a relevant return kind. */
+class ReturnPosition extends TReturnPosition0 {
+  private DataFlowCallable c;
+  private ReturnKindExt kind;
+
+  ReturnPosition() { this = TReturnPosition0(c, kind) }
+
+  /** Gets the callable. */
+  DataFlowCallable getCallable() { result = c }
+
+  /** Gets the return kind. */
+  ReturnKindExt getKind() { result = kind }
+
+  /** Gets a textual representation of this return position. */
+  string toString() { result = "[" + kind + "] " + c }
+}
+
+pragma[noinline]
+private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
+  result = ret.getEnclosingCallable()
+}
+
+pragma[noinline]
+ReturnPosition getReturnPosition(ReturnNodeExt ret) {
+  result = TReturnPosition0(returnNodeGetEnclosingCallable(ret), ret.getKind())
+}
+
+bindingset[cc, callable]
+predicate resolveReturn(CallContext cc, DataFlowCallable callable, DataFlowCall call) {
+  cc instanceof CallContextAny and callable = viableCallable(call)
+  or
+  exists(DataFlowCallable c0, DataFlowCall call0 |
+    call0.getEnclosingCallable() = callable and
+    cc = TReturn(c0, call0) and
+    c0 = prunedViableImplInCallContextReverse(call0, call)
+  )
+}
+
+bindingset[call, cc]
+DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
+  exists(DataFlowCall ctx | cc = TSpecificCall(ctx) |
+    if reducedViableImplInCallContext(call, _, ctx)
+    then result = prunedViableImplInCallContext(call, ctx)
+    else result = viableCallable(call)
+  )
+  or
+  result = viableCallable(call) and cc instanceof CallContextSomeCall
+  or
+  result = viableCallable(call) and cc instanceof CallContextAny
+  or
+  result = viableCallable(call) and cc instanceof CallContextReturn
+}
+
+newtype TSummary =
+  TSummaryVal() or
+  TSummaryTaint() or
+  TSummaryReadVal(Content f) or
+  TSummaryReadTaint(Content f) or
+  TSummaryTaintStore(Content f)
+
+/**
+ * A summary of flow through a callable. This can either be value-preserving
+ * if no additional steps are used, taint-flow if at least one additional step
+ * is used, or any one of those combined with a store or a read. Summaries
+ * recorded at a return node are restricted to include at least one additional
+ * step, as the value-based summaries are calculated independent of the
+ * configuration.
+ */
+class Summary extends TSummary {
+  string toString() {
+    result = "Val" and this = TSummaryVal()
+    or
+    result = "Taint" and this = TSummaryTaint()
+    or
+    exists(Content f |
+      result = "ReadVal " + f.toString() and this = TSummaryReadVal(f)
+      or
+      result = "ReadTaint " + f.toString() and this = TSummaryReadTaint(f)
+      or
+      result = "TaintStore " + f.toString() and this = TSummaryTaintStore(f)
+    )
+  }
+
+  /** Gets the summary that results from extending this with an additional step. */
+  Summary additionalStep() {
+    this = TSummaryVal() and result = TSummaryTaint()
+    or
+    this = TSummaryTaint() and result = TSummaryTaint()
+    or
+    exists(Content f | this = TSummaryReadVal(f) and result = TSummaryReadTaint(f))
+    or
+    exists(Content f | this = TSummaryReadTaint(f) and result = TSummaryReadTaint(f))
+  }
+
+  /** Gets the summary that results from extending this with a read. */
+  Summary readStep(Content f) { this = TSummaryVal() and result = TSummaryReadVal(f) }
+
+  /** Gets the summary that results from extending this with a store. */
+  Summary storeStep(Content f) { this = TSummaryTaint() and result = TSummaryTaintStore(f) }
+
+  /** Gets the summary that results from extending this with `step`. */
+  bindingset[this, step]
+  Summary compose(Summary step) {
+    this = TSummaryVal() and result = step
+    or
+    this = TSummaryTaint() and
+    (step = TSummaryTaint() or step = TSummaryTaintStore(_)) and
+    result = step
+    or
+    exists(Content f |
+      this = TSummaryReadVal(f) and step = TSummaryTaint() and result = TSummaryReadTaint(f)
+    )
+    or
+    this = TSummaryReadTaint(_) and step = TSummaryTaint() and result = this
+  }
+
+  /** Holds if this summary does not include any taint steps. */
+  predicate isPartial() {
+    this = TSummaryVal() or
+    this = TSummaryReadVal(_)
+  }
+}
+
+pragma[noinline]
+DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
+
+predicate readDirect = readStep/3;

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -3,7 +3,7 @@ private import cil
 private import dotnet
 private import DataFlowPublic
 private import DataFlowDispatch
-private import DataFlowImplCommon::Public
+private import DataFlowImplCommon
 private import ControlFlowReachability
 private import DelegateDataFlow
 private import semmle.code.csharp.Caching

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1504,4 +1504,4 @@ private predicate viableConstantBooleanParamArg(
   )
 }
 
-int flowThroughAccessPathLimit() { result = 3 }
+int accessPathLimit() { result = 3 }

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -380,7 +380,9 @@ private module Cached {
         a = cfn.getElement() and
         t = a.stripCasts().getType()
       |
-        t instanceof RefType or
+        t instanceof RefType and
+        not t instanceof NullType
+        or
         t = any(TypeParameter tp | not tp.isValueType())
       )
       or
@@ -1501,3 +1503,5 @@ private predicate viableConstantBooleanParamArg(
     b = arg.getBooleanValue()
   )
 }
+
+int flowThroughAccessPathLimit() { result = 3 }

--- a/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/call-sensitivity/CallSensitivityFlow.expected
@@ -69,7 +69,6 @@ nodes
 | CallSensitivityFlow.cs:175:21:175:32 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
 | CallSensitivityFlow.cs:189:40:189:40 | o : Object | semmle.label | o : Object |
 | CallSensitivityFlow.cs:192:18:192:18 | access to parameter o | semmle.label | access to parameter o |
-| CallSensitivityFlow.cs:203:22:203:22 | access to parameter o | semmle.label | access to parameter o |
 #select
 | CallSensitivityFlow.cs:78:24:78:35 | object creation of type Object : Object | CallSensitivityFlow.cs:78:24:78:35 | object creation of type Object : Object | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o | $@ | CallSensitivityFlow.cs:23:18:23:18 | access to parameter o | access to parameter o |
 | CallSensitivityFlow.cs:79:25:79:36 | object creation of type Object : Object | CallSensitivityFlow.cs:79:25:79:36 | object creation of type Object : Object | CallSensitivityFlow.cs:31:18:31:18 | access to parameter o | $@ | CallSensitivityFlow.cs:31:18:31:18 | access to parameter o | access to parameter o |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -174,6 +174,9 @@ edges
 | G.cs:52:14:52:21 | access to field boxfield [Box1, Elem] | G.cs:52:14:52:26 | access to field Box1 [Elem] : Elem |
 | G.cs:52:14:52:21 | this access [boxfield, Box1, ... (3)] | G.cs:52:14:52:21 | access to field boxfield [Box1, Elem] |
 | G.cs:52:14:52:26 | access to field Box1 [Elem] : Elem | G.cs:52:14:52:31 | access to field Elem |
+| H.cs:88:17:88:17 | [post] access to local variable a [FieldA] : Object | H.cs:89:14:89:14 | access to local variable a [FieldA] : Object |
+| H.cs:88:20:88:31 | object creation of type Object : Object | H.cs:88:17:88:17 | [post] access to local variable a [FieldA] : Object |
+| H.cs:89:14:89:14 | access to local variable a [FieldA] : Object | H.cs:89:14:89:21 | access to field FieldA |
 nodes
 | A.cs:5:17:5:23 | object creation of type C : C | semmle.label | object creation of type C : C |
 | A.cs:6:17:6:25 | call to method Make [c] : C | semmle.label | call to method Make [c] : C |
@@ -371,6 +374,10 @@ nodes
 | G.cs:52:14:52:21 | this access [boxfield, Box1, ... (3)] | semmle.label | this access [boxfield, Box1, ... (3)] |
 | G.cs:52:14:52:26 | access to field Box1 [Elem] : Elem | semmle.label | access to field Box1 [Elem] : Elem |
 | G.cs:52:14:52:31 | access to field Elem | semmle.label | access to field Elem |
+| H.cs:88:17:88:17 | [post] access to local variable a [FieldA] : Object | semmle.label | [post] access to local variable a [FieldA] : Object |
+| H.cs:88:20:88:31 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| H.cs:89:14:89:14 | access to local variable a [FieldA] : Object | semmle.label | access to local variable a [FieldA] : Object |
+| H.cs:89:14:89:21 | access to field FieldA | semmle.label | access to field FieldA |
 #select
 | A.cs:7:14:7:16 | access to field c | A.cs:5:17:5:23 | object creation of type C : C | A.cs:7:14:7:16 | access to field c | $@ | A.cs:5:17:5:23 | object creation of type C : C | object creation of type C : C |
 | A.cs:14:14:14:20 | call to method Get | A.cs:13:15:13:22 | object creation of type C1 : C1 | A.cs:14:14:14:20 | call to method Get | $@ | A.cs:13:15:13:22 | object creation of type C1 : C1 | object creation of type C1 : C1 |
@@ -410,3 +417,4 @@ nodes
 | G.cs:39:14:39:35 | call to method GetElem | G.cs:23:18:23:27 | object creation of type Elem : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:23:18:23:27 | object creation of type Elem : Elem | object creation of type Elem : Elem |
 | G.cs:39:14:39:35 | call to method GetElem | G.cs:31:18:31:27 | object creation of type Elem : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:31:18:31:27 | object creation of type Elem : Elem | object creation of type Elem : Elem |
 | G.cs:52:14:52:31 | access to field Elem | G.cs:44:18:44:27 | object creation of type Elem : Elem | G.cs:52:14:52:31 | access to field Elem | $@ | G.cs:44:18:44:27 | object creation of type Elem : Elem | object creation of type Elem : Elem |
+| H.cs:89:14:89:21 | access to field FieldA | H.cs:88:20:88:31 | object creation of type Object : Object | H.cs:89:14:89:21 | access to field FieldA | $@ | H.cs:88:20:88:31 | object creation of type Object : Object | object creation of type Object : Object |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -174,9 +174,37 @@ edges
 | G.cs:52:14:52:21 | access to field boxfield [Box1, Elem] | G.cs:52:14:52:26 | access to field Box1 [Elem] : Elem |
 | G.cs:52:14:52:21 | this access [boxfield, Box1, ... (3)] | G.cs:52:14:52:21 | access to field boxfield [Box1, Elem] |
 | G.cs:52:14:52:26 | access to field Box1 [Elem] : Elem | G.cs:52:14:52:31 | access to field Elem |
+| H.cs:23:9:23:9 | [post] access to local variable a [FieldA] : Object | H.cs:24:27:24:27 | access to local variable a [FieldA] : Object |
+| H.cs:23:20:23:31 | object creation of type Object : Object | H.cs:23:9:23:9 | [post] access to local variable a [FieldA] : Object |
+| H.cs:24:21:24:28 | call to method Clone [FieldA] : Object | H.cs:25:14:25:18 | access to local variable clone [FieldA] : Object |
+| H.cs:24:27:24:27 | access to local variable a [FieldA] : Object | H.cs:24:21:24:28 | call to method Clone [FieldA] : Object |
+| H.cs:25:14:25:18 | access to local variable clone [FieldA] : Object | H.cs:25:14:25:25 | access to field FieldA |
+| H.cs:43:9:43:9 | [post] access to local variable a [FieldA] : Object | H.cs:44:27:44:27 | access to local variable a [FieldA] : Object |
+| H.cs:43:20:43:31 | object creation of type Object : Object | H.cs:43:9:43:9 | [post] access to local variable a [FieldA] : Object |
+| H.cs:44:17:44:28 | call to method Transform [FieldB] : Object | H.cs:45:14:45:14 | access to local variable b [FieldB] : Object |
+| H.cs:44:27:44:27 | access to local variable a [FieldA] : Object | H.cs:44:17:44:28 | call to method Transform [FieldB] : Object |
+| H.cs:45:14:45:14 | access to local variable b [FieldB] : Object | H.cs:45:14:45:21 | access to field FieldB |
+| H.cs:63:9:63:9 | [post] access to local variable a [FieldA] : Object | H.cs:64:22:64:22 | access to local variable a [FieldA] : Object |
+| H.cs:63:20:63:31 | object creation of type Object : Object | H.cs:63:9:63:9 | [post] access to local variable a [FieldA] : Object |
+| H.cs:64:22:64:22 | access to local variable a [FieldA] : Object | H.cs:64:25:64:26 | [post] access to local variable b1 [FieldB] : Object |
+| H.cs:64:25:64:26 | [post] access to local variable b1 [FieldB] : Object | H.cs:65:14:65:15 | access to local variable b1 [FieldB] : Object |
+| H.cs:65:14:65:15 | access to local variable b1 [FieldB] : Object | H.cs:65:14:65:22 | access to field FieldB |
 | H.cs:88:17:88:17 | [post] access to local variable a [FieldA] : Object | H.cs:89:14:89:14 | access to local variable a [FieldA] : Object |
 | H.cs:88:20:88:31 | object creation of type Object : Object | H.cs:88:17:88:17 | [post] access to local variable a [FieldA] : Object |
+| H.cs:88:20:88:31 | object creation of type Object : Object | H.cs:88:34:88:35 | [post] access to local variable b1 [FieldB] : Object |
+| H.cs:88:34:88:35 | [post] access to local variable b1 [FieldB] : Object | H.cs:90:14:90:15 | access to local variable b1 [FieldB] : Object |
 | H.cs:89:14:89:14 | access to local variable a [FieldA] : Object | H.cs:89:14:89:21 | access to field FieldA |
+| H.cs:90:14:90:15 | access to local variable b1 [FieldB] : Object | H.cs:90:14:90:22 | access to field FieldB |
+| H.cs:112:9:112:9 | [post] access to local variable a [FieldA] : Object | H.cs:113:31:113:31 | access to local variable a [FieldA] : Object |
+| H.cs:112:20:112:31 | object creation of type Object : Object | H.cs:112:9:112:9 | [post] access to local variable a [FieldA] : Object |
+| H.cs:113:17:113:32 | call to method TransformWrap [FieldB] : Object | H.cs:114:14:114:14 | access to local variable b [FieldB] : Object |
+| H.cs:113:31:113:31 | access to local variable a [FieldA] : Object | H.cs:113:17:113:32 | call to method TransformWrap [FieldB] : Object |
+| H.cs:114:14:114:14 | access to local variable b [FieldB] : Object | H.cs:114:14:114:21 | access to field FieldB |
+| H.cs:130:9:130:9 | [post] access to local variable a [FieldA] : Object | H.cs:131:18:131:18 | access to local variable a [FieldA] : Object |
+| H.cs:130:20:130:31 | object creation of type Object : Object | H.cs:130:9:130:9 | [post] access to local variable a [FieldA] : Object |
+| H.cs:131:18:131:18 | access to local variable a [FieldA] : Object | H.cs:131:14:131:19 | call to method Get |
+| H.cs:147:17:147:37 | call to method Through : Object | H.cs:148:14:148:14 | access to local variable o |
+| H.cs:147:25:147:36 | object creation of type Object : Object | H.cs:147:17:147:37 | call to method Through : Object |
 nodes
 | A.cs:5:17:5:23 | object creation of type C : C | semmle.label | object creation of type C : C |
 | A.cs:6:17:6:25 | call to method Make [c] : C | semmle.label | call to method Make [c] : C |
@@ -374,10 +402,44 @@ nodes
 | G.cs:52:14:52:21 | this access [boxfield, Box1, ... (3)] | semmle.label | this access [boxfield, Box1, ... (3)] |
 | G.cs:52:14:52:26 | access to field Box1 [Elem] : Elem | semmle.label | access to field Box1 [Elem] : Elem |
 | G.cs:52:14:52:31 | access to field Elem | semmle.label | access to field Elem |
+| H.cs:23:9:23:9 | [post] access to local variable a [FieldA] : Object | semmle.label | [post] access to local variable a [FieldA] : Object |
+| H.cs:23:20:23:31 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| H.cs:24:21:24:28 | call to method Clone [FieldA] : Object | semmle.label | call to method Clone [FieldA] : Object |
+| H.cs:24:27:24:27 | access to local variable a [FieldA] : Object | semmle.label | access to local variable a [FieldA] : Object |
+| H.cs:25:14:25:18 | access to local variable clone [FieldA] : Object | semmle.label | access to local variable clone [FieldA] : Object |
+| H.cs:25:14:25:25 | access to field FieldA | semmle.label | access to field FieldA |
+| H.cs:43:9:43:9 | [post] access to local variable a [FieldA] : Object | semmle.label | [post] access to local variable a [FieldA] : Object |
+| H.cs:43:20:43:31 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| H.cs:44:17:44:28 | call to method Transform [FieldB] : Object | semmle.label | call to method Transform [FieldB] : Object |
+| H.cs:44:27:44:27 | access to local variable a [FieldA] : Object | semmle.label | access to local variable a [FieldA] : Object |
+| H.cs:45:14:45:14 | access to local variable b [FieldB] : Object | semmle.label | access to local variable b [FieldB] : Object |
+| H.cs:45:14:45:21 | access to field FieldB | semmle.label | access to field FieldB |
+| H.cs:63:9:63:9 | [post] access to local variable a [FieldA] : Object | semmle.label | [post] access to local variable a [FieldA] : Object |
+| H.cs:63:20:63:31 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| H.cs:64:22:64:22 | access to local variable a [FieldA] : Object | semmle.label | access to local variable a [FieldA] : Object |
+| H.cs:64:25:64:26 | [post] access to local variable b1 [FieldB] : Object | semmle.label | [post] access to local variable b1 [FieldB] : Object |
+| H.cs:65:14:65:15 | access to local variable b1 [FieldB] : Object | semmle.label | access to local variable b1 [FieldB] : Object |
+| H.cs:65:14:65:22 | access to field FieldB | semmle.label | access to field FieldB |
 | H.cs:88:17:88:17 | [post] access to local variable a [FieldA] : Object | semmle.label | [post] access to local variable a [FieldA] : Object |
 | H.cs:88:20:88:31 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| H.cs:88:34:88:35 | [post] access to local variable b1 [FieldB] : Object | semmle.label | [post] access to local variable b1 [FieldB] : Object |
 | H.cs:89:14:89:14 | access to local variable a [FieldA] : Object | semmle.label | access to local variable a [FieldA] : Object |
 | H.cs:89:14:89:21 | access to field FieldA | semmle.label | access to field FieldA |
+| H.cs:90:14:90:15 | access to local variable b1 [FieldB] : Object | semmle.label | access to local variable b1 [FieldB] : Object |
+| H.cs:90:14:90:22 | access to field FieldB | semmle.label | access to field FieldB |
+| H.cs:112:9:112:9 | [post] access to local variable a [FieldA] : Object | semmle.label | [post] access to local variable a [FieldA] : Object |
+| H.cs:112:20:112:31 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| H.cs:113:17:113:32 | call to method TransformWrap [FieldB] : Object | semmle.label | call to method TransformWrap [FieldB] : Object |
+| H.cs:113:31:113:31 | access to local variable a [FieldA] : Object | semmle.label | access to local variable a [FieldA] : Object |
+| H.cs:114:14:114:14 | access to local variable b [FieldB] : Object | semmle.label | access to local variable b [FieldB] : Object |
+| H.cs:114:14:114:21 | access to field FieldB | semmle.label | access to field FieldB |
+| H.cs:130:9:130:9 | [post] access to local variable a [FieldA] : Object | semmle.label | [post] access to local variable a [FieldA] : Object |
+| H.cs:130:20:130:31 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| H.cs:131:14:131:19 | call to method Get | semmle.label | call to method Get |
+| H.cs:131:18:131:18 | access to local variable a [FieldA] : Object | semmle.label | access to local variable a [FieldA] : Object |
+| H.cs:147:17:147:37 | call to method Through : Object | semmle.label | call to method Through : Object |
+| H.cs:147:25:147:36 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
+| H.cs:148:14:148:14 | access to local variable o | semmle.label | access to local variable o |
 #select
 | A.cs:7:14:7:16 | access to field c | A.cs:5:17:5:23 | object creation of type C : C | A.cs:7:14:7:16 | access to field c | $@ | A.cs:5:17:5:23 | object creation of type C : C | object creation of type C : C |
 | A.cs:14:14:14:20 | call to method Get | A.cs:13:15:13:22 | object creation of type C1 : C1 | A.cs:14:14:14:20 | call to method Get | $@ | A.cs:13:15:13:22 | object creation of type C1 : C1 | object creation of type C1 : C1 |
@@ -417,4 +479,11 @@ nodes
 | G.cs:39:14:39:35 | call to method GetElem | G.cs:23:18:23:27 | object creation of type Elem : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:23:18:23:27 | object creation of type Elem : Elem | object creation of type Elem : Elem |
 | G.cs:39:14:39:35 | call to method GetElem | G.cs:31:18:31:27 | object creation of type Elem : Elem | G.cs:39:14:39:35 | call to method GetElem | $@ | G.cs:31:18:31:27 | object creation of type Elem : Elem | object creation of type Elem : Elem |
 | G.cs:52:14:52:31 | access to field Elem | G.cs:44:18:44:27 | object creation of type Elem : Elem | G.cs:52:14:52:31 | access to field Elem | $@ | G.cs:44:18:44:27 | object creation of type Elem : Elem | object creation of type Elem : Elem |
+| H.cs:25:14:25:25 | access to field FieldA | H.cs:23:20:23:31 | object creation of type Object : Object | H.cs:25:14:25:25 | access to field FieldA | $@ | H.cs:23:20:23:31 | object creation of type Object : Object | object creation of type Object : Object |
+| H.cs:45:14:45:21 | access to field FieldB | H.cs:43:20:43:31 | object creation of type Object : Object | H.cs:45:14:45:21 | access to field FieldB | $@ | H.cs:43:20:43:31 | object creation of type Object : Object | object creation of type Object : Object |
+| H.cs:65:14:65:22 | access to field FieldB | H.cs:63:20:63:31 | object creation of type Object : Object | H.cs:65:14:65:22 | access to field FieldB | $@ | H.cs:63:20:63:31 | object creation of type Object : Object | object creation of type Object : Object |
 | H.cs:89:14:89:21 | access to field FieldA | H.cs:88:20:88:31 | object creation of type Object : Object | H.cs:89:14:89:21 | access to field FieldA | $@ | H.cs:88:20:88:31 | object creation of type Object : Object | object creation of type Object : Object |
+| H.cs:90:14:90:22 | access to field FieldB | H.cs:88:20:88:31 | object creation of type Object : Object | H.cs:90:14:90:22 | access to field FieldB | $@ | H.cs:88:20:88:31 | object creation of type Object : Object | object creation of type Object : Object |
+| H.cs:114:14:114:21 | access to field FieldB | H.cs:112:20:112:31 | object creation of type Object : Object | H.cs:114:14:114:21 | access to field FieldB | $@ | H.cs:112:20:112:31 | object creation of type Object : Object | object creation of type Object : Object |
+| H.cs:131:14:131:19 | call to method Get | H.cs:130:20:130:31 | object creation of type Object : Object | H.cs:131:14:131:19 | call to method Get | $@ | H.cs:130:20:130:31 | object creation of type Object : Object | object creation of type Object : Object |
+| H.cs:148:14:148:14 | access to local variable o | H.cs:147:25:147:36 | object creation of type Object : Object | H.cs:148:14:148:14 | access to local variable o | $@ | H.cs:147:25:147:36 | object creation of type Object : Object | object creation of type Object : Object |

--- a/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
+++ b/csharp/ql/test/library-tests/dataflow/fields/FieldFlow.expected
@@ -203,8 +203,8 @@ edges
 | H.cs:130:9:130:9 | [post] access to local variable a [FieldA] : Object | H.cs:131:18:131:18 | access to local variable a [FieldA] : Object |
 | H.cs:130:20:130:31 | object creation of type Object : Object | H.cs:130:9:130:9 | [post] access to local variable a [FieldA] : Object |
 | H.cs:131:18:131:18 | access to local variable a [FieldA] : Object | H.cs:131:14:131:19 | call to method Get |
-| H.cs:147:17:147:37 | call to method Through : Object | H.cs:148:14:148:14 | access to local variable o |
-| H.cs:147:25:147:36 | object creation of type Object : Object | H.cs:147:17:147:37 | call to method Through : Object |
+| H.cs:147:17:147:32 | call to method Through : A | H.cs:148:14:148:14 | access to local variable a |
+| H.cs:147:25:147:31 | object creation of type A : A | H.cs:147:17:147:32 | call to method Through : A |
 nodes
 | A.cs:5:17:5:23 | object creation of type C : C | semmle.label | object creation of type C : C |
 | A.cs:6:17:6:25 | call to method Make [c] : C | semmle.label | call to method Make [c] : C |
@@ -437,9 +437,9 @@ nodes
 | H.cs:130:20:130:31 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
 | H.cs:131:14:131:19 | call to method Get | semmle.label | call to method Get |
 | H.cs:131:18:131:18 | access to local variable a [FieldA] : Object | semmle.label | access to local variable a [FieldA] : Object |
-| H.cs:147:17:147:37 | call to method Through : Object | semmle.label | call to method Through : Object |
-| H.cs:147:25:147:36 | object creation of type Object : Object | semmle.label | object creation of type Object : Object |
-| H.cs:148:14:148:14 | access to local variable o | semmle.label | access to local variable o |
+| H.cs:147:17:147:32 | call to method Through : A | semmle.label | call to method Through : A |
+| H.cs:147:25:147:31 | object creation of type A : A | semmle.label | object creation of type A : A |
+| H.cs:148:14:148:14 | access to local variable a | semmle.label | access to local variable a |
 #select
 | A.cs:7:14:7:16 | access to field c | A.cs:5:17:5:23 | object creation of type C : C | A.cs:7:14:7:16 | access to field c | $@ | A.cs:5:17:5:23 | object creation of type C : C | object creation of type C : C |
 | A.cs:14:14:14:20 | call to method Get | A.cs:13:15:13:22 | object creation of type C1 : C1 | A.cs:14:14:14:20 | call to method Get | $@ | A.cs:13:15:13:22 | object creation of type C1 : C1 | object creation of type C1 : C1 |
@@ -486,4 +486,4 @@ nodes
 | H.cs:90:14:90:22 | access to field FieldB | H.cs:88:20:88:31 | object creation of type Object : Object | H.cs:90:14:90:22 | access to field FieldB | $@ | H.cs:88:20:88:31 | object creation of type Object : Object | object creation of type Object : Object |
 | H.cs:114:14:114:21 | access to field FieldB | H.cs:112:20:112:31 | object creation of type Object : Object | H.cs:114:14:114:21 | access to field FieldB | $@ | H.cs:112:20:112:31 | object creation of type Object : Object | object creation of type Object : Object |
 | H.cs:131:14:131:19 | call to method Get | H.cs:130:20:130:31 | object creation of type Object : Object | H.cs:131:14:131:19 | call to method Get | $@ | H.cs:130:20:130:31 | object creation of type Object : Object | object creation of type Object : Object |
-| H.cs:148:14:148:14 | access to local variable o | H.cs:147:25:147:36 | object creation of type Object : Object | H.cs:148:14:148:14 | access to local variable o | $@ | H.cs:147:25:147:36 | object creation of type Object : Object | object creation of type Object : Object |
+| H.cs:148:14:148:14 | access to local variable a | H.cs:147:25:147:31 | object creation of type A : A | H.cs:148:14:148:14 | access to local variable a | $@ | H.cs:147:25:147:31 | object creation of type A : A | object creation of type A : A |

--- a/csharp/ql/test/library-tests/dataflow/fields/H.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/H.cs
@@ -22,7 +22,7 @@ public class H
         var a = new A();
         a.FieldA = new object();
         var clone = Clone(a);
-        Sink(clone.FieldA); // flow [MISSING]
+        Sink(clone.FieldA); // flow
         
         a = new A();
         a.FieldA = o;
@@ -42,7 +42,7 @@ public class H
         var a = new A();
         a.FieldA = new object();
         var b = Transform(a);
-        Sink(b.FieldB); // flow [MISSING]
+        Sink(b.FieldB); // flow
 
         a = new A();
         a.FieldA = o;
@@ -62,7 +62,7 @@ public class H
         var b2 = new B();
         a.FieldA = new object();
         TransformArg(a, b1, b2);
-        Sink(b1.FieldB); // flow [MISSING]
+        Sink(b1.FieldB); // flow
         Sink(b2.FieldB); // no flow
 
         a = new A();
@@ -87,7 +87,7 @@ public class H
         var b2 = new B();
         SetArgs(a, new object(), b1, b2);
         Sink(a.FieldA); // flow
-        Sink(b1.FieldB); // flow [MISSING]
+        Sink(b1.FieldB); // flow
         Sink(b2.FieldB); // no flow
 
         a = new A();
@@ -111,7 +111,7 @@ public class H
         var a = new A();
         a.FieldA = new object();
         var b = TransformWrap(a);
-        Sink(b.FieldB); // flow [MISSING]
+        Sink(b.FieldB); // flow
 
         a = new A();
         a.FieldA = o;
@@ -128,7 +128,7 @@ public class H
     {
         var a = new A();
         a.FieldA = new object();
-        Sink(Get(a)); // flow [MISSING]
+        Sink(Get(a)); // flow
 
         a = new A();
         a.FieldA = o;
@@ -145,7 +145,7 @@ public class H
     void M7()
     {
         var o = Through(new object());
-        Sink(o); // flow [MISSING]
+        Sink(o); // flow
     }
 
     public static void Sink(object o) { }

--- a/csharp/ql/test/library-tests/dataflow/fields/H.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/H.cs
@@ -1,0 +1,152 @@
+public class H
+{
+    class A
+    {
+        public object FieldA;
+    }
+
+    class B
+    {
+        public object FieldB;
+    }
+
+    A Clone(A a)
+    {
+        var ret = new A();
+        ret.FieldA = a.FieldA;
+        return ret;
+    }
+
+    void M1(object o)
+    {
+        var a = new A();
+        a.FieldA = new object();
+        var clone = Clone(a);
+        Sink(clone.FieldA); // flow [MISSING]
+        
+        a = new A();
+        a.FieldA = o;
+        clone = Clone(a);
+        Sink(clone.FieldA); // no flow
+    }
+
+    B Transform(A a)
+    {
+        var b = new B();
+        b.FieldB = a.FieldA;
+        return b;
+    }
+
+    void M2(object o)
+    {
+        var a = new A();
+        a.FieldA = new object();
+        var b = Transform(a);
+        Sink(b.FieldB); // flow [MISSING]
+
+        a = new A();
+        a.FieldA = o;
+        b = Transform(a);
+        Sink(b.FieldB); // no flow
+    }
+
+    void TransformArg(A a, B b1, B b2)
+    {
+        b1.FieldB = a.FieldA;
+    }
+
+    void M3(object o)
+    {
+        var a = new A();
+        var b1 = new B();
+        var b2 = new B();
+        a.FieldA = new object();
+        TransformArg(a, b1, b2);
+        Sink(b1.FieldB); // flow [MISSING]
+        Sink(b2.FieldB); // no flow
+
+        a = new A();
+        b1 = new B();
+        b2 = new B();
+        a.FieldA = o;
+        TransformArg(a, b1, b2);
+        Sink(b1.FieldB); // no flow
+        Sink(b2.FieldB); // no flow
+    }
+
+    void SetArgs(A a, object o, B b1, B b2)
+    {
+        a.FieldA = o;
+        TransformArg(a, b1, b2);
+    }
+
+    void M4(object o)
+    {
+        var a = new A();
+        var b1 = new B();
+        var b2 = new B();
+        SetArgs(a, new object(), b1, b2);
+        Sink(a.FieldA); // flow
+        Sink(b1.FieldB); // flow [MISSING]
+        Sink(b2.FieldB); // no flow
+
+        a = new A();
+        b1 = new B();
+        b2 = new B();
+        SetArgs(a, o, b1, b2);
+        Sink(a.FieldA); // no flow
+        Sink(b1.FieldB); // no flow
+        Sink(b2.FieldB); // no flow
+    }
+
+    B TransformWrap(A a)
+    {
+        var temp = new B();
+        temp.FieldB = a;
+        return Transform((A)temp.FieldB);
+    }
+
+    void M5(object o)
+    {
+        var a = new A();
+        a.FieldA = new object();
+        var b = TransformWrap(a);
+        Sink(b.FieldB); // flow [MISSING]
+
+        a = new A();
+        a.FieldA = o;
+        b = TransformWrap(a);
+        Sink(b.FieldB); // no flow
+    }
+
+    object Get(A a)
+    {
+        return Transform(a).FieldB;
+    }
+
+    void M6(object o)
+    {
+        var a = new A();
+        a.FieldA = new object();
+        Sink(Get(a)); // flow [MISSING]
+
+        a = new A();
+        a.FieldA = o;
+        Sink(Get(a)); // no flow
+    }
+
+    object Through(object o)
+    {
+        var a = new A();
+        a.FieldA = o;
+        return Transform(a).FieldB;
+    }
+
+    void M7()
+    {
+        var o = Through(new object());
+        Sink(o); // flow [MISSING]
+    }
+
+    public static void Sink(object o) { }
+}

--- a/csharp/ql/test/library-tests/dataflow/fields/H.cs
+++ b/csharp/ql/test/library-tests/dataflow/fields/H.cs
@@ -138,14 +138,16 @@ public class H
     object Through(object o)
     {
         var a = new A();
-        a.FieldA = o;
+        a.FieldA = o as A;
         return Transform(a).FieldB;
     }
 
     void M7()
     {
-        var o = Through(new object());
-        Sink(o); // flow
+        var a = Through(new A());
+        Sink(a); // flow
+        var b = Through(new B());
+        Sink(b); // no flow
     }
 
     public static void Sink(object o) { }

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
@@ -1004,6 +1004,7 @@
 | GlobalDataFlow.cs:70:21:70:46 | call to method Return : T | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return : String |
+| GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return : T |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 : String | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 |
@@ -1083,10 +1084,14 @@
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T | GlobalDataFlow.cs:72:21:72:101 | (...) ... |
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T | GlobalDataFlow.cs:72:21:72:101 | (...) ... : T |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
+| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : Object |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : String |
+| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
+| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : Object |
+| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:275:26:275:26 | x : T |
@@ -1116,6 +1121,8 @@
 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : Object |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : String |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 : Object |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
@@ -1125,7 +1132,9 @@
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:281:32:281:32 | x : Object |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : Object |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : String |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 : String |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
@@ -1135,6 +1144,8 @@
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:281:32:281:32 | x : String |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : Object |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 : T |
@@ -1174,13 +1185,19 @@
 | GlobalDataFlow.cs:77:21:77:22 | "" : String | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 : String |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : Object |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : String |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : T |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:287:32:287:32 | x : Object |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : Object |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : String |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : T |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:287:32:287:32 | x : String |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : Object |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : String |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : T |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:287:32:287:32 | x : T |
@@ -1472,6 +1489,7 @@
 | GlobalDataFlow.cs:100:24:100:33 | call to method Return : T | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return : String |
+| GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return : T |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:101:15:101:22 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 |
@@ -1503,15 +1521,20 @@
 | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T | GlobalDataFlow.cs:102:20:102:103 | (...) ... |
 | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T | GlobalDataFlow.cs:102:20:102:103 | (...) ... : T |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
+| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : Object |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : String |
+| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
+| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : Object |
+| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : String |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:275:26:275:26 | x : T |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) : String |
+| GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) : T |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:281:32:281:32 | x : String |
 | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) : String | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 |
@@ -1558,6 +1581,7 @@
 | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 : T | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) : String |
+| GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) : T |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:287:32:287:32 | x : String |
 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) : String | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
@@ -1606,17 +1630,23 @@
 | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 : T | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : Object |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : String |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : Object |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:287:32:287:32 | x : Object |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : Object |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : String |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : String |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:287:32:287:32 | x : String |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : Object |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : String |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : T |
@@ -1846,6 +1876,8 @@
 | GlobalDataFlow.cs:134:40:134:64 | (...) => ... : Func<String,String> | GlobalDataFlow.cs:135:21:135:27 | access to local variable return : Func<String,String> |
 | GlobalDataFlow.cs:134:40:134:64 | (...) => ... : Func<String,String> | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
 | GlobalDataFlow.cs:134:40:134:64 | (...) => ... : Func<String,String> | GlobalDataFlow.cs:139:20:139:26 | access to local variable return : Func<String,String> |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
 | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String | GlobalDataFlow.cs:135:21:135:34 | delegate call |
 | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
 | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String | GlobalDataFlow.cs:139:20:139:36 | delegate call |
@@ -1858,17 +1890,25 @@
 | GlobalDataFlow.cs:134:55:134:60 | delegate creation of type Func<String,String> : Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f : Func<String,String> |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x : Object |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
@@ -1908,13 +1948,19 @@
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:134:40:134:40 | x : Object |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : T |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:134:40:134:40 | x |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:134:40:134:40 | x : String |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : T |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:134:40:134:40 | x |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:134:40:134:40 | x : T |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call : T |
 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object |
@@ -1938,6 +1984,7 @@
 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:134:40:134:40 | x : String |
 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:139:20:139:36 | delegate call |
 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:139:20:139:36 | delegate call : String |
+| GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:139:20:139:36 | delegate call : T |
 | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) : Object | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
 | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) : Object | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 : Object |
 | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) : Object | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
@@ -1972,13 +2019,19 @@
 | GlobalDataFlow.cs:143:31:143:36 | delegate creation of type Func<String,String> : Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f : Func<String,String> |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:364:46:364:46 | x : Object |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
@@ -2004,8 +2057,13 @@
 | GlobalDataFlow.cs:147:30:147:35 | delegate creation of type Func<String,String> : Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f : Func<String,String> |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : String |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
@@ -2014,6 +2072,12 @@
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : T | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : T | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : T | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object |
 | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String |
 | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
@@ -2036,6 +2100,8 @@
 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 : T | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
+| GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object |
 | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String |
 | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
@@ -2146,10 +2212,16 @@
 | GlobalDataFlow.cs:161:22:161:31 | this access : DataFlow | GlobalDataFlow.cs:201:20:201:33 | this access : DataFlow |
 | GlobalDataFlow.cs:161:22:161:31 | this access : DataFlow | GlobalDataFlow.cs:331:25:331:32 | this |
 | GlobalDataFlow.cs:161:22:161:31 | this access : DataFlow | GlobalDataFlow.cs:331:25:331:32 | this : DataFlow |
+| GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : Object |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : String | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : String | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : String |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : T |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : Object |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : Object |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : String |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
@@ -2158,11 +2230,21 @@
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : T |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : T |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:378:39:378:45 | tainted |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:378:39:378:45 | tainted : Object |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:378:39:378:45 | tainted |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:378:39:378:45 | tainted : String |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:378:39:378:45 | tainted |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:378:39:378:45 | tainted : T |
@@ -2599,20 +2681,36 @@
 | GlobalDataFlow.cs:275:26:275:26 | x : T | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T |
 | GlobalDataFlow.cs:275:26:275:26 | x : T | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
@@ -2631,24 +2729,44 @@
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
@@ -2684,14 +2802,22 @@
 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x : Object |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x |
@@ -2699,16 +2825,28 @@
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
@@ -2722,6 +2860,22 @@
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : Object |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : Object |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return : String |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : String |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return : String |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : String |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T | GlobalDataFlow.cs:70:21:70:46 | call to method Return : T |
 | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
@@ -2735,8 +2889,12 @@
 | GlobalDataFlow.cs:278:28:278:37 | default(...) : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
 | GlobalDataFlow.cs:278:28:278:37 | default(...) : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
@@ -2952,8 +3110,36 @@
 | GlobalDataFlow.cs:364:46:364:46 | x : T | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T |
 | GlobalDataFlow.cs:364:46:364:46 | x : T | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T |
 | GlobalDataFlow.cs:364:46:364:46 | x : T | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
@@ -2984,6 +3170,12 @@
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:26 | x |
@@ -2996,10 +3188,18 @@
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:275:26:275:26 | x |
@@ -3014,6 +3214,14 @@
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
@@ -3054,6 +3262,14 @@
 | GlobalDataFlow.cs:375:11:375:11 | access to parameter x : String | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
 | GlobalDataFlow.cs:375:11:375:11 | access to parameter x : String | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 : String |
 | GlobalDataFlow.cs:375:11:375:11 | access to parameter x : String | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 : String |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String |
@@ -3078,6 +3294,10 @@
 | GlobalDataFlow.cs:378:39:378:45 | tainted : T | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : T |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : T |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String |
@@ -3090,6 +3310,12 @@
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : T | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : T |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : T |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String |
@@ -3108,6 +3334,8 @@
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : T | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : T |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : T |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : String |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowEdges.expected
@@ -1004,7 +1004,6 @@
 | GlobalDataFlow.cs:70:21:70:46 | call to method Return : T | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return : String |
-| GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return : T |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 : String | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 |
@@ -1084,14 +1083,10 @@
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T | GlobalDataFlow.cs:72:21:72:101 | (...) ... |
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T | GlobalDataFlow.cs:72:21:72:101 | (...) ... : T |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
-| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : Object |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : String |
-| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
-| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : Object |
-| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:275:26:275:26 | x : T |
@@ -1121,8 +1116,6 @@
 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : Object |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : String |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 : Object |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
@@ -1132,9 +1125,7 @@
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:281:32:281:32 | x : Object |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : Object |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : String |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 : String |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
@@ -1144,8 +1135,6 @@
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:281:32:281:32 | x : String |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : Object |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 : T |
@@ -1185,19 +1174,13 @@
 | GlobalDataFlow.cs:77:21:77:22 | "" : String | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 : String |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : Object |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : T |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:287:32:287:32 | x : Object |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : Object |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : T |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:287:32:287:32 | x : String |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : Object |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : String |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : T |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:287:32:287:32 | x : T |
@@ -1489,7 +1472,6 @@
 | GlobalDataFlow.cs:100:24:100:33 | call to method Return : T | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return : String |
-| GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return : T |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:101:15:101:22 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 |
@@ -1521,20 +1503,15 @@
 | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T | GlobalDataFlow.cs:102:20:102:103 | (...) ... |
 | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T | GlobalDataFlow.cs:102:20:102:103 | (...) ... : T |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
-| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : Object |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : String |
-| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
-| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : Object |
-| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : String |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:275:26:275:26 | x : T |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) : String |
-| GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) : T |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:281:32:281:32 | x : String |
 | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) : String | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 |
@@ -1581,7 +1558,6 @@
 | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 : T | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) : String |
-| GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) : T |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:287:32:287:32 | x : String |
 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) : String | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
@@ -1630,23 +1606,17 @@
 | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 : T | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : Object |
-| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : String |
-| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : Object |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:287:32:287:32 | x : Object |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
-| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : Object |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : String |
-| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : String |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:287:32:287:32 | x : String |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
-| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : Object |
-| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : String |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : T |
@@ -1876,8 +1846,6 @@
 | GlobalDataFlow.cs:134:40:134:64 | (...) => ... : Func<String,String> | GlobalDataFlow.cs:135:21:135:27 | access to local variable return : Func<String,String> |
 | GlobalDataFlow.cs:134:40:134:64 | (...) => ... : Func<String,String> | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
 | GlobalDataFlow.cs:134:40:134:64 | (...) => ... : Func<String,String> | GlobalDataFlow.cs:139:20:139:26 | access to local variable return : Func<String,String> |
-| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call |
-| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
 | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String | GlobalDataFlow.cs:135:21:135:34 | delegate call |
 | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
 | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String | GlobalDataFlow.cs:139:20:139:36 | delegate call |
@@ -1890,25 +1858,17 @@
 | GlobalDataFlow.cs:134:55:134:60 | delegate creation of type Func<String,String> : Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f : Func<String,String> |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x : Object |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
@@ -1948,19 +1908,13 @@
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:134:40:134:40 | x : Object |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
-| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
-| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : T |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:134:40:134:40 | x |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:134:40:134:40 | x : String |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call |
-| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
-| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : T |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:134:40:134:40 | x |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:134:40:134:40 | x : T |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call |
-| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
-| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call : T |
 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object |
@@ -1984,7 +1938,6 @@
 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:134:40:134:40 | x : String |
 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:139:20:139:36 | delegate call |
 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:139:20:139:36 | delegate call : String |
-| GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:139:20:139:36 | delegate call : T |
 | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) : Object | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
 | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) : Object | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 : Object |
 | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) : Object | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
@@ -2019,19 +1972,13 @@
 | GlobalDataFlow.cs:143:31:143:36 | delegate creation of type Func<String,String> : Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f : Func<String,String> |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:364:46:364:46 | x : Object |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
@@ -2057,13 +2004,8 @@
 | GlobalDataFlow.cs:147:30:147:35 | delegate creation of type Func<String,String> : Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f : Func<String,String> |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
-| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object |
-| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : String |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
@@ -2072,12 +2014,6 @@
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : T | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : T | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : T | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T |
-| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object |
-| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object |
-| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object |
 | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String |
 | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
@@ -2100,8 +2036,6 @@
 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 : T | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
-| GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object |
 | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String |
 | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
@@ -2212,16 +2146,10 @@
 | GlobalDataFlow.cs:161:22:161:31 | this access : DataFlow | GlobalDataFlow.cs:201:20:201:33 | this access : DataFlow |
 | GlobalDataFlow.cs:161:22:161:31 | this access : DataFlow | GlobalDataFlow.cs:331:25:331:32 | this |
 | GlobalDataFlow.cs:161:22:161:31 | this access : DataFlow | GlobalDataFlow.cs:331:25:331:32 | this : DataFlow |
-| GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : Object |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : String | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : String | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : String |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : T |
-| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) |
-| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : Object |
-| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : Object |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : String |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
@@ -2230,21 +2158,11 @@
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : T |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : T |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:378:39:378:45 | tainted |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:378:39:378:45 | tainted : Object |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:378:39:378:45 | tainted |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:378:39:378:45 | tainted : String |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:378:39:378:45 | tainted |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:378:39:378:45 | tainted : T |
@@ -2681,36 +2599,20 @@
 | GlobalDataFlow.cs:275:26:275:26 | x : T | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T |
 | GlobalDataFlow.cs:275:26:275:26 | x : T | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
@@ -2729,44 +2631,24 @@
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
@@ -2802,22 +2684,14 @@
 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x : Object |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x |
@@ -2825,28 +2699,16 @@
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
@@ -2860,22 +2722,6 @@
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : Object |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : Object |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return : String |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : String |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return : String |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : String |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T | GlobalDataFlow.cs:70:21:70:46 | call to method Return : T |
 | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
@@ -2889,12 +2735,8 @@
 | GlobalDataFlow.cs:278:28:278:37 | default(...) : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
 | GlobalDataFlow.cs:278:28:278:37 | default(...) : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
@@ -3110,36 +2952,8 @@
 | GlobalDataFlow.cs:364:46:364:46 | x : T | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T |
 | GlobalDataFlow.cs:364:46:364:46 | x : T | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T |
 | GlobalDataFlow.cs:364:46:364:46 | x : T | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
@@ -3170,12 +2984,6 @@
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:26 | x |
@@ -3188,18 +2996,10 @@
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:275:26:275:26 | x |
@@ -3214,14 +3014,6 @@
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
@@ -3262,14 +3054,6 @@
 | GlobalDataFlow.cs:375:11:375:11 | access to parameter x : String | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 |
 | GlobalDataFlow.cs:375:11:375:11 | access to parameter x : String | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 : String |
 | GlobalDataFlow.cs:375:11:375:11 | access to parameter x : String | GlobalDataFlow.cs:260:26:260:35 | sinkParam6 : String |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String |
@@ -3294,10 +3078,6 @@
 | GlobalDataFlow.cs:378:39:378:45 | tainted : T | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : T |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : T |
-| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object |
-| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String |
@@ -3310,12 +3090,6 @@
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : T | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : T |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : T |
-| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object |
-| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object |
-| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String |
@@ -3334,8 +3108,6 @@
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : T | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : T |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : T |
-| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : String |

--- a/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/DataFlowPath.expected
@@ -269,8 +269,6 @@ nodes
 | GlobalDataFlow.cs:56:37:56:37 | x : String | semmle.label | x : String |
 | GlobalDataFlow.cs:56:46:56:46 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 : String | semmle.label | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:60:38:60:50 | access to parameter nonSinkParam0 | semmle.label | access to parameter nonSinkParam0 |
-| GlobalDataFlow.cs:61:61:61:73 | access to parameter nonSinkParam0 | semmle.label | access to parameter nonSinkParam0 |
 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 : String | semmle.label | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:70:21:70:46 | call to method Return : String | semmle.label | call to method Return : String |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | semmle.label | access to property SinkProperty0 : String |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
@@ -1824,6 +1824,8 @@
 | GlobalDataFlow.cs:84:126:84:126 | x : Object | GlobalDataFlow.cs:84:135:84:135 | access to parameter x : String |
 | GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x |
 | GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x |
+| GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x |
+| GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x : String |
 | GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x : String |
 | GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x : String |
 | GlobalDataFlow.cs:84:126:84:126 | x : String[] | GlobalDataFlow.cs:84:126:84:126 | x |
@@ -1904,6 +1906,8 @@
 | GlobalDataFlow.cs:86:129:86:129 | y : Object | GlobalDataFlow.cs:86:135:86:135 | access to parameter y : String |
 | GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y |
 | GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y |
+| GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y |
+| GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y : String |
 | GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y : String |
 | GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y : String |
 | GlobalDataFlow.cs:86:129:86:129 | y : String[] | GlobalDataFlow.cs:86:129:86:129 | y |
@@ -2124,10 +2128,14 @@
 | GlobalDataFlow.cs:90:97:90:97 | s : Object | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
+| GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
+| GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s |
+| GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s |
+| GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String[] | GlobalDataFlow.cs:90:97:90:97 | s |
@@ -2144,6 +2152,8 @@
 | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String | GlobalDataFlow.cs:90:91:90:109 | [output] (...) => ... : String |
 | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
 | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
+| GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
+| GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:112:90:112 | x : Object | GlobalDataFlow.cs:90:112:90:112 | x |
@@ -2592,6 +2602,8 @@
 | GlobalDataFlow.cs:114:76:114:76 | x : Object | GlobalDataFlow.cs:114:81:114:81 | access to parameter x : String |
 | GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
 | GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
+| GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
+| GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x : String |
 | GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x : String |
 | GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x : String |
 | GlobalDataFlow.cs:114:76:114:76 | x : String[] | GlobalDataFlow.cs:114:76:114:76 | x |
@@ -2658,6 +2670,8 @@
 | GlobalDataFlow.cs:116:127:116:127 | y : Object | GlobalDataFlow.cs:116:133:116:133 | access to parameter y : String |
 | GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
 | GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
+| GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
+| GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y : String |
 | GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y : String |
 | GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y : String |
 | GlobalDataFlow.cs:116:127:116:127 | y : String[] | GlobalDataFlow.cs:116:127:116:127 | y |
@@ -2720,6 +2734,8 @@
 | GlobalDataFlow.cs:118:124:118:124 | x : Object | GlobalDataFlow.cs:118:133:118:133 | access to parameter x : String |
 | GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
 | GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
+| GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
+| GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x : String |
 | GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x : String |
 | GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x : String |
 | GlobalDataFlow.cs:118:124:118:124 | x : String[] | GlobalDataFlow.cs:118:124:118:124 | x |
@@ -4252,14 +4268,20 @@
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : String[] | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> |
@@ -4827,6 +4849,10 @@
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
@@ -4871,20 +4897,32 @@
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x : T |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
@@ -1190,6 +1190,7 @@
 | GlobalDataFlow.cs:70:21:70:46 | call to method Return : T | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return : String |
+| GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return : T |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 : String | GlobalDataFlow.cs:72:79:72:100 | array creation of type Object[] |
@@ -1273,12 +1274,16 @@
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T | GlobalDataFlow.cs:72:21:72:101 | (...) ... |
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T | GlobalDataFlow.cs:72:21:72:101 | (...) ... : T |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
+| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : Object |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : String |
+| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:79:72:100 | array creation of type Object[] |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:79:72:100 | array creation of type Object[] : Object[] |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
+| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : Object |
+| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:79:72:100 | array creation of type Object[] |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:79:72:100 | array creation of type Object[] : Object[] |
@@ -1310,6 +1315,8 @@
 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : Object |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : String |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 : Object |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
@@ -1319,7 +1326,9 @@
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:281:32:281:32 | x : Object |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : Object |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : String |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 : String |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
@@ -1329,6 +1338,8 @@
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:281:32:281:32 | x : String |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : Object |
+| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 : T |
@@ -1368,13 +1379,19 @@
 | GlobalDataFlow.cs:77:21:77:22 | "" : String | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 : String |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : Object |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : String |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : T |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:287:32:287:32 | x : Object |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : Object |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : String |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : T |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:287:32:287:32 | x : String |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : Object |
+| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : String |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : T |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:287:32:287:32 | x : T |
@@ -1824,8 +1841,6 @@
 | GlobalDataFlow.cs:84:126:84:126 | x : Object | GlobalDataFlow.cs:84:135:84:135 | access to parameter x : String |
 | GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x |
 | GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x |
-| GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x |
-| GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x : String |
 | GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x : String |
 | GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x : String |
 | GlobalDataFlow.cs:84:126:84:126 | x : String[] | GlobalDataFlow.cs:84:126:84:126 | x |
@@ -1906,8 +1921,6 @@
 | GlobalDataFlow.cs:86:129:86:129 | y : Object | GlobalDataFlow.cs:86:135:86:135 | access to parameter y : String |
 | GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y |
 | GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y |
-| GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y |
-| GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y : String |
 | GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y : String |
 | GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y : String |
 | GlobalDataFlow.cs:86:129:86:129 | y : String[] | GlobalDataFlow.cs:86:129:86:129 | y |
@@ -2128,14 +2141,10 @@
 | GlobalDataFlow.cs:90:97:90:97 | s : Object | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
-| GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
-| GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s |
-| GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s |
-| GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String[] | GlobalDataFlow.cs:90:97:90:97 | s |
@@ -2152,8 +2161,6 @@
 | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String | GlobalDataFlow.cs:90:91:90:109 | [output] (...) => ... : String |
 | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
 | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
-| GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
-| GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:112:90:112 | x : Object | GlobalDataFlow.cs:90:112:90:112 | x |
@@ -2262,6 +2269,7 @@
 | GlobalDataFlow.cs:100:24:100:33 | call to method Return : T | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return : String |
+| GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return : T |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:101:15:101:22 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:78:102:102 | array creation of type Object[] |
@@ -2297,12 +2305,16 @@
 | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T | GlobalDataFlow.cs:102:20:102:103 | (...) ... |
 | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T | GlobalDataFlow.cs:102:20:102:103 | (...) ... : T |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
+| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : Object |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : String |
+| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:78:102:102 | array creation of type Object[] |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:78:102:102 | array creation of type Object[] : Object[] |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
+| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : Object |
+| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : String |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:78:102:102 | array creation of type Object[] |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:78:102:102 | array creation of type Object[] : Object[] |
@@ -2310,6 +2322,7 @@
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:275:26:275:26 | x : T |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) : String |
+| GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) : T |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:281:32:281:32 | x : String |
 | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) : String | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 |
@@ -2356,6 +2369,7 @@
 | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 : T | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) : String |
+| GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) : T |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:287:32:287:32 | x : String |
 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) : String | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
@@ -2436,17 +2450,23 @@
 | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 : T | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : Object |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : String |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : Object |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:287:32:287:32 | x : Object |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : Object |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : String |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : String |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:287:32:287:32 | x : String |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : Object |
+| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : String |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : T |
@@ -2602,8 +2622,6 @@
 | GlobalDataFlow.cs:114:76:114:76 | x : Object | GlobalDataFlow.cs:114:81:114:81 | access to parameter x : String |
 | GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
 | GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
-| GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
-| GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x : String |
 | GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x : String |
 | GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x : String |
 | GlobalDataFlow.cs:114:76:114:76 | x : String[] | GlobalDataFlow.cs:114:76:114:76 | x |
@@ -2670,8 +2688,6 @@
 | GlobalDataFlow.cs:116:127:116:127 | y : Object | GlobalDataFlow.cs:116:133:116:133 | access to parameter y : String |
 | GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
 | GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
-| GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
-| GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y : String |
 | GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y : String |
 | GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y : String |
 | GlobalDataFlow.cs:116:127:116:127 | y : String[] | GlobalDataFlow.cs:116:127:116:127 | y |
@@ -2734,8 +2750,6 @@
 | GlobalDataFlow.cs:118:124:118:124 | x : Object | GlobalDataFlow.cs:118:133:118:133 | access to parameter x : String |
 | GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
 | GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
-| GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
-| GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x : String |
 | GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x : String |
 | GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x : String |
 | GlobalDataFlow.cs:118:124:118:124 | x : String[] | GlobalDataFlow.cs:118:124:118:124 | x |
@@ -3038,6 +3052,8 @@
 | GlobalDataFlow.cs:134:40:134:64 | (...) => ... : Func<String,String> | GlobalDataFlow.cs:135:21:135:27 | access to local variable return : Func<String,String> |
 | GlobalDataFlow.cs:134:40:134:64 | (...) => ... : Func<String,String> | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
 | GlobalDataFlow.cs:134:40:134:64 | (...) => ... : Func<String,String> | GlobalDataFlow.cs:139:20:139:26 | access to local variable return : Func<String,String> |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
 | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String | GlobalDataFlow.cs:135:21:135:34 | delegate call |
 | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
 | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String | GlobalDataFlow.cs:139:20:139:36 | delegate call |
@@ -3050,17 +3066,25 @@
 | GlobalDataFlow.cs:134:55:134:60 | delegate creation of type Func<String,String> : Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f : Func<String,String> |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x : Object |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
@@ -3100,13 +3124,19 @@
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:134:40:134:40 | x : Object |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : T |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:134:40:134:40 | x |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:134:40:134:40 | x : String |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : T |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:134:40:134:40 | x |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:134:40:134:40 | x : T |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
+| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call : T |
 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object |
@@ -3130,6 +3160,7 @@
 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:134:40:134:40 | x : String |
 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:139:20:139:36 | delegate call |
 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:139:20:139:36 | delegate call : String |
+| GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:139:20:139:36 | delegate call : T |
 | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) : Object | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
 | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) : Object | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 : Object |
 | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) : Object | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
@@ -3164,13 +3195,19 @@
 | GlobalDataFlow.cs:143:31:143:36 | delegate creation of type Func<String,String> : Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f : Func<String,String> |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:364:46:364:46 | x : Object |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
@@ -3196,8 +3233,13 @@
 | GlobalDataFlow.cs:147:30:147:35 | delegate creation of type Func<String,String> : Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f : Func<String,String> |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : String |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
@@ -3206,6 +3248,12 @@
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : T | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : T | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : T | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object |
 | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String |
 | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
@@ -3228,6 +3276,8 @@
 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 : T | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
+| GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
+| GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object |
 | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String |
 | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
@@ -3338,10 +3388,16 @@
 | GlobalDataFlow.cs:161:22:161:31 | this access : DataFlow | GlobalDataFlow.cs:201:20:201:33 | this access : DataFlow |
 | GlobalDataFlow.cs:161:22:161:31 | this access : DataFlow | GlobalDataFlow.cs:331:25:331:32 | this |
 | GlobalDataFlow.cs:161:22:161:31 | this access : DataFlow | GlobalDataFlow.cs:331:25:331:32 | this : DataFlow |
+| GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : Object |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : String | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : String | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : String |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : T |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : Object |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
+| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : Object |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : String |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
@@ -3350,11 +3406,21 @@
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : T |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : T |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:378:39:378:45 | tainted |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:378:39:378:45 | tainted : Object |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:378:39:378:45 | tainted |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:378:39:378:45 | tainted : String |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object |
+| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:378:39:378:45 | tainted |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:378:39:378:45 | tainted : T |
@@ -4015,20 +4081,36 @@
 | GlobalDataFlow.cs:275:26:275:26 | x : T | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T |
 | GlobalDataFlow.cs:275:26:275:26 | x : T | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
@@ -4047,24 +4129,44 @@
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
@@ -4104,14 +4206,22 @@
 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x : Object |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x |
@@ -4123,22 +4233,36 @@
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object | GlobalDataFlow.cs:278:16:278:24 | ... == ... : Boolean |
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object | GlobalDataFlow.cs:278:16:278:24 | ... == ... : Boolean |
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String | GlobalDataFlow.cs:278:16:278:24 | ... == ... |
+| GlobalDataFlow.cs:278:16:278:16 | (...) ... : String | GlobalDataFlow.cs:278:16:278:24 | ... == ... |
+| GlobalDataFlow.cs:278:16:278:16 | (...) ... : String | GlobalDataFlow.cs:278:16:278:24 | ... == ... : Boolean |
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String | GlobalDataFlow.cs:278:16:278:24 | ... == ... : Boolean |
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : T | GlobalDataFlow.cs:278:16:278:24 | ... == ... |
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : T | GlobalDataFlow.cs:278:16:278:24 | ... == ... |
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : T | GlobalDataFlow.cs:278:16:278:24 | ... == ... : Boolean |
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : T | GlobalDataFlow.cs:278:16:278:24 | ... == ... : Boolean |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
+| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
@@ -4152,6 +4276,22 @@
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : Object |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : Object |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return : String |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : String |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return : String |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : String |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T | GlobalDataFlow.cs:70:21:70:46 | call to method Return : T |
 | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
@@ -4165,8 +4305,12 @@
 | GlobalDataFlow.cs:278:28:278:37 | default(...) : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
 | GlobalDataFlow.cs:278:28:278:37 | default(...) : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
+| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
@@ -4268,20 +4412,14 @@
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : String[] | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
-| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> |
@@ -4482,8 +4620,36 @@
 | GlobalDataFlow.cs:364:46:364:46 | x : T | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T |
 | GlobalDataFlow.cs:364:46:364:46 | x : T | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T |
 | GlobalDataFlow.cs:364:46:364:46 | x : T | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
+| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
@@ -4514,6 +4680,12 @@
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:26 | x |
@@ -4526,10 +4698,18 @@
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:275:26:275:26 | x |
@@ -4544,6 +4724,14 @@
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
+| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
@@ -4595,12 +4783,20 @@
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:378:39:378:45 | tainted |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:378:39:378:45 | tainted : String |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : String |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : String |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
@@ -4626,6 +4822,10 @@
 | GlobalDataFlow.cs:378:39:378:45 | tainted : T | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : T |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : T |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String |
@@ -4638,6 +4838,12 @@
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : T | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : T |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : T |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String |
@@ -4656,6 +4862,8 @@
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : T | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : T |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : T |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
+| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : String |
@@ -4849,10 +5057,6 @@
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
-| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
-| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
-| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
-| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
@@ -4897,32 +5101,20 @@
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
-| GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
-| GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
-| GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
-| GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x |
-| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x |
-| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x |
-| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x : T |
-| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
-| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
-| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
-| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |
-| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingEdges.expected
@@ -1190,7 +1190,6 @@
 | GlobalDataFlow.cs:70:21:70:46 | call to method Return : T | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return : String |
-| GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return : T |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:71:15:71:19 | access to local variable sink0 : String | GlobalDataFlow.cs:72:79:72:100 | array creation of type Object[] |
@@ -1274,16 +1273,12 @@
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T | GlobalDataFlow.cs:72:21:72:101 | (...) ... |
 | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T | GlobalDataFlow.cs:72:21:72:101 | (...) ... : T |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
-| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : Object |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : String |
-| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:79:72:100 | array creation of type Object[] |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:72:79:72:100 | array creation of type Object[] : Object[] |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
-| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : Object |
-| GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : String |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : T |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:79:72:100 | array creation of type Object[] |
 | GlobalDataFlow.cs:72:94:72:98 | access to local variable sink0 : T | GlobalDataFlow.cs:72:79:72:100 | array creation of type Object[] : Object[] |
@@ -1315,8 +1310,6 @@
 | GlobalDataFlow.cs:73:15:73:19 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : Object |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : String |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 : Object |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
@@ -1326,9 +1319,7 @@
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:281:32:281:32 | x : Object |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : Object |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : String |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 : String |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 |
@@ -1338,8 +1329,6 @@
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : String | GlobalDataFlow.cs:281:32:281:32 | x : String |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : Object |
-| GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : String |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:75:30:75:34 | SSA def(sink2) : T |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 |
 | GlobalDataFlow.cs:75:19:75:23 | access to local variable sink1 : T | GlobalDataFlow.cs:106:19:106:23 | access to local variable sink1 : T |
@@ -1379,19 +1368,13 @@
 | GlobalDataFlow.cs:77:21:77:22 | "" : String | GlobalDataFlow.cs:78:41:78:45 | access to local variable sink3 : String |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : Object |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : T |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : Object | GlobalDataFlow.cs:287:32:287:32 | x : Object |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : Object |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : String |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : T |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : String | GlobalDataFlow.cs:287:32:287:32 | x : String |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : Object |
-| GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : String |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:78:30:78:34 | SSA def(sink3) : T |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:78:19:78:23 | access to local variable sink2 : T | GlobalDataFlow.cs:287:32:287:32 | x : T |
@@ -1841,6 +1824,8 @@
 | GlobalDataFlow.cs:84:126:84:126 | x : Object | GlobalDataFlow.cs:84:135:84:135 | access to parameter x : String |
 | GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x |
 | GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x |
+| GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x |
+| GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x : String |
 | GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x : String |
 | GlobalDataFlow.cs:84:126:84:126 | x : String | GlobalDataFlow.cs:84:135:84:135 | access to parameter x : String |
 | GlobalDataFlow.cs:84:126:84:126 | x : String[] | GlobalDataFlow.cs:84:126:84:126 | x |
@@ -1921,6 +1906,8 @@
 | GlobalDataFlow.cs:86:129:86:129 | y : Object | GlobalDataFlow.cs:86:135:86:135 | access to parameter y : String |
 | GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y |
 | GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y |
+| GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y |
+| GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y : String |
 | GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y : String |
 | GlobalDataFlow.cs:86:129:86:129 | y : String | GlobalDataFlow.cs:86:135:86:135 | access to parameter y : String |
 | GlobalDataFlow.cs:86:129:86:129 | y : String[] | GlobalDataFlow.cs:86:129:86:129 | y |
@@ -2141,10 +2128,14 @@
 | GlobalDataFlow.cs:90:97:90:97 | s : Object | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
+| GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
+| GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s |
+| GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s |
+| GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String |
 | GlobalDataFlow.cs:90:97:90:97 | s : String[] | GlobalDataFlow.cs:90:97:90:97 | s |
@@ -2161,6 +2152,8 @@
 | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String | GlobalDataFlow.cs:90:91:90:109 | [output] (...) => ... : String |
 | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
 | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
+| GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... |
+| GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:109:90:109 | access to parameter s : String | GlobalDataFlow.cs:90:103:90:109 | ... + ... : String |
 | GlobalDataFlow.cs:90:112:90:112 | x : Object | GlobalDataFlow.cs:90:112:90:112 | x |
@@ -2269,7 +2262,6 @@
 | GlobalDataFlow.cs:100:24:100:33 | call to method Return : T | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return : String |
-| GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return : T |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:100:31:100:32 | "" : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:101:15:101:22 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:78:102:102 | array creation of type Object[] |
@@ -2305,16 +2297,12 @@
 | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T | GlobalDataFlow.cs:102:20:102:103 | (...) ... |
 | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T | GlobalDataFlow.cs:102:20:102:103 | (...) ... : T |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
-| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : Object |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : String |
-| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:78:102:102 | array creation of type Object[] |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:102:78:102:102 | array creation of type Object[] : Object[] |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : String | GlobalDataFlow.cs:275:26:275:26 | x : String |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
-| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : Object |
-| GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : String |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : T |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:78:102:102 | array creation of type Object[] |
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:102:78:102:102 | array creation of type Object[] : Object[] |
@@ -2322,7 +2310,6 @@
 | GlobalDataFlow.cs:102:93:102:100 | access to local variable nonSink0 : T | GlobalDataFlow.cs:275:26:275:26 | x : T |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) : String |
-| GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) : T |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:281:32:281:32 | x |
 | GlobalDataFlow.cs:104:19:104:20 | "" : String | GlobalDataFlow.cs:281:32:281:32 | x : String |
 | GlobalDataFlow.cs:104:27:104:34 | SSA def(nonSink0) : String | GlobalDataFlow.cs:105:15:105:22 | access to local variable nonSink0 |
@@ -2369,7 +2356,6 @@
 | GlobalDataFlow.cs:107:15:107:22 | access to local variable nonSink0 : T | GlobalDataFlow.cs:108:41:108:48 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) : String |
-| GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) : T |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:108:19:108:20 | "" : String | GlobalDataFlow.cs:287:32:287:32 | x : String |
 | GlobalDataFlow.cs:108:27:108:34 | SSA def(nonSink0) : String | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 |
@@ -2450,23 +2436,17 @@
 | GlobalDataFlow.cs:109:15:109:22 | access to local variable nonSink0 : T | GlobalDataFlow.cs:114:57:114:64 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : Object |
-| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : String |
-| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : Object |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : Object | GlobalDataFlow.cs:287:32:287:32 | x : Object |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
-| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : Object |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : String |
-| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : String |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:287:32:287:32 | x |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : String | GlobalDataFlow.cs:287:32:287:32 | x : String |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) |
-| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : Object |
-| GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : String |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | SSA def(sink1) : T |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 |
 | GlobalDataFlow.cs:110:19:110:23 | access to local variable sink1 : T | GlobalDataFlow.cs:110:30:110:34 | access to local variable sink1 : T |
@@ -2622,6 +2602,8 @@
 | GlobalDataFlow.cs:114:76:114:76 | x : Object | GlobalDataFlow.cs:114:81:114:81 | access to parameter x : String |
 | GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
 | GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
+| GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x |
+| GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x : String |
 | GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x : String |
 | GlobalDataFlow.cs:114:76:114:76 | x : String | GlobalDataFlow.cs:114:81:114:81 | access to parameter x : String |
 | GlobalDataFlow.cs:114:76:114:76 | x : String[] | GlobalDataFlow.cs:114:76:114:76 | x |
@@ -2688,6 +2670,8 @@
 | GlobalDataFlow.cs:116:127:116:127 | y : Object | GlobalDataFlow.cs:116:133:116:133 | access to parameter y : String |
 | GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
 | GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
+| GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y |
+| GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y : String |
 | GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y : String |
 | GlobalDataFlow.cs:116:127:116:127 | y : String | GlobalDataFlow.cs:116:133:116:133 | access to parameter y : String |
 | GlobalDataFlow.cs:116:127:116:127 | y : String[] | GlobalDataFlow.cs:116:127:116:127 | y |
@@ -2750,6 +2734,8 @@
 | GlobalDataFlow.cs:118:124:118:124 | x : Object | GlobalDataFlow.cs:118:133:118:133 | access to parameter x : String |
 | GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
 | GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
+| GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x |
+| GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x : String |
 | GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x : String |
 | GlobalDataFlow.cs:118:124:118:124 | x : String | GlobalDataFlow.cs:118:133:118:133 | access to parameter x : String |
 | GlobalDataFlow.cs:118:124:118:124 | x : String[] | GlobalDataFlow.cs:118:124:118:124 | x |
@@ -3052,8 +3038,6 @@
 | GlobalDataFlow.cs:134:40:134:64 | (...) => ... : Func<String,String> | GlobalDataFlow.cs:135:21:135:27 | access to local variable return : Func<String,String> |
 | GlobalDataFlow.cs:134:40:134:64 | (...) => ... : Func<String,String> | GlobalDataFlow.cs:139:20:139:26 | access to local variable return |
 | GlobalDataFlow.cs:134:40:134:64 | (...) => ... : Func<String,String> | GlobalDataFlow.cs:139:20:139:26 | access to local variable return : Func<String,String> |
-| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call |
-| GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
 | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String | GlobalDataFlow.cs:135:21:135:34 | delegate call |
 | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
 | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String | GlobalDataFlow.cs:139:20:139:36 | delegate call |
@@ -3066,25 +3050,17 @@
 | GlobalDataFlow.cs:134:55:134:60 | delegate creation of type Func<String,String> : Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f : Func<String,String> |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x : Object |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:134:63:134:63 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
@@ -3124,19 +3100,13 @@
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:134:40:134:40 | x : Object |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
-| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
-| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : Object | GlobalDataFlow.cs:135:21:135:34 | delegate call : T |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:134:40:134:40 | x |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:134:40:134:40 | x : String |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call |
-| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
-| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : String | GlobalDataFlow.cs:135:21:135:34 | delegate call : T |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:134:40:134:40 | x |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:134:40:134:40 | x : T |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call |
-| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call : Object |
-| GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call : String |
 | GlobalDataFlow.cs:135:29:135:33 | access to local variable sink3 : T | GlobalDataFlow.cs:135:21:135:34 | delegate call : T |
 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 |
 | GlobalDataFlow.cs:136:15:136:19 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object |
@@ -3160,7 +3130,6 @@
 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:134:40:134:40 | x : String |
 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:139:20:139:36 | delegate call |
 | GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:139:20:139:36 | delegate call : String |
-| GlobalDataFlow.cs:139:28:139:35 | access to local variable nonSink0 : String | GlobalDataFlow.cs:139:20:139:36 | delegate call : T |
 | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) : Object | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 |
 | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) : Object | GlobalDataFlow.cs:144:15:144:19 | access to local variable sink5 : Object |
 | GlobalDataFlow.cs:143:13:143:44 | SSA def(sink5) : Object | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 |
@@ -3195,19 +3164,13 @@
 | GlobalDataFlow.cs:143:31:143:36 | delegate creation of type Func<String,String> : Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f : Func<String,String> |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : Object | GlobalDataFlow.cs:364:46:364:46 | x : Object |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:143:39:143:43 | access to local variable sink4 : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
@@ -3233,13 +3196,8 @@
 | GlobalDataFlow.cs:147:30:147:35 | delegate creation of type Func<String,String> : Func<String,String> | GlobalDataFlow.cs:364:41:364:41 | f : Func<String,String> |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:147:38:147:39 | "" : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
-| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object |
-| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : String |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
@@ -3248,12 +3206,6 @@
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : T | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : T |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : T | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : T | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T |
-| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) |
-| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : Object |
-| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object |
-| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object |
 | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) |
 | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:149:9:149:44 | SSA def(nonSink0) : String |
 | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 |
@@ -3276,8 +3228,6 @@
 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 : T | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:149:39:149:43 | access to local variable sink5 : T | GlobalDataFlow.cs:364:46:364:46 | x : T |
-| GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
-| GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object |
 | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
 | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String |
 | GlobalDataFlow.cs:150:15:150:22 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 |
@@ -3388,16 +3338,10 @@
 | GlobalDataFlow.cs:161:22:161:31 | this access : DataFlow | GlobalDataFlow.cs:201:20:201:33 | this access : DataFlow |
 | GlobalDataFlow.cs:161:22:161:31 | this access : DataFlow | GlobalDataFlow.cs:331:25:331:32 | this |
 | GlobalDataFlow.cs:161:22:161:31 | this access : DataFlow | GlobalDataFlow.cs:331:25:331:32 | this : DataFlow |
-| GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : Object |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : String | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : String | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : String |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
 | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : T |
-| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) |
-| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : Object |
-| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
-| GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : Object |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : String |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
@@ -3406,21 +3350,11 @@
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T | GlobalDataFlow.cs:163:13:163:43 | SSA def(sink23) : T |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 |
 | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T | GlobalDataFlow.cs:164:15:164:20 | access to local variable sink23 : T |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:378:39:378:45 | tainted |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : Object | GlobalDataFlow.cs:378:39:378:45 | tainted : Object |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:378:39:378:45 | tainted |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : String | GlobalDataFlow.cs:378:39:378:45 | tainted : String |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : Object |
-| GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : String |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:163:22:163:43 | call to method TaintedParam : T |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:378:39:378:45 | tainted |
 | GlobalDataFlow.cs:163:35:163:42 | access to local variable nonSink0 : T | GlobalDataFlow.cs:378:39:378:45 | tainted : T |
@@ -4081,36 +4015,20 @@
 | GlobalDataFlow.cs:275:26:275:26 | x : T | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T |
 | GlobalDataFlow.cs:275:26:275:26 | x : T | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
@@ -4129,44 +4047,24 @@
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
 | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
 | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T | GlobalDataFlow.cs:277:13:277:38 | SSA def(y) |
@@ -4206,22 +4104,14 @@
 | GlobalDataFlow.cs:277:33:277:34 | access to parameter x0 : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : Object | GlobalDataFlow.cs:364:46:364:46 | x : Object |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : String | GlobalDataFlow.cs:364:46:364:46 | x : String |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : T |
 | GlobalDataFlow.cs:277:37:277:37 | access to parameter x : T | GlobalDataFlow.cs:364:46:364:46 | x |
@@ -4233,36 +4123,22 @@
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object | GlobalDataFlow.cs:278:16:278:24 | ... == ... : Boolean |
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object | GlobalDataFlow.cs:278:16:278:24 | ... == ... : Boolean |
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String | GlobalDataFlow.cs:278:16:278:24 | ... == ... |
-| GlobalDataFlow.cs:278:16:278:16 | (...) ... : String | GlobalDataFlow.cs:278:16:278:24 | ... == ... |
-| GlobalDataFlow.cs:278:16:278:16 | (...) ... : String | GlobalDataFlow.cs:278:16:278:24 | ... == ... : Boolean |
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String | GlobalDataFlow.cs:278:16:278:24 | ... == ... : Boolean |
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : T | GlobalDataFlow.cs:278:16:278:24 | ... == ... |
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : T | GlobalDataFlow.cs:278:16:278:24 | ... == ... |
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : T | GlobalDataFlow.cs:278:16:278:24 | ... == ... : Boolean |
 | GlobalDataFlow.cs:278:16:278:16 | (...) ... : T | GlobalDataFlow.cs:278:16:278:24 | ... == ... : Boolean |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:16 | (...) ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : Object | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:16 | (...) ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
-| GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : String | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:16 | (...) ... |
@@ -4276,22 +4152,6 @@
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
 | GlobalDataFlow.cs:278:16:278:16 | access to local variable y : T | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : Object |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : Object |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:70:21:70:46 | call to method Return : String |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke : String |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:100:24:100:33 | call to method Return : String |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:102:28:102:103 | call to method Invoke : String |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
-| GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T | GlobalDataFlow.cs:70:21:70:46 | call to method Return |
 | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T | GlobalDataFlow.cs:70:21:70:46 | call to method Return : T |
 | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T | GlobalDataFlow.cs:72:29:72:101 | call to method Invoke |
@@ -4305,12 +4165,8 @@
 | GlobalDataFlow.cs:278:28:278:37 | default(...) : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
 | GlobalDataFlow.cs:278:28:278:37 | default(...) : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : T |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : Object | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : Object |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
-| GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : String | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... : String |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
 | GlobalDataFlow.cs:278:41:278:41 | access to local variable y : T | GlobalDataFlow.cs:278:16:278:41 | ... ? ... : ... |
@@ -4412,14 +4268,20 @@
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : String[] | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:292:31:292:40 | sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 |
+| GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:294:15:294:24 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T |
 | GlobalDataFlow.cs:295:16:295:25 | access to parameter sinkParam8 : T | GlobalDataFlow.cs:82:84:82:94 | [output] delegate creation of type Func<String,String> |
@@ -4620,36 +4482,8 @@
 | GlobalDataFlow.cs:364:46:364:46 | x : T | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T |
 | GlobalDataFlow.cs:364:46:364:46 | x : T | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T |
 | GlobalDataFlow.cs:364:46:364:46 | x : T | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : Object | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : Object |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:143:21:143:44 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:147:20:147:40 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:149:20:149:44 | call to method ApplyFunc : String |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc |
-| GlobalDataFlow.cs:366:16:366:19 | delegate call : String | GlobalDataFlow.cs:277:17:277:38 | call to method ApplyFunc : String |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc |
 | GlobalDataFlow.cs:366:16:366:19 | delegate call : T | GlobalDataFlow.cs:134:45:134:64 | call to method ApplyFunc : T |
@@ -4680,12 +4514,6 @@
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : Object | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:275:26:275:26 | x |
@@ -4698,18 +4526,10 @@
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : String | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:275:26:275:26 | x |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:275:26:275:26 | x |
@@ -4724,14 +4544,6 @@
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : Object |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
-| GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : String |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
 | GlobalDataFlow.cs:366:18:366:18 | access to parameter x : T | GlobalDataFlow.cs:366:16:366:19 | delegate call : T |
@@ -4783,20 +4595,12 @@
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:378:39:378:45 | tainted |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:378:39:378:45 | tainted : String |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : String |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : String |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
@@ -4822,10 +4626,6 @@
 | GlobalDataFlow.cs:378:39:378:45 | tainted : T | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : T |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:378:39:378:45 | tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : T |
-| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object |
-| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String |
@@ -4838,12 +4638,6 @@
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : T | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : T |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : T |
-| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
-| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : Object |
-| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 |
-| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object |
-| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : String | GlobalDataFlow.cs:380:13:380:28 | SSA def(sink11) : String |
@@ -4862,8 +4656,6 @@
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : T | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : T |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:380:22:380:28 | access to parameter tainted : T | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : T |
-| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
-| GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : Object | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : Object |
 | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 |
 | GlobalDataFlow.cs:381:15:381:20 | access to local variable sink11 : String | GlobalDataFlow.cs:382:16:382:21 | access to local variable sink11 : String |
@@ -5057,6 +4849,10 @@
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
+| GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
 | GlobalDataFlow.cs:429:22:429:22 | SSA def(x) : T | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T |
@@ -5101,20 +4897,32 @@
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
+| GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
 | GlobalDataFlow.cs:431:44:431:47 | delegate call : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : IEnumerable<T> |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:80:79:80:79 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x : T |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:112:84:112:84 | x : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |
+| GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |
 | GlobalDataFlow.cs:431:46:431:46 | access to local variable x : T | GlobalDataFlow.cs:431:44:431:47 | delegate call : T |

--- a/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
+++ b/csharp/ql/test/library-tests/dataflow/global/TaintTrackingPath.expected
@@ -316,8 +316,6 @@ nodes
 | GlobalDataFlow.cs:56:37:56:37 | x : String | semmle.label | x : String |
 | GlobalDataFlow.cs:56:46:56:46 | access to parameter x : String | semmle.label | access to parameter x : String |
 | GlobalDataFlow.cs:57:35:57:52 | access to property SinkProperty0 : String | semmle.label | access to property SinkProperty0 : String |
-| GlobalDataFlow.cs:60:38:60:50 | access to parameter nonSinkParam0 | semmle.label | access to parameter nonSinkParam0 |
-| GlobalDataFlow.cs:61:61:61:73 | access to parameter nonSinkParam0 | semmle.label | access to parameter nonSinkParam0 |
 | GlobalDataFlow.cs:64:22:64:39 | access to property SinkProperty0 : String | semmle.label | access to property SinkProperty0 : String |
 | GlobalDataFlow.cs:70:21:70:46 | call to method Return : String | semmle.label | call to method Return : String |
 | GlobalDataFlow.cs:70:28:70:45 | access to property SinkProperty0 : String | semmle.label | access to property SinkProperty0 : String |

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1838,7 +1838,7 @@ private predicate flowFwdStore(
 ) {
   exists(NodeExt mid, AccessPathFront apf0, boolean through |
     flowFwd(mid, fromArg, apf0, ap0, config) and
-    flowFwdStoreAux(mid, f, node, through, apf0, apf, config)
+    flowFwdStore1(mid, f, node, through, apf0, apf, config)
   |
     through = false or ap0.isValidForFlowThrough()
   )
@@ -1853,12 +1853,20 @@ private predicate flowFwdStore(
   )
 }
 
-private predicate flowFwdStoreAux(
+pragma[noinline]
+private predicate flowFwdStore0(
+  NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, Configuration config
+) {
+  storeExt(mid, f, node, through) and
+  consCand(f, apf0, config)
+}
+
+pragma[noinline]
+private predicate flowFwdStore1(
   NodeExt mid, Content f, NodeExt node, boolean through, AccessPathFront apf0, AccessPathFront apf,
   Configuration config
 ) {
-  storeExt(mid, f, node, through) and
-  consCand(f, apf0, config) and
+  flowFwdStore0(mid, f, node, through, apf0, config) and
   apf.headUsesContent(f) and
   flowCand(node, _, apf, unbind(config))
 }
@@ -1958,7 +1966,7 @@ private predicate flow0(NodeExt node, boolean toReturn, AccessPath ap, Configura
   )
   or
   exists(NodeExt mid, AccessPath ap0 |
-    readFwd(node, _, mid, ap, ap0, config) and
+    readFwd(node, mid, ap, ap0, config) and
     flow(mid, toReturn, ap0, config)
   )
   or
@@ -1991,11 +1999,13 @@ private predicate flowTaintStore(
 
 pragma[nomagic]
 private predicate readFwd(
-  NodeExt node1, Content f, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
+  NodeExt node1, NodeExt node2, AccessPath ap, AccessPath ap0, Configuration config
 ) {
-  readExt(node1, f, node2, _) and
-  flowFwdRead(node2, f, ap, _, config) and
-  ap0 = pop(f, ap)
+  exists(Content f |
+    readExt(node1, f, node2, _) and
+    flowFwdRead(node2, f, ap, _, config) and
+    ap0 = pop(f, ap)
+  )
 }
 
 bindingset[conf, result]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -2076,12 +2076,17 @@ private newtype TPathNode =
       config.isSource(node)
       or
       // ... or a sink that can be reached from a source
-      exists(PathNodeMid mid |
-        pathStep(mid, node, _, _, any(AccessPathNil nil)) and
-        config = mid.getConfiguration()
-      )
+      pathStepNil(node, config)
     )
   }
+
+pragma[nomagic]
+private predicate pathStepNil(Node node, Configuration config) {
+  exists(PathNodeMid mid |
+    pathStep(mid, node, _, _, any(AccessPathNil nil)) and
+    config = mid.getConfiguration()
+  )
+}
 
 /**
  * A `Node` augmented with a call context (except for sinks), an access path, and a configuration.

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -1647,9 +1647,6 @@ abstract private class AccessPath extends TAccessPath {
    * Holds if this access path has `head` at the front and may be followed by `tail`.
    */
   abstract predicate pop(Content head, AccessPath tail);
-
-  /** Gets the untyped version of this access path. */
-  UntypedAccessPath getUntyped() { result.getATyped() = this }
 }
 
 private class AccessPathNil extends AccessPath, TNil {
@@ -2001,50 +1998,10 @@ private Configuration unbind(Configuration conf) { result >= conf and result <= 
 
 private predicate flow(Node n, Configuration config) { flow(TNormalNode(n), _, _, config) }
 
-private newtype TUntypedAccessPath =
-  TNilUntyped() or
-  TConsNilUntyped(Content f) { exists(TConsNil(f, _)) } or
-  TConsConsUntyped(Content f1, Content f2, int len) { exists(TConsCons(f1, f2, len)) }
-
-/**
- * An untyped access path.
- *
- * Untyped access paths are only used when reconstructing flow summaries,
- * where the extra type information is redundant.
- */
-private class UntypedAccessPath extends TUntypedAccessPath {
-  /** Gets a typed version of this untyped access path. */
-  AccessPath getATyped() {
-    this = TNilUntyped() and result = TNil(_)
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = TConsNil(f, _))
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      result = TConsCons(f1, f2, len)
-    )
-  }
-
-  string toString() {
-    this = TNilUntyped() and
-    result = "<nil>"
-    or
-    exists(Content f | this = TConsNilUntyped(f) | result = "[" + f + "]")
-    or
-    exists(Content f1, Content f2, int len | this = TConsConsUntyped(f1, f2, len) |
-      if len = 2
-      then result = "[" + f1.toString() + ", " + f2.toString() + "]"
-      else result = "[" + f1.toString() + ", " + f2.toString() + ", ... (" + len.toString() + ")]"
-    )
-  }
-}
-
 private newtype TSummaryCtx =
   TSummaryCtxNone() or
-  TSummaryCtxSome(ParameterNode p, UntypedAccessPath uap) {
-    exists(ReturnNodeExt ret, Configuration config, AccessPath ap |
-      ap = uap.getATyped() and
-      flow(TNormalNode(p), true, ap, config)
-    |
+  TSummaryCtxSome(ParameterNode p, AccessPath ap) {
+    exists(ReturnNodeExt ret, Configuration config | flow(TNormalNode(p), true, ap, config) |
       exists(Summary summary |
         parameterFlowReturn(p, ret, _, _, _, summary, config) and
         flow(ret, unbind(config))
@@ -2080,12 +2037,30 @@ private newtype TSummaryCtx =
  *
  * Summaries are only created for parameters that may flow through.
  */
-private class SummaryCtx extends TSummaryCtx {
-  string toString() { result = "SummaryCtx" }
+abstract private class SummaryCtx extends TSummaryCtx {
+  abstract string toString();
 }
 
 /** A summary context from which no flow summary can be generated. */
-private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone { }
+private class SummaryCtxNone extends SummaryCtx, TSummaryCtxNone {
+  override string toString() { result = "<none>" }
+}
+
+/** A summary context from which a flow summary can be generated. */
+private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
+  private ParameterNode p;
+  private AccessPath ap;
+
+  SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
+
+  override string toString() { result = p + ": " + ap }
+
+  predicate hasLocationInfo(
+    string filepath, int startline, int startcolumn, int endline, int endcolumn
+  ) {
+    p.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+  }
+}
 
 private newtype TPathNode =
   TPathNodeMid(Node node, CallContext cc, SummaryCtx sc, AccessPath ap, Configuration config) {
@@ -2399,22 +2374,22 @@ private predicate pathOutOfCallable(PathNodeMid mid, Node out, CallContext cc) {
  */
 pragma[noinline]
 private predicate pathIntoArg(
-  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, UntypedAccessPath ap
+  PathNodeMid mid, int i, CallContext cc, DataFlowCall call, AccessPath ap
 ) {
   exists(ArgumentNode arg |
     arg = mid.getNode() and
     cc = mid.getCallContext() and
     arg.argumentOf(call, i) and
-    ap = mid.getAp().getUntyped()
+    ap = mid.getAp()
   )
 }
 
 pragma[noinline]
 private predicate parameterCand(
-  DataFlowCallable callable, int i, UntypedAccessPath ap, Configuration config
+  DataFlowCallable callable, int i, AccessPath ap, Configuration config
 ) {
   exists(ParameterNode p |
-    flow(TNormalNode(p), _, ap.getATyped(), config) and
+    flow(TNormalNode(p), _, ap, config) and
     p.isParameterOf(callable, i)
   )
 }
@@ -2422,7 +2397,7 @@ private predicate parameterCand(
 pragma[nomagic]
 private predicate pathIntoCallable0(
   PathNodeMid mid, DataFlowCallable callable, int i, CallContext outercc, DataFlowCall call,
-  UntypedAccessPath ap
+  AccessPath ap
 ) {
   pathIntoArg(mid, i, outercc, call, ap) and
   callable = resolveCall(call, outercc) and
@@ -2438,7 +2413,7 @@ private predicate pathIntoCallable(
   PathNodeMid mid, ParameterNode p, CallContext outercc, CallContextCall innercc, SummaryCtx sc,
   DataFlowCall call
 ) {
-  exists(int i, DataFlowCallable callable, UntypedAccessPath ap |
+  exists(int i, DataFlowCallable callable, AccessPath ap |
     pathIntoCallable0(mid, callable, i, outercc, call, ap) and
     p.isParameterOf(callable, i) and
     (
@@ -2457,7 +2432,7 @@ private predicate pathIntoCallable(
 /** Holds if data may flow from a parameter given by `sc` to a return of kind `kind`. */
 pragma[nomagic]
 private predicate paramFlowsThrough(
-  ReturnKindExt kind, CallContextCall cc, TSummaryCtxSome sc, AccessPath ap, Configuration config
+  ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
   exists(PathNodeMid mid, ReturnNodeExt ret |
     mid.getNode() = ret and
@@ -2635,14 +2610,7 @@ private module FlowExploration {
 
   private newtype TSummaryCtx2 =
     TSummaryCtx2None() or
-    TSummaryCtx2Nil() or
-    TSummaryCtx2ConsNil(Content f)
-
-  private TSummaryCtx2 getSummaryCtx2(PartialAccessPath ap) {
-    result = TSummaryCtx2Nil() and ap instanceof PartialAccessPathNil
-    or
-    exists(Content f | result = TSummaryCtx2ConsNil(f) and ap = TPartialCons(f, 1))
-  }
+    TSummaryCtx2Some(PartialAccessPath ap)
 
   private newtype TPartialPathNode =
     TPartialPathNodeMk(
@@ -2929,11 +2897,8 @@ private module FlowExploration {
     exists(int i, DataFlowCallable callable |
       partialPathIntoCallable0(mid, callable, i, outercc, call, ap, config) and
       p.isParameterOf(callable, i) and
-      (
-        sc1 = TSummaryCtx1Param(p) and sc2 = getSummaryCtx2(ap)
-        or
-        sc1 = TSummaryCtx1None() and sc2 = TSummaryCtx2None() and not exists(getSummaryCtx2(ap))
-      )
+      sc1 = TSummaryCtx1Param(p) and
+      sc2 = TSummaryCtx2Some(ap)
     |
       if recordDataFlowCallSite(call, callable)
       then innercc = TSpecificCall(call)
@@ -2953,8 +2918,7 @@ private module FlowExploration {
       sc1 = mid.getSummaryCtx1() and
       sc2 = mid.getSummaryCtx2() and
       config = mid.getConfiguration() and
-      ap = mid.getAp() and
-      ap.len() in [0 .. 1]
+      ap = mid.getAp()
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -615,7 +615,9 @@ private newtype TNodeExt =
     exists(Configuration config |
       nodeCand1(node1, config) and
       argumentValueFlowsThrough(call, node1, TContentSome(f1), TContentSome(f2), node2) and
-      nodeCand1(node2, unbind(config))
+      nodeCand1(node2, unbind(config)) and
+      readStoreCand1(f1, unbind(config)) and
+      readStoreCand1(f2, unbind(config))
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -383,17 +383,28 @@ private module Cached {
           contentOut = TContentNone() and
           compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
           or
-          // getter(+setter)
+          // getter
           exists(Content fIn |
             contentIn.getContent() = fIn and
-            compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
+            contentOut = TContentNone() and
+            compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType()) and
+            compatibleTypes(fIn.getType(), getErasedNodeTypeBound(out))
           )
           or
           // setter
           exists(Content fOut |
             contentIn = TContentNone() and
             contentOut.getContent() = fOut and
-            compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType())
+            compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(out))
+          )
+          or
+          // getter+setter
+          exists(Content fIn, Content fOut |
+            contentIn.getContent() = fIn and
+            contentOut.getContent() = fOut and
+            compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(out))
           )
         )
       }

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -754,8 +754,14 @@ private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
 }
 
 pragma[noinline]
+private ReturnPosition getReturnPosition0(ReturnNodeExt ret, ReturnKindExt kind) {
+  result.getCallable() = returnNodeGetEnclosingCallable(ret) and
+  kind = result.getKind()
+}
+
+pragma[noinline]
 ReturnPosition getReturnPosition(ReturnNodeExt ret) {
-  result = TReturnPosition0(returnNodeGetEnclosingCallable(ret), ret.getKind())
+  result = getReturnPosition0(ret, ret.getKind())
 }
 
 bindingset[cc, callable]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplCommon.qll
@@ -1,915 +1,860 @@
 private import DataFlowImplSpecific::Private
-import DataFlowImplSpecific::Public
+private import DataFlowImplSpecific::Public
+import Cached
 
-private ReturnNode getAReturnNodeOfKind(ReturnKind kind) { result.getKind() = kind }
+cached
+private module Cached {
+  /**
+   * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
+   * The instance parameter is considered to have index `-1`.
+   */
+  pragma[nomagic]
+  private predicate viableParam(DataFlowCall call, int i, ParameterNode p) {
+    p.isParameterOf(viableCallable(call), i)
+  }
 
-module Public {
-  import ImplCommon
-  import FlowThrough_v2
-}
+  /**
+   * Holds if `arg` is a possible argument to `p` in `call`, taking virtual
+   * dispatch into account.
+   */
+  cached
+  predicate viableParamArg(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
+    exists(int i |
+      viableParam(call, i, p) and
+      arg.argumentOf(call, i)
+    )
+  }
 
-private module ImplCommon {
-  import Cached
+  /** Provides predicates for calculating flow-through summaries. */
+  private module FlowThrough {
+    /**
+     * The first flow-through approximation:
+     *
+     * - Input/output access paths are abstracted with a Boolean parameter
+     *   that indicates (non-)emptiness.
+     */
+    private module Cand {
+      /**
+       * Holds if `p` can flow to `node` in the same callable using only
+       * value-preserving steps.
+       *
+       * `read` indicates whether it is contents of `p` that can flow to `node`,
+       * and `stored` indicates whether it flows to contents of `node`.
+       */
+      pragma[nomagic]
+      private predicate parameterValueFlowCand(
+        ParameterNode p, Node node, boolean read, boolean stored
+      ) {
+        p = node and
+        read = false and
+        stored = false
+        or
+        // local flow
+        exists(Node mid |
+          parameterValueFlowCand(p, mid, read, stored) and
+          simpleLocalFlowStep(mid, node)
+        )
+        or
+        // read
+        exists(Node mid, boolean readMid, boolean storedMid |
+          parameterValueFlowCand(p, mid, readMid, storedMid) and
+          readStep(mid, _, node) and
+          stored = false
+        |
+          // value neither read nor stored prior to read
+          readMid = false and
+          storedMid = false and
+          read = true
+          or
+          // value (possibly read and then) stored prior to read (same content)
+          read = readMid and
+          storedMid = true
+        )
+        or
+        // store
+        exists(Node mid |
+          parameterValueFlowCand(p, mid, read, false) and
+          storeStep(mid, _, node) and
+          stored = true
+        )
+        or
+        // flow through: no prior read or store
+        exists(ArgumentNode arg |
+          parameterValueFlowArgCand(p, arg, false, false) and
+          argumentValueFlowsThroughCand(arg, node, read, stored)
+        )
+        or
+        // flow through: no read or store inside method
+        exists(ArgumentNode arg |
+          parameterValueFlowArgCand(p, arg, read, stored) and
+          argumentValueFlowsThroughCand(arg, node, false, false)
+        )
+        or
+        // flow through: possible prior read and prior store with compatible
+        // flow-through method
+        exists(ArgumentNode arg, boolean mid |
+          parameterValueFlowArgCand(p, arg, read, mid) and
+          argumentValueFlowsThroughCand(arg, node, mid, stored)
+        )
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowArgCand(
+        ParameterNode p, ArgumentNode arg, boolean read, boolean stored
+      ) {
+        parameterValueFlowCand(p, arg, read, stored)
+      }
+
+      pragma[nomagic]
+      predicate parameterValueFlowsToPreUpdateCand(ParameterNode p, PostUpdateNode n) {
+        parameterValueFlowCand(p, n.getPreUpdateNode(), false, false)
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowsToPostUpdateCand(
+        ParameterNode p, PostUpdateNode n, boolean read
+      ) {
+        parameterValueFlowCand(p, n, read, true)
+      }
+
+      /**
+       * Holds if `p` can flow to a return node of kind `kind` in the same
+       * callable using only value-preserving steps, not taking call contexts
+       * into account.
+       *
+       * `read` indicates whether it is contents of `p` that can flow to the return
+       * node, and `stored` indicates whether it flows to contents of the return
+       * node.
+       */
+      predicate parameterValueFlowReturnCand(
+        ParameterNode p, ReturnKindExt kind, boolean read, boolean stored
+      ) {
+        exists(ReturnNode ret |
+          parameterValueFlowCand(p, ret, read, stored) and
+          kind = TValueReturn(ret.getKind())
+        )
+        or
+        exists(ParameterNode p2, int pos2, PostUpdateNode n |
+          parameterValueFlowsToPostUpdateCand(p, n, read) and
+          parameterValueFlowsToPreUpdateCand(p2, n) and
+          p2.isParameterOf(_, pos2) and
+          kind = TParamUpdate(pos2) and
+          p != p2 and
+          stored = true
+        )
+      }
+
+      pragma[nomagic]
+      private predicate argumentValueFlowsThroughCand0(
+        DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, boolean read, boolean stored
+      ) {
+        exists(ParameterNode param | viableParamArg(call, param, arg) |
+          parameterValueFlowReturnCand(param, kind, read, stored)
+        )
+      }
+
+      /**
+       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
+       * not taking call contexts into account.
+       *
+       * `read` indicates whether it is contents of `arg` that can flow to `out`, and
+       * `stored` indicates whether it flows to contents of `out`.
+       */
+      predicate argumentValueFlowsThroughCand(
+        ArgumentNode arg, Node out, boolean read, boolean stored
+      ) {
+        exists(DataFlowCall call, ReturnKindExt kind |
+          argumentValueFlowsThroughCand0(call, arg, kind, read, stored) and
+          out = kind.getAnOutNode(call)
+        )
+      }
+
+      predicate cand(ParameterNode p, Node n) {
+        parameterValueFlowCand(p, n, _, _) and
+        (
+          parameterValueFlowReturnCand(p, _, _, _)
+          or
+          parameterValueFlowsToPreUpdateCand(p, _)
+        )
+      }
+    }
+
+    private module LocalFlowBigStep {
+      private predicate localFlowEntry(Node n) {
+        Cand::cand(_, n) and
+        (
+          n instanceof ParameterNode or
+          n instanceof OutNode or
+          n instanceof PostUpdateNode or
+          readStep(_, _, n) or
+          n instanceof CastNode
+        )
+      }
+
+      private predicate localFlowExit(Node n) {
+        Cand::cand(_, n) and
+        (
+          n instanceof ArgumentNode
+          or
+          n instanceof ReturnNode
+          or
+          Cand::parameterValueFlowsToPreUpdateCand(_, n)
+          or
+          storeStep(n, _, _)
+          or
+          readStep(n, _, _)
+          or
+          n instanceof CastNode
+          or
+          n =
+            any(PostUpdateNode pun | Cand::parameterValueFlowsToPreUpdateCand(_, pun))
+                .getPreUpdateNode()
+        )
+      }
+
+      pragma[nomagic]
+      private predicate localFlowStepPlus(Node node1, Node node2) {
+        localFlowEntry(node1) and
+        simpleLocalFlowStep(node1, node2) and
+        node1 != node2 and
+        Cand::cand(_, node2)
+        or
+        exists(Node mid |
+          localFlowStepPlus(node1, mid) and
+          simpleLocalFlowStep(mid, node2) and
+          not mid instanceof CastNode and
+          Cand::cand(_, node2)
+        )
+      }
+
+      pragma[nomagic]
+      predicate localFlowBigStep(Node node1, Node node2) {
+        localFlowStepPlus(node1, node2) and
+        localFlowExit(node2)
+      }
+    }
+
+    /**
+     * The final flow-through calculation:
+     *
+     * - Input/output access paths are abstracted with a `ContentOption` parameter
+     *   that represents the head of the access path.
+     * - Types are checked using the `compatibleTypes()` relation.
+     */
+    module Final {
+      /**
+       * Holds if `p` can flow to `node` in the same callable using only
+       * value-preserving steps, not taking call contexts into account.
+       *
+       * `contentIn` describes the content of `p` that can flow to `node`
+       * (if any), and `contentOut` describes the content of `node` that
+       * it flows to (if any).
+       */
+      predicate parameterValueFlow(
+        ParameterNode p, Node node, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow0(p, node, contentIn, contentOut) and
+        Cand::cand(p, node) and
+        if node instanceof CastingNode
+        then
+          // normal flow through
+          contentIn = TContentNone() and
+          contentOut = TContentNone() and
+          compatibleTypes(getErasedNodeTypeBound(p), getErasedNodeTypeBound(node))
+          or
+          // getter
+          exists(Content fIn |
+            contentIn.getContent() = fIn and
+            contentOut = TContentNone() and
+            compatibleTypes(fIn.getType(), getErasedNodeTypeBound(node))
+          )
+          or
+          // setter
+          exists(Content fOut |
+            contentIn = TContentNone() and
+            contentOut.getContent() = fOut and
+            compatibleTypes(getErasedNodeTypeBound(p), fOut.getType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(node))
+          )
+          or
+          // getter+setter
+          exists(Content fIn, Content fOut |
+            contentIn.getContent() = fIn and
+            contentOut.getContent() = fOut and
+            compatibleTypes(fIn.getType(), fOut.getType()) and
+            compatibleTypes(fOut.getContainerType(), getErasedNodeTypeBound(node))
+          )
+        else any()
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlow0(
+        ParameterNode p, Node node, ContentOption contentIn, ContentOption contentOut
+      ) {
+        p = node and
+        Cand::cand(p, _) and
+        contentIn = TContentNone() and
+        contentOut = TContentNone()
+        or
+        // local flow
+        exists(Node mid |
+          parameterValueFlow(p, mid, contentIn, contentOut) and
+          LocalFlowBigStep::localFlowBigStep(mid, node)
+        )
+        or
+        // read
+        exists(Node mid, Content f, ContentOption contentInMid, ContentOption contentOutMid |
+          parameterValueFlow(p, mid, contentInMid, contentOutMid) and
+          readStep(mid, f, node)
+        |
+          // value neither read nor stored prior to read
+          contentInMid = TContentNone() and
+          contentOutMid = TContentNone() and
+          contentIn.getContent() = f and
+          contentOut = TContentNone() and
+          Cand::parameterValueFlowReturnCand(p, _, true, _)
+          or
+          // value (possibly read and then) stored prior to read (same content)
+          contentIn = contentInMid and
+          contentOutMid.getContent() = f and
+          contentOut = TContentNone()
+        )
+        or
+        // store
+        exists(Node mid, Content f |
+          parameterValueFlow(p, mid, contentIn, TContentNone()) and
+          storeStep(mid, f, node) and
+          contentOut.getContent() = f
+        )
+        or
+        // flow through: no prior read or store
+        exists(ArgumentNode arg |
+          parameterValueFlowArg(p, arg, TContentNone(), TContentNone()) and
+          argumentValueFlowsThrough(arg, node, contentIn, contentOut)
+        )
+        or
+        // flow through: no read or store inside method
+        exists(ArgumentNode arg |
+          parameterValueFlowArg(p, arg, contentIn, contentOut) and
+          argumentValueFlowsThrough(arg, node, TContentNone(), TContentNone())
+        )
+        or
+        // flow through: possible prior read and prior store with compatible
+        // flow-through method
+        exists(ArgumentNode arg, ContentOption contentMid |
+          parameterValueFlowArg(p, arg, contentIn, contentMid) and
+          argumentValueFlowsThrough(arg, node, contentMid, contentOut)
+        )
+      }
+
+      pragma[nomagic]
+      private predicate parameterValueFlowArg(
+        ParameterNode p, ArgumentNode arg, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow(p, arg, contentIn, contentOut) and
+        Cand::argumentValueFlowsThroughCand(arg, _, _, _)
+      }
+
+      pragma[nomagic]
+      predicate parameterValueFlowsToPostUpdate(
+        ParameterNode p, PostUpdateNode n, ContentOption contentIn, ContentOption contentOut
+      ) {
+        parameterValueFlow(p, n, contentIn, contentOut) and
+        contentOut.hasContent()
+      }
+
+      pragma[nomagic]
+      predicate argumentValueFlowsThrough0(
+        DataFlowCall call, ArgumentNode arg, ReturnKindExt kind, ContentOption contentIn,
+        ContentOption contentOut
+      ) {
+        exists(ParameterNode param | viableParamArg(call, param, arg) |
+          parameterValueFlowReturn(param, _, kind, contentIn, contentOut)
+        )
+      }
+
+      /**
+       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
+       * not taking call contexts into account.
+       *
+       * `contentIn` describes the content of `arg` that can flow to `out` (if any), and
+       * `contentOut` describes the content of `out` that it flows to (if any).
+       */
+      private predicate argumentValueFlowsThrough(
+        ArgumentNode arg, Node out, ContentOption contentIn, ContentOption contentOut
+      ) {
+        exists(DataFlowCall call, ReturnKindExt kind |
+          argumentValueFlowsThrough0(call, arg, kind, contentIn, contentOut) and
+          out = kind.getAnOutNode(call)
+        )
+      }
+    }
+
+    import Final
+  }
+
+  /**
+   * Holds if `p` can flow to the pre-update node associated with post-update
+   * node `n`, in the same callable, using only value-preserving steps.
+   */
+  cached
+  predicate parameterValueFlowsToPreUpdate(ParameterNode p, PostUpdateNode n) {
+    FlowThrough::parameterValueFlow(p, n.getPreUpdateNode(), TContentNone(), TContentNone())
+  }
+
+  /**
+   * Holds if `p` can flow to a return node of kind `kind` in the same
+   * callable using only value-preserving steps.
+   *
+   * `contentIn` describes the content of `p` that can flow to the return
+   * node (if any), and `contentOut` describes the content of the return
+   * node that it flows to (if any).
+   */
+  cached
+  predicate parameterValueFlowReturn(
+    ParameterNode p, Node ret, ReturnKindExt kind, ContentOption contentIn, ContentOption contentOut
+  ) {
+    ret =
+      any(ReturnNode n |
+        FlowThrough::parameterValueFlow(p, n, contentIn, contentOut) and
+        kind = TValueReturn(n.getKind())
+      )
+    or
+    ret =
+      any(PostUpdateNode n |
+        exists(ParameterNode p2, int pos2 |
+          FlowThrough::parameterValueFlowsToPostUpdate(p, n, contentIn, contentOut) and
+          parameterValueFlowsToPreUpdate(p2, n) and
+          p2.isParameterOf(_, pos2) and
+          kind = TParamUpdate(pos2) and
+          p != p2
+        )
+      )
+  }
+
+  /**
+   * Holds if `arg` flows to `out` through `call` using only value-preserving steps.
+   *
+   * `contentIn` describes the content of `arg` that can flow to `out` (if any), and
+   * `contentOut` describes the content of `out` that it flows to (if any).
+   */
+  cached
+  predicate argumentValueFlowsThrough(
+    DataFlowCall call, ArgumentNode arg, ContentOption contentIn, ContentOption contentOut, Node out
+  ) {
+    exists(ReturnKindExt kind |
+      FlowThrough::argumentValueFlowsThrough0(call, arg, kind, contentIn, contentOut) and
+      out = kind.getAnOutNode(call)
+    |
+      // normal flow through
+      contentIn = TContentNone() and
+      contentOut = TContentNone() and
+      compatibleTypes(getErasedNodeTypeBound(arg), getErasedNodeTypeBound(out))
+      or
+      // getter
+      exists(Content fIn |
+        contentIn.getContent() = fIn and
+        contentOut = TContentNone() and
+        compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
+      )
+      or
+      // setter
+      exists(Content fOut |
+        contentIn = TContentNone() and
+        contentOut.getContent() = fOut and
+        compatibleTypes(getErasedNodeTypeBound(arg), fOut.getType())
+      )
+      or
+      // getter+setter
+      exists(Content fIn, Content fOut |
+        contentIn.getContent() = fIn and
+        contentOut.getContent() = fOut and
+        compatibleTypes(getErasedNodeTypeBound(arg), fIn.getContainerType())
+      )
+    )
+  }
+
+  /**
+   * Holds if data can flow from `node1` to `node2` via a direct assignment to
+   * `f`.
+   *
+   * This includes reverse steps through reads when the result of the read has
+   * been stored into, in order to handle cases like `x.f1.f2 = y`.
+   */
+  cached
+  predicate storeDirect(Node node1, Content f, Node node2) {
+    storeStep(node1, f, node2) and readStep(_, f, _)
+    or
+    exists(Node n1, Node n2 |
+      n1 = node1.(PostUpdateNode).getPreUpdateNode() and
+      n2 = node2.(PostUpdateNode).getPreUpdateNode()
+    |
+      argumentValueFlowsThrough(_, n2, TContentSome(f), TContentNone(), n1)
+      or
+      readStep(n2, f, n1)
+    )
+  }
+
+  /**
+   * Holds if the call context `call` either improves virtual dispatch in
+   * `callable` or if it allows us to prune unreachable nodes in `callable`.
+   */
+  cached
+  predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
+    reducedViableImplInCallContext(_, callable, call)
+    or
+    exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
+  }
 
   cached
-  private module Cached {
-    /**
-     * Holds if `p` is the `i`th parameter of a viable dispatch target of `call`.
-     * The instance parameter is considered to have index `-1`.
-     */
-    pragma[nomagic]
-    private predicate viableParam(DataFlowCall call, int i, ParameterNode p) {
-      p.isParameterOf(viableCallable(call), i)
-    }
+  newtype TCallContext =
+    TAnyCallContext() or
+    TSpecificCall(DataFlowCall call) { recordDataFlowCallSite(call, _) } or
+    TSomeCall() or
+    TReturn(DataFlowCallable c, DataFlowCall call) { reducedViableImplInReturn(c, call) }
 
-    /**
-     * Holds if `arg` is a possible argument to `p` in `call`, taking virtual
-     * dispatch into account.
-     */
-    cached
-    predicate viableParamArg(DataFlowCall call, ParameterNode p, ArgumentNode arg) {
-      exists(int i |
-        viableParam(call, i, p) and
-        arg.argumentOf(call, i)
+  cached
+  newtype TReturnPosition =
+    TReturnPosition0(DataFlowCallable c, ReturnKindExt kind) {
+      exists(ReturnNodeExt ret |
+        c = returnNodeGetEnclosingCallable(ret) and
+        kind = ret.getKind()
       )
     }
 
-    /*
-     * The `FlowThrough_*` modules take a `step` relation as input and provide
-     * an `argumentValueFlowsThrough` relation as output.
-     *
-     * `FlowThrough_v1` includes just `simpleLocalFlowStep`, which is then used
-     * to detect getters and setters.
-     * `FlowThrough_v2` then includes a little bit of local field flow on top
-     * of `simpleLocalFlowStep`.
-     */
-
-    private module FlowThrough_v1 {
-      private predicate step = simpleLocalFlowStep/2;
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, not taking call contexts into account.
-       */
-      private predicate parameterValueFlowCand(ParameterNode p, Node node) {
-        p = node
-        or
-        exists(Node mid |
-          parameterValueFlowCand(p, mid) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlowCand(p, arg) and
-          argumentValueFlowsThroughCand(arg, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, not taking call contexts
-       * into account.
-       */
-      private predicate parameterValueFlowsThroughCand(ParameterNode p, ReturnKind kind) {
-        parameterValueFlowCand(p, getAReturnNodeOfKind(kind))
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThroughCand0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind
-      ) {
-        exists(ParameterNode param | viableParamArg(call, param, arg) |
-          parameterValueFlowsThroughCand(param, kind)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * not taking call contexts into account.
-       */
-      private predicate argumentValueFlowsThroughCand(ArgumentNode arg, OutNode out) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThroughCand0(call, arg, kind)
-        |
-          out = getAnOutNode(call, kind) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-
-      /**
-       * Holds if `arg` is the `i`th argument of `call` inside the callable
-       * `enclosing`, and `arg` may flow through `call`.
-       */
-      pragma[noinline]
-      private predicate argumentOf(
-        DataFlowCall call, int i, ArgumentNode arg, DataFlowCallable enclosing
-      ) {
-        arg.argumentOf(call, i) and
-        argumentValueFlowsThroughCand(arg, _) and
-        enclosing = arg.getEnclosingCallable()
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg0(
-        int i, ArgumentNode arg, CallContext outercc, DataFlowCall call
-      ) {
-        exists(DataFlowCallable c | argumentOf(call, i, arg, c) |
-          (
-            outercc = TAnyCallContext()
-            or
-            outercc = TSomeCall()
-            or
-            exists(DataFlowCall other | outercc = TSpecificCall(other) |
-              recordDataFlowCallSite(other, c)
-            )
-          ) and
-          not isUnreachableInCall(arg, outercc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg1(
-        ParameterNode p, DataFlowCallable callable, int i, ArgumentNode arg, CallContext outercc,
-        DataFlowCall call
-      ) {
-        viableParamArg0(i, arg, outercc, call) and
-        callable = resolveCall(call, outercc) and
-        p.isParameterOf(callable, any(int j | j <= i and j >= i))
-      }
-
-      /**
-       * Holds if `arg` is a possible argument to `p`, in the call `call`, and
-       * `arg` may flow through `call`. The possible contexts before and after
-       * entering the callable are `outercc` and `innercc`, respectively.
-       */
-      private predicate viableParamArg(
-        DataFlowCall call, ParameterNode p, ArgumentNode arg, CallContext outercc,
-        CallContextCall innercc
-      ) {
-        exists(int i, DataFlowCallable callable |
-          viableParamArg1(p, callable, i, arg, outercc, call)
-        |
-          if recordDataFlowCallSite(call, callable)
-          then innercc = TSpecificCall(call)
-          else innercc = TSomeCall()
-        )
-      }
-
-      private CallContextCall getAValidCallContextForParameter(ParameterNode p) {
-        result = TSomeCall()
-        or
-        exists(DataFlowCall call, DataFlowCallable callable |
-          result = TSpecificCall(call) and
-          p.isParameterOf(callable, _) and
-          recordDataFlowCallSite(call, callable)
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlow(ParameterNode p, Node node, CallContextCall cc) {
-        p = node and
-        parameterValueFlowsThroughCand(p, _) and
-        cc = getAValidCallContextForParameter(p)
-        or
-        exists(Node mid |
-          parameterValueFlow(p, mid, cc) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlow(p, arg, cc) and
-          argumentValueFlowsThrough(arg, node, cc) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlowsThrough(
-        ParameterNode p, ReturnKind kind, CallContextCall cc
-      ) {
-        parameterValueFlow(p, getAReturnNodeOfKind(kind), cc)
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThrough0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind, CallContext cc
-      ) {
-        exists(ParameterNode param, CallContext innercc |
-          viableParamArg(call, param, arg, cc, innercc) and
-          parameterValueFlowsThrough(param, kind, innercc)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * in call context cc.
-       */
-      predicate argumentValueFlowsThrough(ArgumentNode arg, OutNode out, CallContext cc) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThrough0(call, arg, kind, cc)
-        |
-          out = getAnOutNode(call, kind) and
-          not isUnreachableInCall(out, cc.(CallContextSpecificCall).getCall()) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-    }
-
-    /**
-     * Holds if `p` can flow to the pre-update node of `n` in the same callable
-     * using only value-preserving steps.
-     */
-    cached
-    predicate parameterValueFlowsToUpdate(ParameterNode p, PostUpdateNode n) {
-      parameterValueFlowNoCtx(p, n.getPreUpdateNode())
-    }
-
-    /**
-     * Holds if data can flow from `node1` to `node2` in one local step or a step
-     * through a value-preserving method.
-     */
-    private predicate localValueStep(Node node1, Node node2) {
-      simpleLocalFlowStep(node1, node2) or
-      FlowThrough_v1::argumentValueFlowsThrough(node1, node2, _)
-    }
-
-    /**
-     * Holds if `p` can flow to `node` in the same callable allowing local flow
-     * steps and value flow through methods. Call contexts are only accounted
-     * for in the nested calls.
-     */
-    private predicate parameterValueFlowNoCtx(ParameterNode p, Node node) {
-      p = node
-      or
-      exists(Node mid |
-        parameterValueFlowNoCtx(p, mid) and
-        localValueStep(mid, node) and
-        compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-      )
-    }
-
-    /*
-     * Calculation of `predicate store(Node node1, Content f, Node node2)`:
-     * There are four cases:
-     * - The base case: A direct local assignment given by `storeStep`.
-     * - A call to a method or constructor with two arguments, `arg1` and `arg2`,
-     *   such that the call has the side-effect `arg2.f = arg1`.
-     * - A call to a method that returns an object in which an argument has been
-     *   stored.
-     * - A reverse step through a read when the result of the read has been
-     *   stored into. This handles cases like `x.f1.f2 = y`.
-     * `storeViaSideEffect` covers the first two cases, and `storeReturn` covers
-     * the third case.
-     */
-
-    /**
-     * Holds if data can flow from `node1` to `node2` via a direct assignment to
-     * `f` or via a call that acts as a setter.
-     */
-    cached
-    predicate store(Node node1, Content f, Node node2) {
-      storeViaSideEffect(node1, f, node2) or
-      storeReturn(node1, f, node2) or
-      read(node2.(PostUpdateNode).getPreUpdateNode(), f, node1.(PostUpdateNode).getPreUpdateNode())
-    }
-
-    private predicate storeViaSideEffect(Node node1, Content f, PostUpdateNode node2) {
-      storeStep(node1, f, node2) and readStep(_, f, _)
-      or
-      exists(DataFlowCall call, int i1, int i2 |
-        setterCall(call, i1, i2, f) and
-        node1.(ArgumentNode).argumentOf(call, i1) and
-        node2.getPreUpdateNode().(ArgumentNode).argumentOf(call, i2) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getContainerType())
-      )
-    }
-
-    pragma[nomagic]
-    private predicate setterInParam(ParameterNode p1, Content f, ParameterNode p2) {
-      exists(Node n1, PostUpdateNode n2 |
-        parameterValueFlowNoCtx(p1, n1) and
-        storeViaSideEffect(n1, f, n2) and
-        parameterValueFlowNoCtx(p2, n2.getPreUpdateNode()) and
-        p1 != p2
-      )
-    }
-
-    pragma[nomagic]
-    private predicate setterCall(DataFlowCall call, int i1, int i2, Content f) {
-      exists(DataFlowCallable callable, ParameterNode p1, ParameterNode p2 |
-        setterInParam(p1, f, p2) and
-        callable = viableCallable(call) and
-        p1.isParameterOf(callable, i1) and
-        p2.isParameterOf(callable, i2)
-      )
-    }
-
-    pragma[noinline]
-    private predicate storeReturn0(DataFlowCall call, ReturnKind kind, ArgumentNode arg, Content f) {
-      exists(ParameterNode p |
-        viableParamArg(call, p, arg) and
-        setterReturn(p, f, kind)
-      )
-    }
-
-    private predicate storeReturn(Node node1, Content f, Node node2) {
-      exists(DataFlowCall call, ReturnKind kind |
-        storeReturn0(call, kind, node1, f) and
-        node2 = getAnOutNode(call, kind) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getContainerType())
-      )
-    }
-
-    private predicate setterReturn(ParameterNode p, Content f, ReturnKind kind) {
-      exists(Node n1, Node n2 |
-        parameterValueFlowNoCtx(p, n1) and
-        store(n1, f, n2) and
-        localValueStep*(n2, getAReturnNodeOfKind(kind))
-      )
-    }
-
-    pragma[noinline]
-    private predicate read0(DataFlowCall call, ReturnKind kind, ArgumentNode arg, Content f) {
-      exists(ParameterNode p |
-        viableParamArg(call, p, arg) and
-        getter(p, f, kind)
-      )
-    }
-
-    /**
-     * Holds if data can flow from `node1` to `node2` via a direct read of `f` or
-     * via a getter.
-     */
-    cached
-    predicate read(Node node1, Content f, Node node2) {
-      readStep(node1, f, node2)
-      or
-      exists(DataFlowCall call, ReturnKind kind |
-        read0(call, kind, node1, f) and
-        node2 = getAnOutNode(call, kind) and
-        compatibleTypes(getErasedNodeTypeBound(node1), f.getContainerType()) and
-        compatibleTypes(getErasedNodeTypeBound(node2), f.getType())
-      )
-    }
-
-    private predicate getter(ParameterNode p, Content f, ReturnKind kind) {
-      exists(Node n1, Node n2 |
-        parameterValueFlowNoCtx(p, n1) and
-        read(n1, f, n2) and
-        localValueStep*(n2, getAReturnNodeOfKind(kind))
-      )
-    }
-
-    cached
-    predicate localStoreReadStep(Node node1, Node node2) {
-      exists(Node mid1, Node mid2, Content f |
-        store(node1, f, mid1) and
-        localValueStep*(mid1, mid2) and
-        read(mid2, f, node2) and
-        compatibleTypes(getErasedNodeTypeBound(node1), getErasedNodeTypeBound(node2))
-      )
-    }
-
-    cached
-    module FlowThrough_v2 {
-      private predicate step(Node node1, Node node2) {
-        simpleLocalFlowStep(node1, node2) or
-        localStoreReadStep(node1, node2)
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, not taking call contexts into account.
-       */
-      private predicate parameterValueFlowCand(ParameterNode p, Node node) {
-        p = node
-        or
-        exists(Node mid |
-          parameterValueFlowCand(p, mid) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlowCand(p, arg) and
-          argumentValueFlowsThroughCand(arg, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node))
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, not taking call contexts
-       * into account.
-       */
-      private predicate parameterValueFlowsThroughCand(ParameterNode p, ReturnKind kind) {
-        parameterValueFlowCand(p, getAReturnNodeOfKind(kind))
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThroughCand0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind
-      ) {
-        exists(ParameterNode param | viableParamArg(call, param, arg) |
-          parameterValueFlowsThroughCand(param, kind)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * not taking call contexts into account.
-       */
-      private predicate argumentValueFlowsThroughCand(ArgumentNode arg, OutNode out) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThroughCand0(call, arg, kind)
-        |
-          out = getAnOutNode(call, kind) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-
-      /**
-       * Holds if `arg` is the `i`th argument of `call` inside the callable
-       * `enclosing`, and `arg` may flow through `call`.
-       */
-      pragma[noinline]
-      private predicate argumentOf(
-        DataFlowCall call, int i, ArgumentNode arg, DataFlowCallable enclosing
-      ) {
-        arg.argumentOf(call, i) and
-        argumentValueFlowsThroughCand(arg, _) and
-        enclosing = arg.getEnclosingCallable()
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg0(
-        int i, ArgumentNode arg, CallContext outercc, DataFlowCall call
-      ) {
-        exists(DataFlowCallable c | argumentOf(call, i, arg, c) |
-          (
-            outercc = TAnyCallContext()
-            or
-            outercc = TSomeCall()
-            or
-            exists(DataFlowCall other | outercc = TSpecificCall(other) |
-              recordDataFlowCallSite(other, c)
-            )
-          ) and
-          not isUnreachableInCall(arg, outercc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      pragma[noinline]
-      private predicate viableParamArg1(
-        ParameterNode p, DataFlowCallable callable, int i, ArgumentNode arg, CallContext outercc,
-        DataFlowCall call
-      ) {
-        viableParamArg0(i, arg, outercc, call) and
-        callable = resolveCall(call, outercc) and
-        p.isParameterOf(callable, any(int j | j <= i and j >= i))
-      }
-
-      /**
-       * Holds if `arg` is a possible argument to `p`, in the call `call`, and
-       * `arg` may flow through `call`. The possible contexts before and after
-       * entering the callable are `outercc` and `innercc`, respectively.
-       */
-      private predicate viableParamArg(
-        DataFlowCall call, ParameterNode p, ArgumentNode arg, CallContext outercc,
-        CallContextCall innercc
-      ) {
-        exists(int i, DataFlowCallable callable |
-          viableParamArg1(p, callable, i, arg, outercc, call)
-        |
-          if recordDataFlowCallSite(call, callable)
-          then innercc = TSpecificCall(call)
-          else innercc = TSomeCall()
-        )
-      }
-
-      private CallContextCall getAValidCallContextForParameter(ParameterNode p) {
-        result = TSomeCall()
-        or
-        exists(DataFlowCall call, DataFlowCallable callable |
-          result = TSpecificCall(call) and
-          p.isParameterOf(callable, _) and
-          recordDataFlowCallSite(call, callable)
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to `node` in the same callable using only
-       * value-preserving steps, in call context `cc`.
-       */
-      private predicate parameterValueFlow(ParameterNode p, Node node, CallContextCall cc) {
-        p = node and
-        parameterValueFlowsThroughCand(p, _) and
-        cc = getAValidCallContextForParameter(p)
-        or
-        exists(Node mid |
-          parameterValueFlow(p, mid, cc) and
-          step(mid, node) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-        or
-        // flow through a callable
-        exists(Node arg |
-          parameterValueFlow(p, arg, cc) and
-          argumentValueFlowsThrough(arg, node, cc) and
-          compatibleTypes(getErasedNodeType(p), getErasedNodeType(node)) and
-          not isUnreachableInCall(node, cc.(CallContextSpecificCall).getCall())
-        )
-      }
-
-      /**
-       * Holds if `p` can flow to a return node of kind `kind` in the same
-       * callable using only value-preserving steps, in call context `cc`.
-       */
-      cached
-      predicate parameterValueFlowsThrough(ParameterNode p, ReturnKind kind, CallContextCall cc) {
-        parameterValueFlow(p, getAReturnNodeOfKind(kind), cc)
-      }
-
-      pragma[nomagic]
-      private predicate argumentValueFlowsThrough0(
-        DataFlowCall call, ArgumentNode arg, ReturnKind kind, CallContext cc
-      ) {
-        exists(ParameterNode param, CallContext innercc |
-          viableParamArg(call, param, arg, cc, innercc) and
-          parameterValueFlowsThrough(param, kind, innercc)
-        )
-      }
-
-      /**
-       * Holds if `arg` flows to `out` through a call using only value-preserving steps,
-       * in call context cc.
-       */
-      cached
-      predicate argumentValueFlowsThrough(ArgumentNode arg, OutNode out, CallContext cc) {
-        exists(DataFlowCall call, ReturnKind kind |
-          argumentValueFlowsThrough0(call, arg, kind, cc)
-        |
-          out = getAnOutNode(call, kind) and
-          not isUnreachableInCall(out, cc.(CallContextSpecificCall).getCall()) and
-          compatibleTypes(getErasedNodeType(arg), getErasedNodeType(out))
-        )
-      }
-    }
-
-    /**
-     * Holds if the call context `call` either improves virtual dispatch in
-     * `callable` or if it allows us to prune unreachable nodes in `callable`.
-     */
-    cached
-    predicate recordDataFlowCallSite(DataFlowCall call, DataFlowCallable callable) {
-      reducedViableImplInCallContext(_, callable, call)
-      or
-      exists(Node n | n.getEnclosingCallable() = callable | isUnreachableInCall(n, call))
-    }
-
-    cached
-    newtype TCallContext =
-      TAnyCallContext() or
-      TSpecificCall(DataFlowCall call) { recordDataFlowCallSite(call, _) } or
-      TSomeCall() or
-      TReturn(DataFlowCallable c, DataFlowCall call) { reducedViableImplInReturn(c, call) }
-
-    cached
-    newtype TReturnPosition =
-      TReturnPosition0(DataFlowCallable c, ReturnKindExt kind) { returnPosition(_, c, kind) }
-
-    cached
-    newtype TLocalFlowCallContext =
-      TAnyLocalCall() or
-      TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
-  }
-
-  pragma[noinline]
-  private predicate returnPosition(ReturnNodeExt ret, DataFlowCallable c, ReturnKindExt kind) {
-    c = returnNodeGetEnclosingCallable(ret) and
-    kind = ret.getKind()
-  }
-
-  /**
-   * A call context to restrict the targets of virtual dispatch, prune local flow,
-   * and match the call sites of flow into a method with flow out of a method.
-   *
-   * There are four cases:
-   * - `TAnyCallContext()` : No restrictions on method flow.
-   * - `TSpecificCall(DataFlowCall call)` : Flow entered through the
-   *    given `call`. This call improves the set of viable
-   *    dispatch targets for at least one method call in the current callable
-   *    or helps prune unreachable nodes in the current callable.
-   * - `TSomeCall()` : Flow entered through a parameter. The
-   *    originating call does not improve the set of dispatch targets for any
-   *    method call in the current callable and was therefore not recorded.
-   * - `TReturn(Callable c, DataFlowCall call)` : Flow reached `call` from `c` and
-   *    this dispatch target of `call` implies a reduced set of dispatch origins
-   *    to which data may flow if it should reach a `return` statement.
-   */
-  abstract class CallContext extends TCallContext {
-    abstract string toString();
-
-    /** Holds if this call context is relevant for `callable`. */
-    abstract predicate relevantFor(DataFlowCallable callable);
-  }
-
-  class CallContextAny extends CallContext, TAnyCallContext {
-    override string toString() { result = "CcAny" }
-
-    override predicate relevantFor(DataFlowCallable callable) { any() }
-  }
-
-  abstract class CallContextCall extends CallContext { }
-
-  class CallContextSpecificCall extends CallContextCall, TSpecificCall {
-    override string toString() {
-      exists(DataFlowCall call | this = TSpecificCall(call) | result = "CcCall(" + call + ")")
-    }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      recordDataFlowCallSite(getCall(), callable)
-    }
-
-    DataFlowCall getCall() { this = TSpecificCall(result) }
-  }
-
-  class CallContextSomeCall extends CallContextCall, TSomeCall {
-    override string toString() { result = "CcSomeCall" }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      exists(ParameterNode p | p.getEnclosingCallable() = callable)
-    }
-  }
-
-  class CallContextReturn extends CallContext, TReturn {
-    override string toString() {
-      exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
-    }
-
-    override predicate relevantFor(DataFlowCallable callable) {
-      exists(DataFlowCall call | this = TReturn(_, call) and call.getEnclosingCallable() = callable)
-    }
-  }
-
-  /**
-   * A call context that is relevant for pruning local flow.
-   */
-  abstract class LocalCallContext extends TLocalFlowCallContext {
-    abstract string toString();
-
-    /** Holds if this call context is relevant for `callable`. */
-    abstract predicate relevantFor(DataFlowCallable callable);
-  }
-
-  class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
-    override string toString() { result = "LocalCcAny" }
-
-    override predicate relevantFor(DataFlowCallable callable) { any() }
-  }
-
-  class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
-    LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
-
-    DataFlowCall call;
-
-    DataFlowCall getCall() { result = call }
-
-    override string toString() { result = "LocalCcCall(" + call + ")" }
-
-    override predicate relevantFor(DataFlowCallable callable) { relevantLocalCCtx(call, callable) }
-  }
-
-  private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
-    exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
-  }
-
-  /**
-   * Gets the local call context given the call context and the callable that
-   * the contexts apply to.
-   */
-  LocalCallContext getLocalCallContext(CallContext ctx, DataFlowCallable callable) {
-    ctx.relevantFor(callable) and
-    if relevantLocalCCtx(ctx.(CallContextSpecificCall).getCall(), callable)
-    then result.(LocalCallContextSpecificCall).getCall() = ctx.(CallContextSpecificCall).getCall()
-    else result instanceof LocalCallContextAny
-  }
-
-  /**
-   * A node from which flow can return to the caller. This is either a regular
-   * `ReturnNode` or a `PostUpdateNode` corresponding to the value of a parameter.
-   */
-  class ReturnNodeExt extends Node {
-    ReturnNodeExt() {
-      this instanceof ReturnNode or
-      parameterValueFlowsToUpdate(_, this)
-    }
-
-    /** Gets the kind of this returned value. */
-    ReturnKindExt getKind() {
-      result = TValueReturn(this.(ReturnNode).getKind())
-      or
-      exists(ParameterNode p, int pos |
-        parameterValueFlowsToUpdate(p, this) and
-        p.isParameterOf(_, pos) and
-        result = TParamUpdate(pos)
-      )
-    }
-  }
-
-  private newtype TReturnKindExt =
+  cached
+  newtype TLocalFlowCallContext =
+    TAnyLocalCall() or
+    TSpecificLocalCall(DataFlowCall call) { isUnreachableInCall(_, call) }
+
+  cached
+  newtype TReturnKindExt =
     TValueReturn(ReturnKind kind) or
-    TParamUpdate(int pos) {
-      exists(ParameterNode p | parameterValueFlowsToUpdate(p, _) and p.isParameterOf(_, pos))
-    }
-
-  /**
-   * An extended return kind. A return kind describes how data can be returned
-   * from a callable. This can either be through a returned value or an updated
-   * parameter.
-   */
-  abstract class ReturnKindExt extends TReturnKindExt {
-    /** Gets a textual representation of this return kind. */
-    abstract string toString();
-
-    /** Gets a node corresponding to data flow out of `call`. */
-    abstract Node getAnOutNode(DataFlowCall call);
-  }
-
-  class ValueReturnKind extends ReturnKindExt, TValueReturn {
-    private ReturnKind kind;
-
-    ValueReturnKind() { this = TValueReturn(kind) }
-
-    ReturnKind getKind() { result = kind }
-
-    override string toString() { result = kind.toString() }
-
-    override Node getAnOutNode(DataFlowCall call) { result = getAnOutNode(call, this.getKind()) }
-  }
-
-  class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
-    private int pos;
-
-    ParamUpdateReturnKind() { this = TParamUpdate(pos) }
-
-    int getPosition() { result = pos }
-
-    override string toString() { result = "param update " + pos }
-
-    override Node getAnOutNode(DataFlowCall call) {
-      exists(ArgumentNode arg |
-        result.(PostUpdateNode).getPreUpdateNode() = arg and
-        arg.argumentOf(call, this.getPosition())
-      )
-    }
-  }
-
-  /** A callable tagged with a relevant return kind. */
-  class ReturnPosition extends TReturnPosition0 {
-    private DataFlowCallable c;
-    private ReturnKindExt kind;
-
-    ReturnPosition() { this = TReturnPosition0(c, kind) }
-
-    /** Gets the callable. */
-    DataFlowCallable getCallable() { result = c }
-
-    /** Gets the return kind. */
-    ReturnKindExt getKind() { result = kind }
-
-    /** Gets a textual representation of this return position. */
-    string toString() { result = "[" + kind + "] " + c }
-  }
-
-  pragma[noinline]
-  DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
-    result = ret.getEnclosingCallable()
-  }
-
-  pragma[noinline]
-  ReturnPosition getReturnPosition(ReturnNodeExt ret) {
-    exists(DataFlowCallable c, ReturnKindExt k | returnPosition(ret, c, k) |
-      result = TReturnPosition0(c, k)
-    )
-  }
-
-  bindingset[cc, callable]
-  predicate resolveReturn(CallContext cc, DataFlowCallable callable, DataFlowCall call) {
-    cc instanceof CallContextAny and callable = viableCallable(call)
-    or
-    exists(DataFlowCallable c0, DataFlowCall call0 |
-      call0.getEnclosingCallable() = callable and
-      cc = TReturn(c0, call0) and
-      c0 = prunedViableImplInCallContextReverse(call0, call)
-    )
-  }
-
-  bindingset[call, cc]
-  DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
-    exists(DataFlowCall ctx | cc = TSpecificCall(ctx) |
-      if reducedViableImplInCallContext(call, _, ctx)
-      then result = prunedViableImplInCallContext(call, ctx)
-      else result = viableCallable(call)
-    )
-    or
-    result = viableCallable(call) and cc instanceof CallContextSomeCall
-    or
-    result = viableCallable(call) and cc instanceof CallContextAny
-    or
-    result = viableCallable(call) and cc instanceof CallContextReturn
-  }
-
-  newtype TSummary =
-    TSummaryVal() or
-    TSummaryTaint() or
-    TSummaryReadVal(Content f) or
-    TSummaryReadTaint(Content f) or
-    TSummaryTaintStore(Content f)
-
-  /**
-   * A summary of flow through a callable. This can either be value-preserving
-   * if no additional steps are used, taint-flow if at least one additional step
-   * is used, or any one of those combined with a store or a read. Summaries
-   * recorded at a return node are restricted to include at least one additional
-   * step, as the value-based summaries are calculated independent of the
-   * configuration.
-   */
-  class Summary extends TSummary {
-    string toString() {
-      result = "Val" and this = TSummaryVal()
-      or
-      result = "Taint" and this = TSummaryTaint()
-      or
-      exists(Content f |
-        result = "ReadVal " + f.toString() and this = TSummaryReadVal(f)
-        or
-        result = "ReadTaint " + f.toString() and this = TSummaryReadTaint(f)
-        or
-        result = "TaintStore " + f.toString() and this = TSummaryTaintStore(f)
-      )
-    }
-
-    /** Gets the summary that results from extending this with an additional step. */
-    Summary additionalStep() {
-      this = TSummaryVal() and result = TSummaryTaint()
-      or
-      this = TSummaryTaint() and result = TSummaryTaint()
-      or
-      exists(Content f | this = TSummaryReadVal(f) and result = TSummaryReadTaint(f))
-      or
-      exists(Content f | this = TSummaryReadTaint(f) and result = TSummaryReadTaint(f))
-    }
-
-    /** Gets the summary that results from extending this with a read. */
-    Summary readStep(Content f) { this = TSummaryVal() and result = TSummaryReadVal(f) }
-
-    /** Gets the summary that results from extending this with a store. */
-    Summary storeStep(Content f) { this = TSummaryTaint() and result = TSummaryTaintStore(f) }
-
-    /** Gets the summary that results from extending this with `step`. */
-    bindingset[this, step]
-    Summary compose(Summary step) {
-      this = TSummaryVal() and result = step
-      or
-      this = TSummaryTaint() and
-      (step = TSummaryTaint() or step = TSummaryTaintStore(_)) and
-      result = step
-      or
-      exists(Content f |
-        this = TSummaryReadVal(f) and step = TSummaryTaint() and result = TSummaryReadTaint(f)
-      )
-      or
-      this = TSummaryReadTaint(_) and step = TSummaryTaint() and result = this
-    }
-
-    /** Holds if this summary does not include any taint steps. */
-    predicate isPartial() {
-      this = TSummaryVal() or
-      this = TSummaryReadVal(_)
-    }
-  }
-
-  pragma[noinline]
-  DataFlowType getErasedNodeType(Node n) { result = getErasedRepr(n.getType()) }
-
-  pragma[noinline]
-  DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
+    TParamUpdate(int pos) { exists(ParameterNode p | p.isParameterOf(_, pos)) }
 }
+
+/**
+ * A `Node` at which a cast can occur such that the type should be checked.
+ */
+class CastingNode extends Node {
+  CastingNode() {
+    this instanceof ParameterNode or
+    this instanceof CastNode or
+    this instanceof OutNode or
+    this.(PostUpdateNode).getPreUpdateNode() instanceof ArgumentNode
+  }
+}
+
+newtype TContentOption =
+  TContentNone() or
+  TContentSome(Content f)
+
+class ContentOption extends TContentOption {
+  Content getContent() { this = TContentSome(result) }
+
+  predicate hasContent() { exists(this.getContent()) }
+
+  string toString() {
+    result = this.getContent().toString()
+    or
+    not this.hasContent() and
+    result = ""
+  }
+}
+
+/**
+ * A call context to restrict the targets of virtual dispatch, prune local flow,
+ * and match the call sites of flow into a method with flow out of a method.
+ *
+ * There are four cases:
+ * - `TAnyCallContext()` : No restrictions on method flow.
+ * - `TSpecificCall(DataFlowCall call)` : Flow entered through the
+ *    given `call`. This call improves the set of viable
+ *    dispatch targets for at least one method call in the current callable
+ *    or helps prune unreachable nodes in the current callable.
+ * - `TSomeCall()` : Flow entered through a parameter. The
+ *    originating call does not improve the set of dispatch targets for any
+ *    method call in the current callable and was therefore not recorded.
+ * - `TReturn(Callable c, DataFlowCall call)` : Flow reached `call` from `c` and
+ *    this dispatch target of `call` implies a reduced set of dispatch origins
+ *    to which data may flow if it should reach a `return` statement.
+ */
+abstract class CallContext extends TCallContext {
+  abstract string toString();
+
+  /** Holds if this call context is relevant for `callable`. */
+  abstract predicate relevantFor(DataFlowCallable callable);
+}
+
+class CallContextAny extends CallContext, TAnyCallContext {
+  override string toString() { result = "CcAny" }
+
+  override predicate relevantFor(DataFlowCallable callable) { any() }
+}
+
+abstract class CallContextCall extends CallContext { }
+
+class CallContextSpecificCall extends CallContextCall, TSpecificCall {
+  override string toString() {
+    exists(DataFlowCall call | this = TSpecificCall(call) | result = "CcCall(" + call + ")")
+  }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    recordDataFlowCallSite(getCall(), callable)
+  }
+
+  DataFlowCall getCall() { this = TSpecificCall(result) }
+}
+
+class CallContextSomeCall extends CallContextCall, TSomeCall {
+  override string toString() { result = "CcSomeCall" }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    exists(ParameterNode p | p.getEnclosingCallable() = callable)
+  }
+}
+
+class CallContextReturn extends CallContext, TReturn {
+  override string toString() {
+    exists(DataFlowCall call | this = TReturn(_, call) | result = "CcReturn(" + call + ")")
+  }
+
+  override predicate relevantFor(DataFlowCallable callable) {
+    exists(DataFlowCall call | this = TReturn(_, call) and call.getEnclosingCallable() = callable)
+  }
+}
+
+/**
+ * A call context that is relevant for pruning local flow.
+ */
+abstract class LocalCallContext extends TLocalFlowCallContext {
+  abstract string toString();
+
+  /** Holds if this call context is relevant for `callable`. */
+  abstract predicate relevantFor(DataFlowCallable callable);
+}
+
+class LocalCallContextAny extends LocalCallContext, TAnyLocalCall {
+  override string toString() { result = "LocalCcAny" }
+
+  override predicate relevantFor(DataFlowCallable callable) { any() }
+}
+
+class LocalCallContextSpecificCall extends LocalCallContext, TSpecificLocalCall {
+  LocalCallContextSpecificCall() { this = TSpecificLocalCall(call) }
+
+  DataFlowCall call;
+
+  DataFlowCall getCall() { result = call }
+
+  override string toString() { result = "LocalCcCall(" + call + ")" }
+
+  override predicate relevantFor(DataFlowCallable callable) { relevantLocalCCtx(call, callable) }
+}
+
+private predicate relevantLocalCCtx(DataFlowCall call, DataFlowCallable callable) {
+  exists(Node n | n.getEnclosingCallable() = callable and isUnreachableInCall(n, call))
+}
+
+/**
+ * Gets the local call context given the call context and the callable that
+ * the contexts apply to.
+ */
+LocalCallContext getLocalCallContext(CallContext ctx, DataFlowCallable callable) {
+  ctx.relevantFor(callable) and
+  if relevantLocalCCtx(ctx.(CallContextSpecificCall).getCall(), callable)
+  then result.(LocalCallContextSpecificCall).getCall() = ctx.(CallContextSpecificCall).getCall()
+  else result instanceof LocalCallContextAny
+}
+
+/**
+ * A node from which flow can return to the caller. This is either a regular
+ * `ReturnNode` or a `PostUpdateNode` corresponding to the value of a parameter.
+ */
+class ReturnNodeExt extends Node {
+  ReturnNodeExt() {
+    this instanceof ReturnNode or
+    parameterValueFlowsToPreUpdate(_, this)
+  }
+
+  /** Gets the kind of this returned value. */
+  ReturnKindExt getKind() {
+    result = TValueReturn(this.(ReturnNode).getKind())
+    or
+    exists(ParameterNode p, int pos |
+      parameterValueFlowsToPreUpdate(p, this) and
+      p.isParameterOf(_, pos) and
+      result = TParamUpdate(pos)
+    )
+  }
+}
+
+/**
+ * An extended return kind. A return kind describes how data can be returned
+ * from a callable. This can either be through a returned value or an updated
+ * parameter.
+ */
+abstract class ReturnKindExt extends TReturnKindExt {
+  /** Gets a textual representation of this return kind. */
+  abstract string toString();
+
+  /** Gets a node corresponding to data flow out of `call`. */
+  abstract Node getAnOutNode(DataFlowCall call);
+}
+
+class ValueReturnKind extends ReturnKindExt, TValueReturn {
+  private ReturnKind kind;
+
+  ValueReturnKind() { this = TValueReturn(kind) }
+
+  ReturnKind getKind() { result = kind }
+
+  override string toString() { result = kind.toString() }
+
+  override Node getAnOutNode(DataFlowCall call) { result = getAnOutNode(call, this.getKind()) }
+}
+
+class ParamUpdateReturnKind extends ReturnKindExt, TParamUpdate {
+  private int pos;
+
+  ParamUpdateReturnKind() { this = TParamUpdate(pos) }
+
+  int getPosition() { result = pos }
+
+  override string toString() { result = "param update " + pos }
+
+  override PostUpdateNode getAnOutNode(DataFlowCall call) {
+    exists(ArgumentNode arg |
+      result.getPreUpdateNode() = arg and
+      arg.argumentOf(call, this.getPosition())
+    )
+  }
+}
+
+/** A callable tagged with a relevant return kind. */
+class ReturnPosition extends TReturnPosition0 {
+  private DataFlowCallable c;
+  private ReturnKindExt kind;
+
+  ReturnPosition() { this = TReturnPosition0(c, kind) }
+
+  /** Gets the callable. */
+  DataFlowCallable getCallable() { result = c }
+
+  /** Gets the return kind. */
+  ReturnKindExt getKind() { result = kind }
+
+  /** Gets a textual representation of this return position. */
+  string toString() { result = "[" + kind + "] " + c }
+}
+
+pragma[noinline]
+private DataFlowCallable returnNodeGetEnclosingCallable(ReturnNodeExt ret) {
+  result = ret.getEnclosingCallable()
+}
+
+pragma[noinline]
+ReturnPosition getReturnPosition(ReturnNodeExt ret) {
+  result = TReturnPosition0(returnNodeGetEnclosingCallable(ret), ret.getKind())
+}
+
+bindingset[cc, callable]
+predicate resolveReturn(CallContext cc, DataFlowCallable callable, DataFlowCall call) {
+  cc instanceof CallContextAny and callable = viableCallable(call)
+  or
+  exists(DataFlowCallable c0, DataFlowCall call0 |
+    call0.getEnclosingCallable() = callable and
+    cc = TReturn(c0, call0) and
+    c0 = prunedViableImplInCallContextReverse(call0, call)
+  )
+}
+
+bindingset[call, cc]
+DataFlowCallable resolveCall(DataFlowCall call, CallContext cc) {
+  exists(DataFlowCall ctx | cc = TSpecificCall(ctx) |
+    if reducedViableImplInCallContext(call, _, ctx)
+    then result = prunedViableImplInCallContext(call, ctx)
+    else result = viableCallable(call)
+  )
+  or
+  result = viableCallable(call) and cc instanceof CallContextSomeCall
+  or
+  result = viableCallable(call) and cc instanceof CallContextAny
+  or
+  result = viableCallable(call) and cc instanceof CallContextReturn
+}
+
+newtype TSummary =
+  TSummaryVal() or
+  TSummaryTaint() or
+  TSummaryReadVal(Content f) or
+  TSummaryReadTaint(Content f) or
+  TSummaryTaintStore(Content f)
+
+/**
+ * A summary of flow through a callable. This can either be value-preserving
+ * if no additional steps are used, taint-flow if at least one additional step
+ * is used, or any one of those combined with a store or a read. Summaries
+ * recorded at a return node are restricted to include at least one additional
+ * step, as the value-based summaries are calculated independent of the
+ * configuration.
+ */
+class Summary extends TSummary {
+  string toString() {
+    result = "Val" and this = TSummaryVal()
+    or
+    result = "Taint" and this = TSummaryTaint()
+    or
+    exists(Content f |
+      result = "ReadVal " + f.toString() and this = TSummaryReadVal(f)
+      or
+      result = "ReadTaint " + f.toString() and this = TSummaryReadTaint(f)
+      or
+      result = "TaintStore " + f.toString() and this = TSummaryTaintStore(f)
+    )
+  }
+
+  /** Gets the summary that results from extending this with an additional step. */
+  Summary additionalStep() {
+    this = TSummaryVal() and result = TSummaryTaint()
+    or
+    this = TSummaryTaint() and result = TSummaryTaint()
+    or
+    exists(Content f | this = TSummaryReadVal(f) and result = TSummaryReadTaint(f))
+    or
+    exists(Content f | this = TSummaryReadTaint(f) and result = TSummaryReadTaint(f))
+  }
+
+  /** Gets the summary that results from extending this with a read. */
+  Summary readStep(Content f) { this = TSummaryVal() and result = TSummaryReadVal(f) }
+
+  /** Gets the summary that results from extending this with a store. */
+  Summary storeStep(Content f) { this = TSummaryTaint() and result = TSummaryTaintStore(f) }
+
+  /** Gets the summary that results from extending this with `step`. */
+  bindingset[this, step]
+  Summary compose(Summary step) {
+    this = TSummaryVal() and result = step
+    or
+    this = TSummaryTaint() and
+    (step = TSummaryTaint() or step = TSummaryTaintStore(_)) and
+    result = step
+    or
+    exists(Content f |
+      this = TSummaryReadVal(f) and step = TSummaryTaint() and result = TSummaryReadTaint(f)
+    )
+    or
+    this = TSummaryReadTaint(_) and step = TSummaryTaint() and result = this
+  }
+
+  /** Holds if this summary does not include any taint steps. */
+  predicate isPartial() {
+    this = TSummaryVal() or
+    this = TSummaryReadVal(_)
+  }
+}
+
+pragma[noinline]
+DataFlowType getErasedNodeTypeBound(Node n) { result = getErasedRepr(n.getTypeBound()) }
+
+predicate readDirect = readStep/3;

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -323,4 +323,4 @@ predicate isUnreachableInCall(Node n, DataFlowCall call) {
   )
 }
 
-int flowThroughAccessPathLimit() { none() }
+int accessPathLimit() { result = 5 }

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -1,6 +1,6 @@
 private import java
 private import DataFlowUtil
-private import DataFlowImplCommon::Public
+private import DataFlowImplCommon
 private import DataFlowDispatch
 private import semmle.code.java.controlflow.Guards
 private import semmle.code.java.dataflow.SSA
@@ -322,3 +322,5 @@ predicate isUnreachableInCall(Node n, DataFlowCall call) {
     guard.controls(n.asExpr().getBasicBlock(), arg.getBooleanValue().booleanNot())
   )
 }
+
+int flowThroughAccessPathLimit() { none() }

--- a/java/ql/test/library-tests/dataflow/call-sensitivity/flow.expected
+++ b/java/ql/test/library-tests/dataflow/call-sensitivity/flow.expected
@@ -32,7 +32,6 @@ nodes
 | A2.java:15:15:15:28 | new Integer(...) : Number | semmle.label | new Integer(...) : Number |
 | A2.java:27:27:27:34 | o : Number | semmle.label | o : Number |
 | A2.java:29:9:29:9 | o | semmle.label | o |
-| A2.java:37:10:37:10 | o | semmle.label | o |
 | A.java:14:29:14:36 | o : Number | semmle.label | o : Number |
 | A.java:16:9:16:9 | o | semmle.label | o |
 | A.java:20:30:20:37 | o : Number | semmle.label | o : Number |

--- a/java/ql/test/library-tests/dataflow/gettersetter/gettersetter.expected
+++ b/java/ql/test/library-tests/dataflow/gettersetter/gettersetter.expected
@@ -1,6 +1,7 @@
 | Read | A.java:5:12:5:15 | this | A.java:5:12:5:19 | this.foo | A.java:2:7:2:9 | foo |
 | Read | A.java:21:13:21:13 | a | A.java:21:13:21:22 | getFoo(...) | A.java:2:7:2:9 | foo |
 | Read | A.java:23:9:23:9 | a | A.java:23:9:23:19 | aGetter(...) | A.java:2:7:2:9 | foo |
+| Read | A.java:24:9:24:10 | a2 | A.java:24:9:24:23 | notAGetter(...) | A.java:2:7:2:9 | foo |
 | Read | A.java:45:12:45:38 | maybeIdWrap(...) | A.java:45:12:45:42 | maybeIdWrap(...).foo | A.java:2:7:2:9 | foo |
 | Read | A.java:49:12:49:38 | maybeIdWrap(...) | A.java:49:12:49:42 | maybeIdWrap(...).foo | A.java:2:7:2:9 | foo |
 | Store | A.java:9:16:9:16 | x | A.java:9:5:9:8 | this [post update] | A.java:2:7:2:9 | foo |

--- a/java/ql/test/library-tests/dataflow/gettersetter/gettersetter.ql
+++ b/java/ql/test/library-tests/dataflow/gettersetter/gettersetter.ql
@@ -1,7 +1,17 @@
 import java
-import semmle.code.java.dataflow.internal.DataFlowImplCommon::Public
+import semmle.code.java.dataflow.internal.DataFlowImplCommon
 import semmle.code.java.dataflow.internal.DataFlowImplSpecific::Public
 import semmle.code.java.dataflow.internal.DataFlowImplSpecific::Private
+
+private predicate read(Node n1, Content f, Node n2) {
+  readDirect(n1, f, n2) or
+  argumentValueFlowsThrough(_, n1, TContentSome(f), TContentNone(), n2)
+}
+
+private predicate store(Node n1, Content f, Node n2) {
+  storeDirect(n1, f, n2) or
+  argumentValueFlowsThrough(_, n1, TContentNone(), TContentSome(f), n2)
+}
 
 from Node n1, Content f, Node n2, string k
 where


### PR DESCRIPTION
### Summary

The essence of this PR is to generalize the predicate

```
argumentValueFlowsThrough(ArgumentNode arg, OutNode out)
```

to

```
argumentValueFlowsThrough(
  ArgumentNode arg, Node out, ContentOption contentIn, ContentOption contentOut
)
```

The extra parameters `ContentOption contentIn` and `ContentOption contentOut` describe the contents (if any) of `arg` that can flow through to the contents (if any) of `out`. This gives four combinations:

`contentIn` | `contentOut` | Type | Count on [mono](https://github.com/mono/mono)
--- | --- | --- | ---
`None` | `None` | Normal flow through (as before this PR) | 102.312
`Some(f)` | `None` | An `f` getter | 1.022.730
`None` | `Some(f)` | An `f` setter | 281.193
`Some(f1)` | `Some(f2)` | An `f1`-getter + `f2`-setter | 1.620.922

Getters and setters were handled prior to this PR as well, but they were defined as special cases. The new type getter+setter means we are able to handle summaries for e.g. clone methods:
```
class A
{
    object Field;

    public A Clone() // a getter+setter
    {
        var ret = new A();
        ret.Field = this.Field;
        return ret;
    }
}
```
 
### Implementation details

#### DataFlowImplCommon.qll
- The old implementation contained two modules `FlowThrough_v1` and `FlowThrough_v2` for computing flow summaries. The latter was used to calculate getters and setters, which was used as input to the second calculation.
- The new implementation calculates generalized flow summaries, so getters and setters (and getter-setters) are computed as part of the recursion, which means we no longer need two phases.
- Call contexts are no longer needed, since we now reconstruct all flow-through summaries as part of `pathStep` in `DataFlowImpl.qll`.

#### DataFlowImpl.qll
- `nodeCandFwd1`, `nodeCand1`, and `parameterFlow` no longer use flow summaries, as they are able to reconstruct the summaries.
- Getter-setter steps are simulated by synthesizing a new `ReadStoreNodeExt n` node; `n1 -read-> n -store-> n2`. Consequently, all pruning steps (except those above), use a new `NodeExt` type instead of `Node`.
- `pathStep` now reconstructs *all* flow summaries (not just those involving taint steps). In particular, `pathStep` works with normal `Node`s and not `NodeExt`s.

### Performance

#### C#
Dist-compare report is [here](https://gist.github.com/hvitved/9395d8bdafd0d31533f2e07597e2416c#file-report5-md). In order to get acceptable performance, I had to restrict flow-through to access path of length at most 3.

#### Java
Java-Differences job is [here](https://jenkins.internal.semmle.com/job/Changes/job/Java-Differences/571/) (internal link).

#### C++
CPP-Differences job is [here](https://jenkins.internal.semmle.com/job/Changes/job/CPP-Differences/814/) (internal link).


### Follow-up work

Taint-getters and taint-setters will be generalized along the same lines, and the various pruning steps can be simplified by introducing new synthesized `NodeExt`s, like for getter-setters.

### Notes for the reviewer

Commit-by-commit review is strongly encouraged, and I suggest reviewing 7678cb0349f6e316c0bd241af42a6b734783f43e with the feature `Hide whitespace changes` enabled.