### PR TITLE
C++: Performance fix for getMemoryOperandDefinition

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/SSAConstruction.qll
@@ -75,6 +75,22 @@ private module Cached {
     )
   }
 
+  private predicate hasMemoryOperandDefinition (OldInstruction oldInstruction, OldIR::NonPhiMemoryOperand oldOperand,
+    Overlap overlap, Instruction instr) {
+      oldOperand = oldInstruction.getAnOperand() and
+    exists(
+      OldBlock useBlock, int useRank, Alias::MemoryLocation useLocation,
+      Alias::MemoryLocation defLocation, OldBlock defBlock, int defRank, int defOffset
+    |
+      useLocation = Alias::getOperandMemoryLocation(oldOperand) and
+      hasDefinitionAtRank(useLocation, defLocation, defBlock, defRank, defOffset) and
+      hasUseAtRank(useLocation, useBlock, useRank, oldInstruction) and
+      definitionReachesUse(useLocation, defBlock, defRank, useBlock, useRank) and
+      overlap = Alias::getOverlap(defLocation, useLocation) and
+      instr = getDefinitionOrChiInstruction(defBlock, defOffset, defLocation, _)
+    )
+  }
+
   cached
   Instruction getMemoryOperandDefinition(
     Instruction instruction, MemoryOperandTag tag, Overlap overlap
@@ -87,17 +103,7 @@ private module Cached {
         (
           if exists(Alias::getOperandMemoryLocation(oldOperand))
           then
-            exists(
-              OldBlock useBlock, int useRank, Alias::MemoryLocation useLocation,
-              Alias::MemoryLocation defLocation, OldBlock defBlock, int defRank, int defOffset
-            |
-              useLocation = Alias::getOperandMemoryLocation(oldOperand) and
-              hasDefinitionAtRank(useLocation, defLocation, defBlock, defRank, defOffset) and
-              hasUseAtRank(useLocation, useBlock, useRank, oldInstruction) and
-              definitionReachesUse(useLocation, defBlock, defRank, useBlock, useRank) and
-              overlap = Alias::getOverlap(defLocation, useLocation) and
-              result = getDefinitionOrChiInstruction(defBlock, defOffset, defLocation, _)
-            )
+          hasMemoryOperandDefinition(oldInstruction, oldOperand, overlap, result)
           else (
             result = instruction.getEnclosingIRFunction().getUnmodeledDefinitionInstruction() and
             overlap instanceof MustTotallyOverlap


### PR DESCRIPTION
Old tuple counts:
```
[2020-01-16 08:57:24] (858s) Tuple counts for SSAConstruction::Cached::getMemoryOperandDefinition#ffff:
                      1955272   ~0%         {2} r1 = SCAN Operand::NonPhiOperand#2#ffff AS I OUTPUT I.<3>, I.<0>
                      769411    ~0%         {2} r2 = JOIN r1 WITH OperandTag::MemoryOperandTag#class#f AS R ON FIRST 1 OUTPUT r1.<1>, R.<0>
                      769411    ~0%         {2} r3 = JOIN r2 WITH Operand::NonPhiMemoryOperand#fffff AS R ON FIRST 1 OUTPUT r2.<0>, r2.<1>
                      769411    ~2%         {3} r4 = JOIN r3 WITH Operand::Operand::getUse_dispred#2#ff AS R ON FIRST 1 OUTPUT R.<1>, r3.<1>, r3.<0>
                      768903    ~0%         {4} r5 = JOIN r4 WITH SSAConstruction::Cached::WrappedInstruction#ff AS R ON FIRST 1 OUTPUT r4.<2>, r4.<1>, r4.<0>, R.<1>
                      453194    ~0%         {4} r6 = JOIN r5 WITH AliasedSSA::getOperandMemoryLocation#ff AS R ON FIRST 1 OUTPUT R.<1>, r5.<1>, r5.<2>, r5.<3>
                      499950488 ~0%         {6} r7 = JOIN r6 WITH AliasedSSA::getOverlap#fff_102#join_rhs AS R ON FIRST 1 OUTPUT r6.<0>, r6.<2>, r6.<1>, r6.<3>, R.<1>, R.<2>
                      499950488 ~0%         {7} r8 = JOIN r7 WITH SSAConstruction::DefUse::hasUseAtRank#ffff_0312#join_rhs AS R ON FIRST 2 OUTPUT r7.<0>, R.<2>, R.<3>, r7.<2>, r7.<3>, r7.<4>, r7.<5>
                      499950488 ~1%         {7} r9 = JOIN r8 WITH SSAConstruction::DefUse::definitionReachesUse#fffff_03412#join_rhs AS R ON FIRST 3 OUTPUT r8.<0>, r8.<5>, R.<3>, R.<4>, r8.<3>, r8.<4>, r8.<6>
                      453203    ~2%         {6} r10 = JOIN r9 WITH SSAConstruction::DefUse::hasDefinitionAtRank#fffff AS R ON FIRST 4 OUTPUT r9.<2>, R.<4>, r9.<1>, r9.<4>, r9.<5>, r9.<6>
                      453203    ~2%         {4} r11 = JOIN r10 WITH project#SSAConstruction::DefUse::getDefinitionOrChiInstruction#fffff AS R ON FIRST 3 OUTPUT r10.<4>, r10.<3>, r10.<5>, R.<3>
                      768903    ~0%         {4} r12 = JOIN r4 WITH SSAConstruction::Cached::WrappedInstruction#ff AS R ON FIRST 1 OUTPUT r4.<1>, r4.<2>, r4.<0>, R.<1>
                      768903    ~4%         {5} r13 = JOIN r12 WITH Overlap::MustTotallyOverlap#class#f AS R CARTESIAN PRODUCT OUTPUT r12.<0>, r12.<1>, r12.<2>, r12.<3>, R.<0>
                      316548    ~0%         {5} r14 = r13 AND NOT project#AliasedSSA::getOperandMemoryLocation#ff AS R(r13.<1>)
                      316548    ~11056%     {3} r15 = SCAN r14 OUTPUT r14.<3>, r14.<0>, r14.<4>
                      316548    ~10778%     {4} r16 = JOIN r15 WITH SSAConstruction::Cached::getInstructionEnclosingIRFunction#ff AS R ON FIRST 1 OUTPUT R.<1>, r15.<1>, r15.<0>, r15.<2>
                      316548    ~10954%     {4} r17 = JOIN r16 WITH IRFunction::IRFunction::getUnmodeledDefinitionInstruction#ff AS R ON FIRST 1 OUTPUT r16.<2>, r16.<1>, r16.<3>, R.<1>
                      769751    ~72%        {4} r18 = r11 \/ r17
                      316548    ~0%         {4} r19 = JOIN r12 WITH OperandTag::UnmodeledUseOperandTag#class#f AS R ON FIRST 1 OUTPUT r12.<3>, r12.<0>, r12.<1>, r12.<2>
                      316548    ~6%         {4} r20 = JOIN r19 WITH Instruction::UnmodeledUseInstruction#class#f AS R ON FIRST 1 OUTPUT r19.<2>, r19.<1>, r19.<3>, r19.<0>
                      316548    ~3%         {5} r21 = JOIN r20 WITH Operand::NonPhiOperand#2#ffff AS R ON FIRST 1 OUTPUT r20.<1>, r20.<0>, r20.<2>, r20.<3>, R.<2>
                      2760      ~0%         {5} r22 = r21 AND NOT project#AliasedSSA::getResultMemoryLocation#ff AS R(r21.<4>)
                      2760      ~3%         {3} r23 = SCAN r22 OUTPUT r22.<4>, r22.<0>, r22.<3>
                      2760      ~0%         {3} r24 = JOIN r23 WITH SSAConstruction::Cached::WrappedInstruction#ff AS R ON FIRST 1 OUTPUT r23.<1>, r23.<2>, R.<1>
                      2760      ~0%         {4} r25 = JOIN r24 WITH Overlap::MustTotallyOverlap#class#f AS R CARTESIAN PRODUCT OUTPUT r24.<1>, r24.<0>, R.<0>, r24.<2>
                      772511    ~73%        {4} r26 = r18 \/ r25
                      1         ~0%         {1} r27 = JOIN OperandTag::ChiPartialOperandTag#class#f AS L WITH OperandTag::MemoryOperandTag#class#f AS R ON FIRST 1 OUTPUT L.<0>
                      1         ~0%         {2} r28 = JOIN r27 WITH Overlap::MustExactlyOverlap#class#f AS R CARTESIAN PRODUCT OUTPUT r27.<0>, R.<0>
                      1455456   ~6%         {4} r29 = JOIN r28 WITH SSAConstruction::Cached::WrappedInstruction#ff AS R CARTESIAN PRODUCT OUTPUT R.<0>, r28.<0>, r28.<1>, R.<1>
                      309336    ~2%         {4} r30 = JOIN r29 WITH SSAConstruction::Cached::Chi#ff AS R ON FIRST 1 OUTPUT R.<1>, r29.<1>, r29.<2>, r29.<3>
                      1081847   ~41%        {4} r31 = r26 \/ r30
                      1         ~0%         {1} r32 = JOIN OperandTag::UnmodeledUseOperandTag#class#f AS L WITH OperandTag::MemoryOperandTag#class#f AS R ON FIRST 1 OUTPUT L.<0>
                      1         ~0%         {2} r33 = JOIN r32 WITH Overlap::MustTotallyOverlap#class#f AS R CARTESIAN PRODUCT OUTPUT r32.<0>, R.<0>
                      2761      ~0%         {4} r34 = JOIN r33 WITH IRFunction::IRFunction::getUnmodeledDefinitionInstruction#ff AS R CARTESIAN PRODUCT OUTPUT R.<0>, r33.<0>, r33.<1>, R.<1>
                      2760      ~0%         {4} r35 = JOIN r34 WITH IRFunction::IRFunction::getUnmodeledUseInstruction#ff AS R ON FIRST 1 OUTPUT R.<1>, r34.<1>, r34.<2>, r34.<3>
                      1084607   ~41%        {4} r36 = r31 \/ r35
                      1         ~0%         {1} r37 = JOIN OperandTag::ChiTotalOperandTag#class#f AS L WITH OperandTag::MemoryOperandTag#class#f AS R ON FIRST 1 OUTPUT L.<0>
                      1         ~0%         {2} r38 = JOIN r37 WITH Overlap::MustExactlyOverlap#class#f AS R CARTESIAN PRODUCT OUTPUT r37.<0>, R.<0>
                      309336    ~1%         {4} r39 = JOIN r38 WITH SSAConstruction::Cached::getChiInstructionTotalOperand#ff AS R CARTESIAN PRODUCT OUTPUT R.<0>, r38.<0>, r38.<1>, R.<1>
                      1393943   ~34%        {4} r40 = r36 \/ r39
                                            return r40
```
New tuple counts:
```
[2020-01-17 10:59:33] (576s) Tuple counts for SSAConstruction::Cached::hasMemoryOperandDefinition#ffff:
                      769411   ~2%     {2} r1 = JOIN cast_result#NonPhiMemoryOperand#f AS L WITH Operand::Operand::getUse_dispred#2#ff AS R ON FIRST 1 OUTPUT R.<0>, R.<1>
                      769411   ~2%     {2} r2 = STREAM DEDUP r1
                      453702   ~0%     {3} r3 = JOIN r2 WITH AliasedSSA::getOperandMemoryLocation#ff AS R ON FIRST 1 OUTPUT R.<1>, r2.<1>, r2.<0>
                      453194   ~8%     {5} r4 = JOIN r3 WITH SSAConstruction::DefUse::hasUseAtRank#ffff_0312#join_rhs AS R ON FIRST 2 OUTPUT r3.<0>, R.<2>, R.<3>, r3.<2>, r3.<1>
                      453194   ~1%     {5} r5 = JOIN r4 WITH SSAConstruction::DefUse::definitionReachesUse#fffff_03412#join_rhs AS R ON FIRST 3 OUTPUT r4.<0>, R.<3>, R.<4>, r4.<3>, r4.<4>
                      453203   ~2%     {6} r6 = JOIN r5 WITH SSAConstruction::DefUse::hasDefinitionAtRank#fffff_02314#join_rhs AS R ON FIRST 3 OUTPUT r5.<1>, R.<4>, R.<3>, r5.<3>, r5.<4>, r5.<0>
                      453203   ~0%     {5} r7 = JOIN r6 WITH SSAConstruction::DefUse::getDefinitionOrChiInstruction#fffff AS R ON FIRST 3 OUTPUT r6.<2>, r6.<5>, r6.<3>, r6.<4>, R.<4>
                      453203   ~1%     {4} r8 = JOIN r7 WITH AliasedSSA::getOverlap#fff AS R ON FIRST 2 OUTPUT r7.<3>, r7.<2>, R.<2>, r7.<4>
                                       return r8
```
```
[2020-01-17 10:59:34] (577s) Tuple counts for SSAConstruction::Cached::getMemoryOperandDefinition#ffff:
                      1955272 ~0%         {2} r1 = SCAN Operand::NonPhiOperand#2#ffff AS I OUTPUT I.<3>, I.<0>
                      769411  ~0%         {2} r2 = JOIN r1 WITH OperandTag::MemoryOperandTag#class#f AS R ON FIRST 1 OUTPUT r1.<1>, R.<0>
                      769411  ~0%         {2} r3 = JOIN r2 WITH Operand::NonPhiMemoryOperand#fffff AS R ON FIRST 1 OUTPUT r2.<0>, r2.<1>
                      769411  ~2%         {3} r4 = JOIN r3 WITH Operand::Operand::getUse_dispred#2#ff AS R ON FIRST 1 OUTPUT R.<1>, r3.<1>, r3.<0>
                      768903  ~0%         {4} r5 = JOIN r4 WITH SSAConstruction::Cached::WrappedInstruction#ff AS R ON FIRST 1 OUTPUT r4.<2>, r4.<1>, r4.<0>, R.<1>
                      452355  ~0%         {4} r6 = JOIN r5 WITH project#AliasedSSA::getOperandMemoryLocation#ff AS R ON FIRST 1 OUTPUT r5.<2>, r5.<0>, r5.<1>, r5.<3>
                      452369  ~1%         {4} r7 = JOIN r6 WITH SSAConstruction::Cached::hasMemoryOperandDefinition#ffff AS R ON FIRST 2 OUTPUT r6.<3>, r6.<2>, R.<2>, R.<3>
                      768903  ~0%         {4} r8 = JOIN r4 WITH SSAConstruction::Cached::WrappedInstruction#ff AS R ON FIRST 1 OUTPUT r4.<1>, r4.<2>, r4.<0>, R.<1>
                      768903  ~4%         {5} r9 = JOIN r8 WITH Overlap::MustTotallyOverlap#class#f AS R CARTESIAN PRODUCT OUTPUT r8.<0>, r8.<1>, r8.<2>, r8.<3>, R.<0>
                      316548  ~0%         {5} r10 = r9 AND NOT project#AliasedSSA::getOperandMemoryLocation#ff AS R(r9.<1>)
                      316548  ~11056%     {3} r11 = SCAN r10 OUTPUT r10.<3>, r10.<0>, r10.<4>
                      316548  ~10778%     {4} r12 = JOIN r11 WITH SSAConstruction::Cached::getInstructionEnclosingIRFunction#ff AS R ON FIRST 1 OUTPUT R.<1>, r11.<1>, r11.<0>, r11.<2>
                      316548  ~10954%     {4} r13 = JOIN r12 WITH IRFunction::IRFunction::getUnmodeledDefinitionInstruction#ff AS R ON FIRST 1 OUTPUT r12.<2>, r12.<1>, r12.<3>, R.<1>
                      768917  ~72%        {4} r14 = r7 \/ r13
                      316548  ~0%         {4} r15 = JOIN r8 WITH OperandTag::UnmodeledUseOperandTag#class#f AS R ON FIRST 1 OUTPUT r8.<3>, r8.<0>, r8.<1>, r8.<2>
                      316548  ~6%         {4} r16 = JOIN r15 WITH Instruction::UnmodeledUseInstruction#class#f AS R ON FIRST 1 OUTPUT r15.<2>, r15.<1>, r15.<3>, r15.<0>
                      316548  ~3%         {5} r17 = JOIN r16 WITH Operand::NonPhiOperand#2#ffff AS R ON FIRST 1 OUTPUT r16.<1>, r16.<0>, r16.<2>, r16.<3>, R.<2>
                      2760    ~0%         {5} r18 = r17 AND NOT project#AliasedSSA::getResultMemoryLocation#ff AS R(r17.<4>)
                      2760    ~3%         {3} r19 = SCAN r18 OUTPUT r18.<4>, r18.<0>, r18.<3>
                      2760    ~0%         {3} r20 = JOIN r19 WITH SSAConstruction::Cached::WrappedInstruction#ff AS R ON FIRST 1 OUTPUT r19.<1>, r19.<2>, R.<1>
                      2760    ~0%         {4} r21 = JOIN r20 WITH Overlap::MustTotallyOverlap#class#f AS R CARTESIAN PRODUCT OUTPUT r20.<1>, r20.<0>, R.<0>, r20.<2>
                      771677  ~73%        {4} r22 = r14 \/ r21
                      1       ~0%         {1} r23 = JOIN OperandTag::ChiPartialOperandTag#class#f AS L WITH OperandTag::MemoryOperandTag#class#f AS R ON FIRST 1 OUTPUT L.<0>
                      1       ~0%         {2} r24 = JOIN r23 WITH Overlap::MustExactlyOverlap#class#f AS R CARTESIAN PRODUCT OUTPUT r23.<0>, R.<0>
                      1455456 ~6%         {4} r25 = JOIN r24 WITH SSAConstruction::Cached::WrappedInstruction#ff AS R CARTESIAN PRODUCT OUTPUT R.<0>, r24.<0>, r24.<1>, R.<1>
                      309336  ~2%         {4} r26 = JOIN r25 WITH SSAConstruction::Cached::Chi#ff AS R ON FIRST 1 OUTPUT R.<1>, r25.<1>, r25.<2>, r25.<3>
                      1081013 ~41%        {4} r27 = r22 \/ r26
                      1       ~0%         {1} r28 = JOIN OperandTag::UnmodeledUseOperandTag#class#f AS L WITH OperandTag::MemoryOperandTag#class#f AS R ON FIRST 1 OUTPUT L.<0>
                      1       ~0%         {2} r29 = JOIN r28 WITH Overlap::MustTotallyOverlap#class#f AS R CARTESIAN PRODUCT OUTPUT r28.<0>, R.<0>
                      2761    ~0%         {4} r30 = JOIN r29 WITH IRFunction::IRFunction::getUnmodeledDefinitionInstruction#ff AS R CARTESIAN PRODUCT OUTPUT R.<0>, r29.<0>, r29.<1>, R.<1>
                      2760    ~0%         {4} r31 = JOIN r30 WITH IRFunction::IRFunction::getUnmodeledUseInstruction#ff AS R ON FIRST 1 OUTPUT R.<1>, r30.<1>, r30.<2>, r30.<3>
                      1083773 ~41%        {4} r32 = r27 \/ r31
                      1       ~0%         {1} r33 = JOIN OperandTag::ChiTotalOperandTag#class#f AS L WITH OperandTag::MemoryOperandTag#class#f AS R ON FIRST 1 OUTPUT L.<0>
                      1       ~0%         {2} r34 = JOIN r33 WITH Overlap::MustExactlyOverlap#class#f AS R CARTESIAN PRODUCT OUTPUT r33.<0>, R.<0>
                      309336  ~1%         {4} r35 = JOIN r34 WITH SSAConstruction::Cached::getChiInstructionTotalOperand#ff AS R CARTESIAN PRODUCT OUTPUT R.<0>, r34.<0>, r34.<1>, R.<1>
                      1393109 ~34%        {4} r36 = r32 \/ r35
                                          return r36
```
The tuple bulge is fixed and it evaluates in under a second rather than almost five minutes. The duplicate tuple percentages in r11, r12, and r13 are extremely high but they don't seem to have an impact on evaluation time.