### PR TITLE
CPP: Model strdup

### DIFF
--- a/change-notes/1.24/analysis-cpp.md
+++ b/change-notes/1.24/analysis-cpp.md
@@ -35,3 +35,8 @@ The following changes in version 1.24 affect C/C++ analysis in all applications.
     about the _name or scope_ of variables should remain unchanged.
   * The `LocalScopeVariableReachability` library is deprecated in favor of
     `StackVariableReachability`. The functionality is the same.
+* The data flow library (`semmle.code.cpp.dataflow.DataFlow`) has had the
+  following improvements, all of which benefit the taint tracking library
+  (`semmle.code.cpp.dataflow.TaintTracking`) as well.
+  * The library now models data flow through `strdup` and similar functions.
+  

--- a/change-notes/1.24/analysis-cpp.md
+++ b/change-notes/1.24/analysis-cpp.md
@@ -35,8 +35,7 @@ The following changes in version 1.24 affect C/C++ analysis in all applications.
     about the _name or scope_ of variables should remain unchanged.
   * The `LocalScopeVariableReachability` library is deprecated in favor of
     `StackVariableReachability`. The functionality is the same.
-* The data flow library (`semmle.code.cpp.dataflow.DataFlow`) has had the
-  following improvements, all of which benefit the taint tracking library
-  (`semmle.code.cpp.dataflow.TaintTracking`) as well.
+* The taint tracking library (`semmle.code.cpp.dataflow.TaintTracking`) has had
+  the following improvements:
   * The library now models data flow through `strdup` and similar functions.
   

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -602,14 +602,9 @@ private predicate exprToExprStep_nocfg(Expr fromExpr, Expr toExpr) {
       exists(DataFlowFunction f, FunctionInput inModel, FunctionOutput outModel, int iIn |
         call.getTarget() = f and
         f.hasDataFlow(inModel, outModel) and
-        fromExpr = call.getArgument(iIn) and
-        (
-          inModel.isParameter(iIn) and
-          outModel.isReturnValue()
-          or
-          inModel.isParameterDeref(iIn) and
-          outModel.isReturnValueDeref()
-        )
+        outModel.isReturnValue() and
+        inModel.isParameter(iIn) and
+        fromExpr = call.getArgument(iIn)
       )
     )
 }

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -602,9 +602,14 @@ private predicate exprToExprStep_nocfg(Expr fromExpr, Expr toExpr) {
       exists(DataFlowFunction f, FunctionInput inModel, FunctionOutput outModel, int iIn |
         call.getTarget() = f and
         f.hasDataFlow(inModel, outModel) and
-        outModel.isReturnValue() and
-        inModel.isParameter(iIn) and
-        fromExpr = call.getArgument(iIn)
+        fromExpr = call.getArgument(iIn) and
+        (
+          inModel.isParameter(iIn) and
+          outModel.isReturnValue()
+          or
+          inModel.isParameterDeref(iIn) and
+          outModel.isReturnValueDeref()
+        )
       )
     )
 }

--- a/cpp/ql/src/semmle/code/cpp/models/Models.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/Models.qll
@@ -9,5 +9,6 @@ private import implementations.Printf
 private import implementations.Pure
 private import implementations.Strcat
 private import implementations.Strcpy
+private import implementations.Strdup
 private import implementations.Strftime
 private import implementations.Swap

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
@@ -173,32 +173,14 @@ class ReallocAllocationFunction extends AllocationFunction {
 }
 
 /**
- * An allocation function (such as `strdup`) that has no explicit argument for
+ * A miscellaneous allocation function that has no explicit argument for
  * the size of the allocation.
  */
