### PR TITLE
C#: Add release notes and precisions to queries

### DIFF
--- a/change-notes/1.24/analysis-csharp.md
+++ b/change-notes/1.24/analysis-csharp.md
@@ -9,7 +9,7 @@ The following changes in version 1.24 affect C# analysis in all applications.
 | Assembly path injection (`cs/assembly-path-injection`) | security, external/cwe/cwe-114 | Finds user-controlled data used to load an assembly. |
 | Insecure configuration for ASP.NET requestValidationMode (`cs/insecure-request-validation-mode`) | security, external/cwe/cwe-016 | Finds where this attribute has been set to a value less than 4.5, which turns off some validation features and makes the application less secure. |
 | Insecure SQL connection (`cs/insecure-sql-connection`) | security, external/cwe/cwe-327 | Finds unencrypted SQL connection strings. |
-| Page request validation is disabled (`cs/web/request-validation-disabled`) | security, frameworks/asp.net, external/cwe/cwe-016 | Finds where ASP.NET page request validation has been disabled, which could makes the application less secure. |
+| Page request validation is disabled (`cs/web/request-validation-disabled`) | security, frameworks/asp.net, external/cwe/cwe-016 | Finds where ASP.NET page request validation has been disabled, which could make the application less secure. |
 | Serialization check bypass (`cs/serialization-check-bypass`) | security, external/cwe/cwe-20 | Finds where data is not validated in a deserialization method. |
 | XML injection (`cs/xml-injection`) | security, external/cwe/cwe-091 | Finds user-controlled data that is used to write directly to an XML document. |
 
@@ -33,4 +33,3 @@ The following changes in version 1.24 affect C# analysis in all applications.
 * Expression nullability flow state is given by the predicates `Expr.hasNotNullFlowState()` and `Expr.hasMaybeNullFlowState()`.
 
 ## Changes to autobuilder
-

--- a/change-notes/1.24/analysis-csharp.md
+++ b/change-notes/1.24/analysis-csharp.md
@@ -6,8 +6,12 @@ The following changes in version 1.24 affect C# analysis in all applications.
 
 | **Query**                   | **Tags**  | **Purpose**                                                        |
 |-----------------------------|-----------|--------------------------------------------------------------------|
+| Assembly path injection (`cs/assembly-path-injection`) | security, external/cwe/cwe-114 | Finds user-controlled data used to load an assembly. |
 | Insecure configuration for ASP.NET requestValidationMode (`cs/insecure-request-validation-mode`) | security, external/cwe/cwe-016 | Finds where this attribute has been set to a value less than 4.5, which turns off some validation features and makes the application less secure. |
+| Insecure SQL connection (`cs/insecure-sql-connection`) | security, external/cwe/cwe-327 | Finds unencrypted SQL connection strings. |
 | Page request validation is disabled (`cs/web/request-validation-disabled`) | security, frameworks/asp.net, external/cwe/cwe-016 | Finds where ASP.NET page request validation has been disabled, which could makes the application less secure. |
+| Serialization check bypass (`cs/serialization-check-bypass`) | security, external/cwe/cwe-20 | Finds where data is not validated in a deserialization method. |
+| XML injection (`cs/xml-injection`) | security, external/cwe/cwe-091 | Finds user-controlled data that is used to write directly to an XML document. |
 
 ## Changes to existing queries
 

--- a/csharp/ql/src/Security Features/CWE-020/RuntimeChecksBypass.ql
+++ b/csharp/ql/src/Security Features/CWE-020/RuntimeChecksBypass.ql
@@ -4,12 +4,9 @@
  * @kind problem
  * @id cs/serialization-check-bypass
  * @problem.severity warning
+ * @precision medium
  * @tags security
  *       external/cwe/cwe-20
- */
-
-/*
- * consider: @precision medium
  */
 
 import semmle.code.csharp.serialization.Serialization

--- a/csharp/ql/src/Security Features/CWE-091/XMLInjection.ql
+++ b/csharp/ql/src/Security Features/CWE-091/XMLInjection.ql
@@ -5,12 +5,9 @@
  * @kind problem
  * @id cs/xml-injection
  * @problem.severity error
+ * @precision high
  * @tags security
  *       external/cwe/cwe-091
- */
-
-/*
- * consider: @precision high
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-114/AssemblyPathInjection.ql
+++ b/csharp/ql/src/Security Features/CWE-114/AssemblyPathInjection.ql
@@ -6,27 +6,14 @@
  * @kind problem
  * @id cs/assembly-path-injection
  * @problem.severity error
+ * @precision high
  * @tags security
  *       external/cwe/cwe-114
  */
 
-/*
- * consider: @precision high
- */
-
 import csharp
 import semmle.code.csharp.dataflow.flowsources.Remote
-
-class MainMethod extends Method {
-  MainMethod() {
-    this.hasName("Main") and
-    this.isStatic() and
-    (this.getReturnType() instanceof VoidType or this.getReturnType() instanceof IntType) and
-    if this.getNumberOfParameters() = 1
-    then this.getParameter(0).getType().(ArrayType).getElementType() instanceof StringType
-    else this.getNumberOfParameters() = 0
-  }
-}
+import semmle.code.csharp.commons.Util
 
 /**
  * A taint-tracking configuration for untrusted user input used to load a DLL.

--- a/csharp/ql/src/Security Features/CWE-327/InsecureSQLConnection.ql
+++ b/csharp/ql/src/Security Features/CWE-327/InsecureSQLConnection.ql
@@ -1,15 +1,12 @@
 /**
  * @name Insecure SQL connection
- * @description Using an SQL Server connection without enforcing encryption is a security vulnerability.
+ * @description Using a SQL Server connection without enforcing encryption is a security vulnerability.
  * @kind path-problem
  * @id cs/insecure-sql-connection
  * @problem.severity error
+ * @precision medium
  * @tags security
  *       external/cwe/cwe-327
- */
-
-/*
- * consider: @precision high
  */
 
 import csharp

--- a/csharp/ql/src/Security Features/CWE-327/InsecureSQLConnection.ql
+++ b/csharp/ql/src/Security Features/CWE-327/InsecureSQLConnection.ql
@@ -1,6 +1,6 @@
 /**
  * @name Insecure SQL connection
- * @description Using a SQL Server connection without enforcing encryption is a security vulnerability.
+ * @description Using an SQL Server connection without enforcing encryption is a security vulnerability.
  * @kind path-problem
  * @id cs/insecure-sql-connection
  * @problem.severity error


### PR DESCRIPTION
I ran these queries over a small set of projects and the results looked good. In one case, `cs/insecure-sql-connection` it found real results although only from the benchmarking project.

Precisions based on similar queries.

Fixes https://github.com/github/codeql-csharp-team/issues/9
Fixes https://github.com/github/codeql-csharp-team/issues/8
Fixes https://github.com/github/codeql-csharp-team/issues/6
Fixes https://github.com/github/codeql-csharp-team/issues/5
