### PR TITLE
C#: Fix cs/serialization-check-bypass

### DIFF
--- a/csharp/ql/src/Security Features/CWE-020/RuntimeChecksBypass.ql
+++ b/csharp/ql/src/Security Features/CWE-020/RuntimeChecksBypass.ql
@@ -35,7 +35,9 @@ Expr uncheckedWrite(Callable callable, Field f) {
   result.getEnclosingCallable() = callable and
   not callable.calls*(checkedWrite(f, _, _).getEnclosingCallable()) and
   // Exclude object creations because they were not deserialized
-  not exists(ObjectCreation src | DataFlow::localExprFlow(src, result))
+  not exists(Expr src | DataFlow::localExprFlow(src, result) |
+    src instanceof ObjectCreation or src.hasValue()
+  )
 }
 
 from BinarySerializableType t, Field f, IfStmt check, Expr write, Expr unsafeWrite

--- a/csharp/ql/test/query-tests/Security Features/CWE-020/RuntimeChecksBypass.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-020/RuntimeChecksBypass.cs
@@ -17,7 +17,7 @@ public class Test1
     [OnDeserializing]
     public void Deserialize()
     {
-        f = "invalid";  // BAD
+        f = $"invalid";  // BAD
     }
 }
 
@@ -37,7 +37,7 @@ public class Test2
     [OnDeserializing]
     public void Deserialize()
     {
-        var v = "invalid";
+        var v = $"invalid";
         f = v;  // BAD: False negative
 
         if (v == "valid")
@@ -63,7 +63,7 @@ public class Test3
     [OnDeserializing]
     public void Deserialize()
     {
-        var v = "invalid";
+        var v = $"invalid";
         f = v;  // GOOD: False negative
         Assign(v);
     }
@@ -95,7 +95,7 @@ public class Test4
     [OnDeserializing]
     public void Deserialize()
     {
-        var v = "invalid";
+        var v = $"invalid";
         if (v == "valid")
             Assign(v);
     }

--- a/csharp/ql/test/query-tests/Security Features/CWE-020/RuntimeChecksBypass.cs
+++ b/csharp/ql/test/query-tests/Security Features/CWE-020/RuntimeChecksBypass.cs
@@ -10,14 +10,14 @@ public class Test1
     {
         if (v == "valid")
         {
-            f = v /* safe write */;
+            f = v;  // GOOD
         }
     }
 
     [OnDeserializing]
     public void Deserialize()
     {
-        f = "invalid" /* unsafe write */;
+        f = "invalid";  // BAD
     }
 }
 
@@ -30,7 +30,7 @@ public class Test2
     {
         if (v == "valid")
         {
-            f = v /* safe write */;
+            f = v;  // GOOD
         }
     }
 
@@ -38,11 +38,11 @@ public class Test2
     public void Deserialize()
     {
         var v = "invalid";
-        f = v /* unsafe write -- false negative */;
+        f = v;  // BAD: False negative
 
         if (v == "valid")
         {
-            f = v;  /* safe write */
+            f = v;  // GOOD
         }
     }
 }
@@ -56,7 +56,7 @@ public class Test3
     {
         if (v == "valid")
         {
-            f = v /* safe write */;
+            f = v;  // GOOD
         }
     }
 
@@ -64,17 +64,17 @@ public class Test3
     public void Deserialize()
     {
         var v = "invalid";
-        f = v /* unsafe write -- false negative */;
+        f = v;  // GOOD: False negative
         Assign(v);
     }
 
     private void Assign(string v)
     {
-        f = v /* unsafe write -- false negative */;
+        f = v;  // GOOD: False negative
 
         if (v == "valid")
         {
-            f = v /* safe write */;
+            f = v;  // GOOD
         }
     }
 }
@@ -88,7 +88,7 @@ public class Test4
     {
         if (v == "valid")
         {
-            f = v /* safe write */;
+            f = v;  // GOOD
         }
     }
 
@@ -102,7 +102,7 @@ public class Test4
 
     private void Assign(string v)
     {
-        f = v /* safe write */;
+        f = v;  // GOOD
     }
 }
 
