### PR TITLE
CPP: Fix a mistake in Inet.qll.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Inet.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Inet.qll
@@ -47,7 +47,7 @@ class InetNetwork extends TaintFunction, ArrayFunction {
   InetNetwork() { hasGlobalName("inet_network") }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
-    input.isParameterDeref(1) and
+    input.isParameterDeref(0) and
     output.isReturnValue()
   }
 


### PR DESCRIPTION
`inet_network` only has an input parameter 0, e.g. see https://linux.die.net/man/3/inet_network

(spotted as part of https://jira.semmle.com/browse/CPP-466)