### PR TITLE
Java: Allow null literals as sources in data flow.

### DIFF
--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -235,6 +235,8 @@ DataFlowType getErasedRepr(Type t) {
       then result.(BoxedType).getPrimitiveType().getName() = "boolean"
       else result = e
   )
+  or
+  t instanceof NullType and result instanceof TypeObject
 }
 
 /** Gets a string representation of a type returned by `getErasedRepr`. */

--- a/java/ql/test/library-tests/dataflow/null/A.java
+++ b/java/ql/test/library-tests/dataflow/null/A.java
@@ -1,0 +1,9 @@
+public class A {
+  void sink(Object o) { }
+
+  void foo() {
+    Object src = null;
+    Object x = src;
+    sink(x);
+  }
+}

--- a/java/ql/test/library-tests/dataflow/null/testnullflow.expected
+++ b/java/ql/test/library-tests/dataflow/null/testnullflow.expected
@@ -1,0 +1,4 @@
+| A.java:5:18:5:21 | null | A.java:2:13:2:20 | o |
+| A.java:5:18:5:21 | null | A.java:5:18:5:21 | null |
+| A.java:5:18:5:21 | null | A.java:6:16:6:18 | src |
+| A.java:5:18:5:21 | null | A.java:7:10:7:10 | x |

--- a/java/ql/test/library-tests/dataflow/null/testnullflow.ql
+++ b/java/ql/test/library-tests/dataflow/null/testnullflow.ql
@@ -1,0 +1,14 @@
+import java
+import semmle.code.java.dataflow.DataFlow
+
+class Conf extends DataFlow::Configuration {
+  Conf() { this = "qqconf" }
+
+  override predicate isSource(DataFlow::Node n) { n.asExpr() instanceof NullLiteral }
+
+  override predicate isSink(DataFlow::Node n) { any() }
+}
+
+from Conf conf, DataFlow::Node src, DataFlow::Node sink
+where conf.hasFlow(src, sink)
+select src, sink


### PR DESCRIPTION
This is a minor bugfix in the Java data flow library.  Global data flow isn't really targeted towards nullness analysis, but there's no reason that it shouldn't work to have null literals as sources, as there will likely be someone who wants to play around with it.  The reason why null sources haven't worked for a long time is that they have been accidentally filtered by type pruning.