### PR TITLE
C++: Fix typo in MallocSizeExpr

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/NtohlArrayNoBound.qll
+++ b/cpp/ql/src/Likely Bugs/Memory Management/NtohlArrayNoBound.qll
@@ -122,7 +122,7 @@ class MallocSizeExpr extends BufferAccess, FunctionCall {
 
   override Expr getPointer() { none() }
 
-  override Expr getAccessedLength() { result = getArgument(1) }
+  override Expr getAccessedLength() { result = getArgument(0) }
 }
 
 class NetworkFunctionCall extends FunctionCall {


### PR DESCRIPTION
The first argument is index 0, not 1.