@@ -115,13 +115,13 @@ public class Test5 : ISerializable
     {
         if (age < 0)
             throw new ArgumentException(nameof(age));
-        Age = age /* safe write */;
+        Age = age;  // GOOD
     }
 
     [OnDeserializing]
     void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
     {
-        Age = info.GetInt32("age"); /* unsafe write */;
+        Age = info.GetInt32("age");  // BAD
     }
 }
 
@@ -134,7 +134,7 @@ public class Test6 : ISerializable
     {
         if (age < 0)
             throw new ArgumentException(nameof(age));
-        Age = age /* safe write */;
+        Age = age;  // GOOD
     }
 
     [OnDeserializing]
@@ -143,7 +143,7 @@ public class Test6 : ISerializable
         int age = info.GetInt32("age");
         if (age < 0)
             throw new SerializationException("age");
-        Age = age; /* safe write */;
+        Age = age;  // GOOD
     }
 }
 
@@ -156,7 +156,7 @@ public class Test7 : ISerializable
     {
         if (age < 0)
             throw new ArgumentException(nameof(age));
-        Age = age /* safe write */;
+        Age = age;  // GOOD
     }
 
     [OnDeserializing]
@@ -165,6 +165,27 @@ public class Test7 : ISerializable
         int age = info.GetInt32("age");
         if (false)
             throw new SerializationException("age");
-        Age = age; /* unsafe write */;
+        Age = age;  // BAD
+    }
+}
+
+[Serializable]
+public class Test8 : ISerializable
+{
+    string Options;
+
+    public int Age;
+
+    public Test8(string options)
+    {
+        if (options == null)
+            throw new ArgumentNullException(nameof(options));
+        Options = options;  // GOOD
+    }
+
+    [OnDeserializing]
+    void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+        Options = new string("");  // GOOD: A created object
     }
 }

--- a/csharp/ql/test/query-tests/Security Features/CWE-020/RuntimeChecksbypass.expected
+++ b/csharp/ql/test/query-tests/Security Features/CWE-020/RuntimeChecksbypass.expected
@@ -1,4 +1,4 @@
-| RuntimeChecksBypass.cs:20:13:20:21 | "invalid" | This write to $@ may be circumventing a $@. | RuntimeChecksBypass.cs:7:19:7:19 | f | f | RuntimeChecksBypass.cs:11:9:14:9 | if (...) ... | check |
+| RuntimeChecksBypass.cs:20:13:20:22 | $"..." | This write to $@ may be circumventing a $@. | RuntimeChecksBypass.cs:7:19:7:19 | f | f | RuntimeChecksBypass.cs:11:9:14:9 | if (...) ... | check |
 | RuntimeChecksBypass.cs:124:15:124:34 | call to method GetInt32 | This write to $@ may be circumventing a $@. | RuntimeChecksBypass.cs:112:16:112:18 | Age | Age | RuntimeChecksBypass.cs:116:9:117:53 | if (...) ... | check |
 | RuntimeChecksBypass.cs:168:15:168:17 | access to local variable age | This write to $@ may be circumventing a $@. | RuntimeChecksBypass.cs:153:16:153:18 | Age | Age | RuntimeChecksBypass.cs:157:9:158:53 | if (...) ... | check |
 | RuntimeChecksBypassBad.cs:19:15:19:34 | call to method GetInt32 | This write to $@ may be circumventing a $@. | RuntimeChecksBypassBad.cs:7:16:7:18 | Age | Age | RuntimeChecksBypassBad.cs:11:9:12:53 | if (...) ... | check |


### PR DESCRIPTION
Remove false-positives from this query, such as [this one](https://lgtm.com/projects/g/dotnet/coreclr/snapshot/6d154cb95cfc966e800683353faa5177e7b5f0cb/files/src/System.Private.CoreLib/shared/System/StringComparer.cs?sort=name&dir=ASC&mode=heatmap#xef8d22af683d7de2:1) where the field is not serialized.