### PR TITLE
C#: Fix bad magic optimization in `NonAssignedFields.ql`

### DIFF
--- a/csharp/ql/src/Dead Code/NonAssignedFields.ql
+++ b/csharp/ql/src/Dead Code/NonAssignedFields.ql
@@ -34,15 +34,14 @@ ValueOrRefType getAReferencedType(Type t) {
 
 predicate isTypeExternallyInitialized(ValueOrRefType t) {
   // The type got created via a call to PtrToStructure().
-  exists(MethodCall mc |
+  exists(MethodCall mc, Type t0, Expr arg |
     mc.getTarget() = any(SystemRuntimeInteropServicesMarshalClass c).getPtrToStructureTypeMethod() and
-    t = getAReferencedType(mc.getArgument(1).(TypeofExpr).getTypeAccess().getTarget())
-  )
-  or
-  // The type got created via a call to PtrToStructure().
-  exists(MethodCall mc |
-    mc.getTarget() = any(SystemRuntimeInteropServicesMarshalClass c).getPtrToStructureObjectMethod() and
-    t = getAReferencedType(mc.getArgument(1).getType())
+    t = getAReferencedType(t0) and
+    arg = mc.getArgument(1)
+  |
+    t0 = arg.(TypeofExpr).getTypeAccess().getTarget()
+    or
+    t0 = arg.getType()
   )
   or
   // An extern method exists which could initialize the type.


### PR DESCRIPTION
A bad magic predicate `m#Call::Call#class#b` had crept in, and after a bit of (manual) bisecting, I found out that this was caused by https://github.com/Semmle/ql/pull/2450. Presumably the reason is that the PR updates the db stats, so for the future we should remember to run a `dist-compare` whenever we update the db stats.