### PR TITLE
Java/C++/C#: Remove DataFlowLocation as it's no longer needed.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -282,8 +282,6 @@ class DataFlowExpr = Expr;
 
 class DataFlowType = Type;
 
-class DataFlowLocation = Location;
-
 /** A function call relevant for data flow. */
 class DataFlowCall extends Expr {
   DataFlowCall() { this instanceof Call }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -191,8 +191,6 @@ class DataFlowExpr = Expr;
 
 class DataFlowType = Type;
 
-class DataFlowLocation = Location;
-
 /** A function call relevant for data flow. */
 class DataFlowCall extends CallInstruction {
   /**

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1472,8 +1472,6 @@ class DataFlowExpr = DotNet::Expr;
 
 class DataFlowType = Gvn::GvnType;
 
-class DataFlowLocation = Location;
-
 /** Holds if `e` is an expression that always has the same Boolean value `val`. */
 private predicate constantBooleanExpr(Expr e, boolean val) {
   e = any(AbstractValues::BooleanValue bv | val = bv.getValue()).getAnExpr()

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -279,8 +279,6 @@ class DataFlowExpr = Expr;
 
 class DataFlowType = RefType;
 
-class DataFlowLocation = Location;
-
 class DataFlowCall extends Call {
   /** Gets the data flow node corresponding to this call. */
   ExprNode getNode() { result.getExpr() = this }


### PR DESCRIPTION
This alias is not referenced anywhere.  AFAIR it was only used very shortly in the joint implementation.