### PR TITLE
C++: Overrideable taint sources in DefaultTaintTracking

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
@@ -28,6 +28,8 @@ private predicate userInputInstruction(Instruction instr) {
   or
   userInputReturned(instr.getConvertedResultExpression())
   or
+  isUserInput(instr.getConvertedResultExpression(), _)
+  or
   instr.getConvertedResultExpression() instanceof EnvironmentRead
   or
   instr


### PR DESCRIPTION
This PR adds support for overriding `SecurityOptions.isUserInput` in `DefaultTaintTracking.qll` as suggested in the jira ticket: https://jira.semmle.com/browse/CPP-482