-class StrdupAllocationFunction extends AllocationFunction {
-  StrdupAllocationFunction() {
+class SizelessAllocationFunction extends AllocationFunction {
+  SizelessAllocationFunction() {
     exists(string name |
-      hasGlobalOrStdName(name) and
-      (
-        // strdup(str)
-        name = "strdup"
-        or
-        // wcsdup(str)
-        name = "wcsdup"
-      )
-      or
       hasGlobalName(name) and
       (
-        // _strdup(str)
-        name = "_strdup"
-        or
-        // _wcsdup(str)
-        name = "_wcsdup"
-        or
-        // _mbsdup(str)
-        name = "_mbsdup"
-        or
         // ExAllocateFromLookasideListEx(list)
         name = "ExAllocateFromLookasideListEx"
         or

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Strdup.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Strdup.qll
@@ -1,0 +1,31 @@
+import semmle.code.cpp.models.interfaces.Allocation
+
+/**
+ * A `strdup` style allocation function.
+ */
+class StrdupFunction extends AllocationFunction {
+  StrdupFunction() {
+    exists(string name |
+      hasGlobalOrStdName(name) and
+      (
+        // strdup(str)
+        name = "strdup"
+        or
+        // wcsdup(str)
+        name = "wcsdup"
+      )
+      or
+      hasGlobalName(name) and
+      (
+        // _strdup(str)
+        name = "_strdup"
+        or
+        // _wcsdup(str)
+        name = "_wcsdup"
+        or
+        // _mbsdup(str)
+        name = "_mbsdup"
+      )
+    )
+  }
+}

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Strdup.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Strdup.qll
@@ -1,9 +1,12 @@
 import semmle.code.cpp.models.interfaces.Allocation
+import semmle.code.cpp.models.interfaces.ArrayFunction
+import semmle.code.cpp.models.interfaces.DataFlow
+import semmle.code.cpp.models.interfaces.Taint
 
 /**
  * A `strdup` style allocation function.
  */
-class StrdupFunction extends AllocationFunction {
+class StrdupFunction extends AllocationFunction, ArrayFunction, DataFlowFunction {
   StrdupFunction() {
     exists(string name |
       hasGlobalOrStdName(name) and
@@ -27,5 +30,16 @@ class StrdupFunction extends AllocationFunction {
         name = "_mbsdup"
       )
     )
+  }
+
+  override predicate hasArrayInput(int bufParam) { bufParam = 0 }
+
+  override predicate hasArrayWithNullTerminator(int bufParam) { bufParam = 0 }
+
+  override predicate hasDataFlow(FunctionInput input, FunctionOutput output) {
+    // These always copy the full value of the input buffer to the result
+    // buffer
+    input.isParameterDeref(0) and
+    output.isReturnValueDeref()
   }
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -144,7 +144,7 @@
 | taint.cpp:170:10:170:15 | ref arg buffer | taint.cpp:171:8:171:13 | buffer |  |
 | taint.cpp:170:10:170:15 | ref arg buffer | taint.cpp:172:10:172:15 | buffer |  |
 | taint.cpp:170:10:170:15 | ref arg buffer | taint.cpp:173:8:173:13 | buffer |  |
-| taint.cpp:170:18:170:26 | Hello,  | taint.cpp:170:3:170:8 | call to strcpy |  |
+| taint.cpp:170:18:170:26 | Hello,  | taint.cpp:170:3:170:8 | call to strcpy | TAINT |
 | taint.cpp:170:18:170:26 | Hello,  | taint.cpp:170:10:170:15 | ref arg buffer | TAINT |
 | taint.cpp:171:8:171:13 | ref arg buffer | taint.cpp:172:10:172:15 | buffer |  |
 | taint.cpp:171:8:171:13 | ref arg buffer | taint.cpp:173:8:173:13 | buffer |  |
@@ -164,9 +164,9 @@
 | taint.cpp:194:9:194:10 | ref arg & ... | taint.cpp:194:2:194:7 | call to memcpy |  |
 | taint.cpp:194:9:194:10 | ref arg & ... | taint.cpp:195:7:195:7 | x |  |
 | taint.cpp:194:10:194:10 | x | taint.cpp:194:9:194:10 | & ... |  |
-| taint.cpp:194:13:194:18 | ref arg source | taint.cpp:194:2:194:7 | call to memcpy |  |
-| taint.cpp:194:13:194:18 | source | taint.cpp:194:2:194:7 | call to memcpy |  |
+| taint.cpp:194:13:194:18 | source | taint.cpp:194:2:194:7 | call to memcpy | TAINT |
 | taint.cpp:194:13:194:18 | source | taint.cpp:194:9:194:10 | ref arg & ... | TAINT |
+| taint.cpp:194:21:194:31 | sizeof(int) | taint.cpp:194:2:194:7 | call to memcpy | TAINT |
 | taint.cpp:194:21:194:31 | sizeof(int) | taint.cpp:194:9:194:10 | ref arg & ... | TAINT |
 | taint.cpp:207:6:207:11 | call to source | taint.cpp:207:2:207:13 | ... = ... |  |
 | taint.cpp:207:6:207:11 | call to source | taint.cpp:210:7:210:7 | x |  |
@@ -331,10 +331,10 @@
 | taint.cpp:365:24:365:29 | source | taint.cpp:371:14:371:19 | source |  |
 | taint.cpp:369:6:369:11 | call to strdup | taint.cpp:369:2:369:19 | ... = ... |  |
 | taint.cpp:369:6:369:11 | call to strdup | taint.cpp:372:7:372:7 | a |  |
-| taint.cpp:369:13:369:18 | source | taint.cpp:369:6:369:11 | call to strdup |  |
+| taint.cpp:369:13:369:18 | source | taint.cpp:369:6:369:11 | call to strdup | TAINT |
 | taint.cpp:370:6:370:11 | call to strdup | taint.cpp:370:2:370:27 | ... = ... |  |
 | taint.cpp:370:6:370:11 | call to strdup | taint.cpp:373:7:373:7 | b |  |
-| taint.cpp:370:13:370:26 | hello, world | taint.cpp:370:6:370:11 | call to strdup |  |
+| taint.cpp:370:13:370:26 | hello, world | taint.cpp:370:6:370:11 | call to strdup | TAINT |
 | taint.cpp:371:6:371:12 | call to strndup | taint.cpp:371:2:371:25 | ... = ... |  |
 | taint.cpp:371:6:371:12 | call to strndup | taint.cpp:374:7:374:7 | c |  |
 | taint.cpp:377:23:377:28 | source | taint.cpp:381:30:381:35 | source |  |
@@ -343,7 +343,7 @@
 | taint.cpp:385:27:385:32 | source | taint.cpp:389:13:389:18 | source |  |
 | taint.cpp:389:6:389:11 | call to wcsdup | taint.cpp:389:2:389:19 | ... = ... |  |
 | taint.cpp:389:6:389:11 | call to wcsdup | taint.cpp:391:7:391:7 | a |  |
-| taint.cpp:389:13:389:18 | source | taint.cpp:389:6:389:11 | call to wcsdup |  |
+| taint.cpp:389:13:389:18 | source | taint.cpp:389:6:389:11 | call to wcsdup | TAINT |
 | taint.cpp:390:6:390:11 | call to wcsdup | taint.cpp:390:2:390:28 | ... = ... |  |
 | taint.cpp:390:6:390:11 | call to wcsdup | taint.cpp:392:7:392:7 | b |  |
-| taint.cpp:390:13:390:27 | hello, world | taint.cpp:390:6:390:11 | call to wcsdup |  |
+| taint.cpp:390:13:390:27 | hello, world | taint.cpp:390:6:390:11 | call to wcsdup | TAINT |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -324,3 +324,19 @@
 | taint.cpp:347:13:347:13 | d | taint.cpp:347:12:347:13 | & ... |  |
 | taint.cpp:348:14:348:14 | ref arg e | taint.cpp:355:7:355:7 | e |  |
 | taint.cpp:348:17:348:17 | ref arg t | taint.cpp:350:7:350:7 | t |  |
+| taint.cpp:365:24:365:29 | source | taint.cpp:369:13:369:18 | source |  |
+| taint.cpp:365:24:365:29 | source | taint.cpp:371:14:371:19 | source |  |
+| taint.cpp:369:6:369:11 | call to strdup | taint.cpp:369:2:369:19 | ... = ... |  |
+| taint.cpp:369:6:369:11 | call to strdup | taint.cpp:372:7:372:7 | a |  |
+| taint.cpp:370:6:370:11 | call to strdup | taint.cpp:370:2:370:27 | ... = ... |  |
+| taint.cpp:370:6:370:11 | call to strdup | taint.cpp:373:7:373:7 | b |  |
+| taint.cpp:371:6:371:12 | call to strndup | taint.cpp:371:2:371:25 | ... = ... |  |
+| taint.cpp:371:6:371:12 | call to strndup | taint.cpp:374:7:374:7 | c |  |
+| taint.cpp:377:23:377:28 | source | taint.cpp:381:30:381:35 | source |  |
+| taint.cpp:381:6:381:12 | call to strndup | taint.cpp:381:2:381:36 | ... = ... |  |
+| taint.cpp:381:6:381:12 | call to strndup | taint.cpp:382:7:382:7 | a |  |
+| taint.cpp:385:27:385:32 | source | taint.cpp:389:13:389:18 | source |  |
+| taint.cpp:389:6:389:11 | call to wcsdup | taint.cpp:389:2:389:19 | ... = ... |  |
+| taint.cpp:389:6:389:11 | call to wcsdup | taint.cpp:391:7:391:7 | a |  |
+| taint.cpp:390:6:390:11 | call to wcsdup | taint.cpp:390:2:390:28 | ... = ... |  |
+| taint.cpp:390:6:390:11 | call to wcsdup | taint.cpp:392:7:392:7 | b |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -144,6 +144,7 @@
 | taint.cpp:170:10:170:15 | ref arg buffer | taint.cpp:171:8:171:13 | buffer |  |
 | taint.cpp:170:10:170:15 | ref arg buffer | taint.cpp:172:10:172:15 | buffer |  |
 | taint.cpp:170:10:170:15 | ref arg buffer | taint.cpp:173:8:173:13 | buffer |  |
+| taint.cpp:170:18:170:26 | Hello,  | taint.cpp:170:3:170:8 | call to strcpy |  |
 | taint.cpp:170:18:170:26 | Hello,  | taint.cpp:170:10:170:15 | ref arg buffer | TAINT |
 | taint.cpp:171:8:171:13 | ref arg buffer | taint.cpp:172:10:172:15 | buffer |  |
 | taint.cpp:171:8:171:13 | ref arg buffer | taint.cpp:173:8:173:13 | buffer |  |
@@ -163,6 +164,8 @@
 | taint.cpp:194:9:194:10 | ref arg & ... | taint.cpp:194:2:194:7 | call to memcpy |  |
 | taint.cpp:194:9:194:10 | ref arg & ... | taint.cpp:195:7:195:7 | x |  |
 | taint.cpp:194:10:194:10 | x | taint.cpp:194:9:194:10 | & ... |  |
+| taint.cpp:194:13:194:18 | ref arg source | taint.cpp:194:2:194:7 | call to memcpy |  |
+| taint.cpp:194:13:194:18 | source | taint.cpp:194:2:194:7 | call to memcpy |  |
 | taint.cpp:194:13:194:18 | source | taint.cpp:194:9:194:10 | ref arg & ... | TAINT |
 | taint.cpp:194:21:194:31 | sizeof(int) | taint.cpp:194:9:194:10 | ref arg & ... | TAINT |
 | taint.cpp:207:6:207:11 | call to source | taint.cpp:207:2:207:13 | ... = ... |  |
@@ -328,8 +331,10 @@
 | taint.cpp:365:24:365:29 | source | taint.cpp:371:14:371:19 | source |  |
 | taint.cpp:369:6:369:11 | call to strdup | taint.cpp:369:2:369:19 | ... = ... |  |
 | taint.cpp:369:6:369:11 | call to strdup | taint.cpp:372:7:372:7 | a |  |
+| taint.cpp:369:13:369:18 | source | taint.cpp:369:6:369:11 | call to strdup |  |
 | taint.cpp:370:6:370:11 | call to strdup | taint.cpp:370:2:370:27 | ... = ... |  |
 | taint.cpp:370:6:370:11 | call to strdup | taint.cpp:373:7:373:7 | b |  |
+| taint.cpp:370:13:370:26 | hello, world | taint.cpp:370:6:370:11 | call to strdup |  |
 | taint.cpp:371:6:371:12 | call to strndup | taint.cpp:371:2:371:25 | ... = ... |  |
 | taint.cpp:371:6:371:12 | call to strndup | taint.cpp:374:7:374:7 | c |  |
 | taint.cpp:377:23:377:28 | source | taint.cpp:381:30:381:35 | source |  |
@@ -338,5 +343,7 @@
 | taint.cpp:385:27:385:32 | source | taint.cpp:389:13:389:18 | source |  |
 | taint.cpp:389:6:389:11 | call to wcsdup | taint.cpp:389:2:389:19 | ... = ... |  |
 | taint.cpp:389:6:389:11 | call to wcsdup | taint.cpp:391:7:391:7 | a |  |
+| taint.cpp:389:13:389:18 | source | taint.cpp:389:6:389:11 | call to wcsdup |  |
 | taint.cpp:390:6:390:11 | call to wcsdup | taint.cpp:390:2:390:28 | ... = ... |  |
 | taint.cpp:390:6:390:11 | call to wcsdup | taint.cpp:392:7:392:7 | b |  |
+| taint.cpp:390:13:390:27 | hello, world | taint.cpp:390:6:390:11 | call to wcsdup |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -354,3 +354,40 @@ void test_outparams()
 	sink(d); // tainted [NOT DETECTED]
 	sink(e);
 }
+
+// --- strdup ---
+
+typedef unsigned long size_t;
+char *strdup(const char *s1);
+char *strndup(const char *s1, size_t n);
+wchar_t* wcsdup(const wchar_t* s1);
+
+void test_strdup(char *source)
+{
+	char *a, *b, *c;
+
+	a = strdup(source);
+	b = strdup("hello, world");
+	c = strndup(source, 100);
+	sink(a); // tainted [NOT DETECTED]
+	sink(b);
+	sink(c); // tainted [NOT DETECTED]
+}
+
+void test_strndup(int source)
+{
+	char *a;
+
+	a = strndup("hello, world", source);
+	sink(a);
+}
+
+void test_wcsdup(wchar_t *source)
+{
+	wchar_t *a, *b;
+
+	a = wcsdup(source);
+	b = wcsdup(L"hello, world");
+	sink(a); // tainted [NOT DETECTED]
+	sink(b);
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -369,7 +369,7 @@ void test_strdup(char *source)
 	a = strdup(source);
 	b = strdup("hello, world");
 	c = strndup(source, 100);
-	sink(a); // tainted [NOT DETECTED]
+	sink(a); // tainted
 	sink(b);
 	sink(c); // tainted [NOT DETECTED]
 }
@@ -388,6 +388,6 @@ void test_wcsdup(wchar_t *source)
 
 	a = wcsdup(source);
 	b = wcsdup(L"hello, world");
-	sink(a); // tainted [NOT DETECTED]
+	sink(a); // tainted
 	sink(b);
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -37,3 +37,5 @@
 | taint.cpp:350:7:350:7 | t | taint.cpp:330:6:330:11 | call to source |
 | taint.cpp:351:7:351:7 | a | taint.cpp:330:6:330:11 | call to source |
 | taint.cpp:352:7:352:7 | b | taint.cpp:330:6:330:11 | call to source |
+| taint.cpp:372:7:372:7 | a | taint.cpp:365:24:365:29 | source |
+| taint.cpp:391:7:391:7 | a | taint.cpp:385:27:385:32 | source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -25,3 +25,5 @@
 | taint.cpp:350:7:350:7 | taint.cpp:330:6:330:11 | AST only |
 | taint.cpp:351:7:351:7 | taint.cpp:330:6:330:11 | AST only |
 | taint.cpp:352:7:352:7 | taint.cpp:330:6:330:11 | AST only |
+| taint.cpp:372:7:372:7 | taint.cpp:365:24:365:29 | AST only |
+| taint.cpp:391:7:391:7 | taint.cpp:385:27:385:32 | AST only |


### PR DESCRIPTION
We already modelled `strdup` as an allocation function.  This PR adds `ArrayFunction` and `DataFlowFunction` models for it as well (for https://jira.semmle.com/browse/CPP-466).

Notably `DataFlowUtil.qll` has extremely sparse support for possible data flows through modelled functions.  I suspect I will be making many changes to it in the coming days / weeks so please be super critical and/or constructive about that part.