### PR TITLE
CPP: Support taint flow in and out of qualifiers

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
@@ -133,19 +133,24 @@ private predicate exprToExprStep(Expr exprIn, Expr exprOut) {
     )
   )
   or
-  exists(TaintFunction f, Call call, FunctionOutput outModel |
+  exists(TaintFunction f, Call call, FunctionInput inModel, FunctionOutput outModel |
     call.getTarget() = f and
-    exprOut = call and
-    outModel.isReturnValueDeref() and
-    exists(int argInIndex, FunctionInput inModel | f.hasTaintFlow(inModel, outModel) |
-      inModel.isParameterDeref(argInIndex) and
-      exprIn = call.getArgument(argInIndex)
-      or
-      inModel.isParameterDeref(argInIndex) and
-      call.passesByReference(argInIndex, exprIn)
-      or
-      inModel.isParameter(argInIndex) and
-      exprIn = call.getArgument(argInIndex)
+    (
+      exprOut = call and
+      outModel.isReturnValueDeref()
+    ) and
+    f.hasTaintFlow(inModel, outModel) and
+    (
+      exists(int argInIndex |
+        inModel.isParameterDeref(argInIndex) and
+        exprIn = call.getArgument(argInIndex)
+        or
+        inModel.isParameterDeref(argInIndex) and
+        call.passesByReference(argInIndex, exprIn)
+        or
+        inModel.isParameter(argInIndex) and
+        exprIn = call.getArgument(argInIndex)
+      )
     )
   )
 }
@@ -163,19 +168,22 @@ private predicate exprToDefinitionByReferenceStep(Expr exprIn, Expr argOut) {
     )
   )
   or
-  exists(TaintFunction f, Call call, FunctionOutput outModel, int argOutIndex |
+  exists(TaintFunction f, Call call, FunctionInput inModel, FunctionOutput outModel, int argOutIndex |
     call.getTarget() = f and
     argOut = call.getArgument(argOutIndex) and
     outModel.isParameterDeref(argOutIndex) and
-    exists(int argInIndex, FunctionInput inModel | f.hasTaintFlow(inModel, outModel) |
-      inModel.isParameterDeref(argInIndex) and
-      exprIn = call.getArgument(argInIndex)
-      or
-      inModel.isParameterDeref(argInIndex) and
-      call.passesByReference(argInIndex, exprIn)
-      or
-      inModel.isParameter(argInIndex) and
-      exprIn = call.getArgument(argInIndex)
+    f.hasTaintFlow(inModel, outModel) and
+    (
+      exists(int argInIndex |
+        inModel.isParameterDeref(argInIndex) and
+        exprIn = call.getArgument(argInIndex)
+        or
+        inModel.isParameterDeref(argInIndex) and
+        call.passesByReference(argInIndex, exprIn)
+        or
+        inModel.isParameter(argInIndex) and
+        exprIn = call.getArgument(argInIndex)
+      )
     )
   )
 }

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
@@ -140,6 +140,9 @@ private predicate exprToExprStep(Expr exprIn, Expr exprOut) {
     (
       exprOut = call and
       outModel.isReturnValueDeref()
+      or
+      exprOut = call and
+      outModel.isReturnValue()
     ) and
     f.hasTaintFlow(inModel, outModel) and
     (

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
@@ -152,7 +152,9 @@ private predicate exprToExprStep(Expr exprIn, Expr exprOut) {
         or
         inModel.isParameter(argInIndex) and
         exprIn = call.getArgument(argInIndex)
-      )
+      ) or
+      inModel.isQualifierObject() and
+      exprIn = call.getQualifier()
     )
   )
 }
@@ -185,7 +187,9 @@ private predicate exprToDefinitionByReferenceStep(Expr exprIn, Expr argOut) {
         or
         inModel.isParameter(argInIndex) and
         exprIn = call.getArgument(argInIndex)
-      )
+      ) or
+      inModel.isQualifierObject() and
+      exprIn = call.getQualifier()
     )
   )
 }

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/TaintTrackingUtil.qll
@@ -155,7 +155,8 @@ private predicate exprToExprStep(Expr exprIn, Expr exprOut) {
         or
         inModel.isParameter(argInIndex) and
         exprIn = call.getArgument(argInIndex)
-      ) or
+      )
+      or
       inModel.isQualifierObject() and
       exprIn = call.getQualifier()
     )
@@ -175,7 +176,9 @@ private predicate exprToDefinitionByReferenceStep(Expr exprIn, Expr argOut) {
     )
   )
   or
-  exists(TaintFunction f, Call call, FunctionInput inModel, FunctionOutput outModel, int argOutIndex |
+  exists(
+    TaintFunction f, Call call, FunctionInput inModel, FunctionOutput outModel, int argOutIndex
+  |
     call.getTarget() = f and
     argOut = call.getArgument(argOutIndex) and
     outModel.isParameterDeref(argOutIndex) and
@@ -190,7 +193,8 @@ private predicate exprToDefinitionByReferenceStep(Expr exprIn, Expr argOut) {
         or
         inModel.isParameter(argInIndex) and
         exprIn = call.getArgument(argInIndex)
-      ) or
+      )
+      or
       inModel.isQualifierObject() and
       exprIn = call.getQualifier()
     )

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/TaintTestCommon.qll
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/TaintTestCommon.qll
@@ -1,5 +1,6 @@
 import cpp
 import semmle.code.cpp.dataflow.TaintTracking
+import semmle.code.cpp.models.interfaces.Taint
 
 /** Common data flow configuration to be used by tests. */
 class TestAllocationConfig extends TaintTracking::Configuration {
@@ -23,5 +24,41 @@ class TestAllocationConfig extends TaintTracking::Configuration {
 
   override predicate isSanitizer(DataFlow::Node barrier) {
     barrier.asExpr().(VariableAccess).getTarget().hasName("sanitizer")
+  }
+}
+
+class SetMemberFunction extends TaintFunction {
+  SetMemberFunction() { this.hasName("setMember") }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    input.isParameter(0) and
+    output.isQualifierObject()
+  }
+}
+
+class GetMemberFunction extends TaintFunction {
+  GetMemberFunction() { this.hasName("getMember") }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    input.isQualifierObject() and
+    output.isReturnValue()
+  }
+}
+
+class SetStringFunction extends TaintFunction {
+  SetStringFunction() { this.hasName("setString") }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    input.isParameterDeref(0) and
+    output.isQualifierObject()
+  }
+}
+
+class GetStringFunction extends TaintFunction {
+  GetStringFunction() { this.hasName("getString") }
+
+  override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {
+    input.isQualifierObject() and
+    output.isReturnValueDeref()
   }
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -347,3 +347,62 @@
 | taint.cpp:390:6:390:11 | call to wcsdup | taint.cpp:390:2:390:28 | ... = ... |  |
 | taint.cpp:390:6:390:11 | call to wcsdup | taint.cpp:392:7:392:7 | b |  |
 | taint.cpp:390:13:390:27 | hello, world | taint.cpp:390:6:390:11 | call to wcsdup | TAINT |
+| taint.cpp:417:13:417:14 | call to MyClass2 | taint.cpp:420:7:420:7 | a |  |
+| taint.cpp:417:13:417:14 | call to MyClass2 | taint.cpp:421:7:421:7 | a |  |
+| taint.cpp:417:13:417:14 | call to MyClass2 | taint.cpp:422:2:422:2 | a |  |
+| taint.cpp:417:13:417:14 | call to MyClass2 | taint.cpp:423:7:423:7 | a |  |
+| taint.cpp:417:13:417:14 | call to MyClass2 | taint.cpp:424:7:424:7 | a |  |
+| taint.cpp:417:19:417:20 | call to MyClass2 | taint.cpp:426:7:426:7 | b |  |
+| taint.cpp:417:19:417:20 | call to MyClass2 | taint.cpp:427:7:427:7 | b |  |
+| taint.cpp:417:19:417:20 | call to MyClass2 | taint.cpp:428:2:428:2 | b |  |
+| taint.cpp:417:19:417:20 | call to MyClass2 | taint.cpp:429:7:429:7 | b |  |
+| taint.cpp:417:19:417:20 | call to MyClass2 | taint.cpp:430:7:430:7 | b |  |
+| taint.cpp:417:19:417:20 | call to MyClass2 | taint.cpp:431:7:431:7 | b |  |
+| taint.cpp:418:13:418:15 | call to MyClass3 | taint.cpp:443:7:443:7 | d |  |
+| taint.cpp:418:13:418:15 | call to MyClass3 | taint.cpp:444:7:444:7 | d |  |
+| taint.cpp:418:13:418:15 | call to MyClass3 | taint.cpp:445:2:445:2 | d |  |
+| taint.cpp:418:13:418:15 | call to MyClass3 | taint.cpp:446:7:446:7 | d |  |
+| taint.cpp:418:13:418:15 | call to MyClass3 | taint.cpp:447:7:447:7 | d |  |
+| taint.cpp:421:7:421:7 | a [post update] | taint.cpp:422:2:422:2 | a |  |
+| taint.cpp:421:7:421:7 | a [post update] | taint.cpp:423:7:423:7 | a |  |
+| taint.cpp:421:7:421:7 | a [post update] | taint.cpp:424:7:424:7 | a |  |
+| taint.cpp:422:2:422:2 | a [post update] | taint.cpp:423:7:423:7 | a |  |
+| taint.cpp:422:2:422:2 | a [post update] | taint.cpp:424:7:424:7 | a |  |
+| taint.cpp:427:7:427:7 | b [post update] | taint.cpp:428:2:428:2 | b |  |
+| taint.cpp:427:7:427:7 | b [post update] | taint.cpp:429:7:429:7 | b |  |
+| taint.cpp:427:7:427:7 | b [post update] | taint.cpp:430:7:430:7 | b |  |
+| taint.cpp:427:7:427:7 | b [post update] | taint.cpp:431:7:431:7 | b |  |
+| taint.cpp:428:2:428:2 | b [post update] | taint.cpp:429:7:429:7 | b |  |
+| taint.cpp:428:2:428:2 | b [post update] | taint.cpp:430:7:430:7 | b |  |
+| taint.cpp:428:2:428:2 | b [post update] | taint.cpp:431:7:431:7 | b |  |
+| taint.cpp:428:2:428:20 | ... = ... | taint.cpp:430:9:430:14 | member |  |
+| taint.cpp:428:13:428:18 | call to source | taint.cpp:428:2:428:20 | ... = ... |  |
+| taint.cpp:433:6:433:20 | call to MyClass2 | taint.cpp:433:6:433:20 | new |  |
+| taint.cpp:433:6:433:20 | new | taint.cpp:433:2:433:20 | ... = ... |  |
+| taint.cpp:433:6:433:20 | new | taint.cpp:435:7:435:7 | c |  |
+| taint.cpp:433:6:433:20 | new | taint.cpp:436:7:436:7 | c |  |
+| taint.cpp:433:6:433:20 | new | taint.cpp:437:2:437:2 | c |  |
+| taint.cpp:433:6:433:20 | new | taint.cpp:438:7:438:7 | c |  |
+| taint.cpp:433:6:433:20 | new | taint.cpp:439:7:439:7 | c |  |
+| taint.cpp:433:6:433:20 | new | taint.cpp:441:9:441:9 | c |  |
+| taint.cpp:435:7:435:7 | ref arg c | taint.cpp:436:7:436:7 | c |  |
+| taint.cpp:435:7:435:7 | ref arg c | taint.cpp:437:2:437:2 | c |  |
+| taint.cpp:435:7:435:7 | ref arg c | taint.cpp:438:7:438:7 | c |  |
+| taint.cpp:435:7:435:7 | ref arg c | taint.cpp:439:7:439:7 | c |  |
+| taint.cpp:435:7:435:7 | ref arg c | taint.cpp:441:9:441:9 | c |  |
+| taint.cpp:436:7:436:7 | c [post update] | taint.cpp:437:2:437:2 | c |  |
+| taint.cpp:436:7:436:7 | c [post update] | taint.cpp:438:7:438:7 | c |  |
+| taint.cpp:436:7:436:7 | c [post update] | taint.cpp:439:7:439:7 | c |  |
+| taint.cpp:436:7:436:7 | c [post update] | taint.cpp:441:9:441:9 | c |  |
+| taint.cpp:437:2:437:2 | c [post update] | taint.cpp:438:7:438:7 | c |  |
+| taint.cpp:437:2:437:2 | c [post update] | taint.cpp:439:7:439:7 | c |  |
+| taint.cpp:437:2:437:2 | c [post update] | taint.cpp:441:9:441:9 | c |  |
+| taint.cpp:438:7:438:7 | ref arg c | taint.cpp:439:7:439:7 | c |  |
+| taint.cpp:438:7:438:7 | ref arg c | taint.cpp:441:9:441:9 | c |  |
+| taint.cpp:439:7:439:7 | c [post update] | taint.cpp:441:9:441:9 | c |  |
+| taint.cpp:441:9:441:9 | c | taint.cpp:441:2:441:9 | delete | TAINT |
+| taint.cpp:444:7:444:7 | d [post update] | taint.cpp:445:2:445:2 | d |  |
+| taint.cpp:444:7:444:7 | d [post update] | taint.cpp:446:7:446:7 | d |  |
+| taint.cpp:444:7:444:7 | d [post update] | taint.cpp:447:7:447:7 | d |  |
+| taint.cpp:445:2:445:2 | d [post update] | taint.cpp:446:7:446:7 | d |  |
+| taint.cpp:445:2:445:2 | d [post update] | taint.cpp:447:7:447:7 | d |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -444,5 +444,5 @@ void test_qualifiers()
 	sink(d.getString());
 	d.setString(strings::source());
 	sink(d); // tainted
-	sink(d.getString()); // tainted [NOT DETECTED]
+	sink(d.getString()); // tainted
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -420,7 +420,7 @@ void test_qualifiers()
 	sink(a);
 	sink(a.getMember());
 	a.setMember(source());
-	sink(a); // tainted [NOT DETECTED]
+	sink(a); // tainted
 	sink(a.getMember()); // tainted [NOT DETECTED]
 
 	sink(b);
@@ -435,7 +435,7 @@ void test_qualifiers()
 	sink(c);
 	sink(c->getMember());
 	c->setMember(source());
-	sink(c); // tainted (deref) [NOT DETECTED]
+	sink(c); // tainted (deref)
 	sink(c->getMember()); // tainted [NOT DETECTED]
 
 	delete c;
@@ -443,6 +443,6 @@ void test_qualifiers()
 	sink(d);
 	sink(d.getString());
 	d.setString(strings::source());
-	sink(d); // tainted [NOT DETECTED]
+	sink(d); // tainted
 	sink(d.getString()); // tainted [NOT DETECTED]
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -391,3 +391,58 @@ void test_wcsdup(wchar_t *source)
 	sink(a); // tainted
 	sink(b);
 }
+
+// --- qualifiers ---
+
+class MyClass2 {
+public:
+	MyClass2(int value);
+	void setMember(int value);
+	int getMember();
+
+	int member;
+};
+
+class MyClass3 {
+public:
+	MyClass3(const char *string);
+	void setString(const char *string);
+	const char *getString();
+
+	const char *buffer;
+};
+
+void test_qualifiers()
+{
+	MyClass2 a(0), b(0), *c;
+	MyClass3 d("");
+
+	sink(a);
+	sink(a.getMember());
+	a.setMember(source());
+	sink(a); // tainted [NOT DETECTED]
+	sink(a.getMember()); // tainted [NOT DETECTED]
+
+	sink(b);
+	sink(b.getMember());
+	b.member = source();
+	sink(b); // tainted
+	sink(b.member); // tainted
+	sink(b.getMember());
+
+	c = new MyClass2(0);
+
+	sink(c);
+	sink(c->getMember());
+	c->setMember(source());
+	sink(c); // tainted (deref) [NOT DETECTED]
+	sink(c->getMember()); // tainted [NOT DETECTED]
+
+	delete c;
+
+	sink(d);
+	sink(d.getString());
+	d.setString(strings::source());
+	sink(d); // tainted [NOT DETECTED]
+	sink(d.getString()); // tainted [NOT DETECTED]
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -421,7 +421,7 @@ void test_qualifiers()
 	sink(a.getMember());
 	a.setMember(source());
 	sink(a); // tainted
-	sink(a.getMember()); // tainted [NOT DETECTED]
+	sink(a.getMember()); // tainted
 
 	sink(b);
 	sink(b.getMember());
@@ -436,7 +436,7 @@ void test_qualifiers()
 	sink(c->getMember());
 	c->setMember(source());
 	sink(c); // tainted (deref)
-	sink(c->getMember()); // tainted [NOT DETECTED]
+	sink(c->getMember()); // tainted
 
 	delete c;
 

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -40,7 +40,9 @@
 | taint.cpp:372:7:372:7 | a | taint.cpp:365:24:365:29 | source |
 | taint.cpp:391:7:391:7 | a | taint.cpp:385:27:385:32 | source |
 | taint.cpp:423:7:423:7 | a | taint.cpp:422:14:422:19 | call to source |
+| taint.cpp:424:9:424:17 | call to getMember | taint.cpp:422:14:422:19 | call to source |
 | taint.cpp:430:9:430:14 | member | taint.cpp:428:13:428:18 | call to source |
 | taint.cpp:438:7:438:7 | c | taint.cpp:437:15:437:20 | call to source |
+| taint.cpp:439:10:439:18 | call to getMember | taint.cpp:437:15:437:20 | call to source |
 | taint.cpp:446:7:446:7 | d | taint.cpp:445:14:445:28 | call to source |
 | taint.cpp:447:9:447:17 | call to getString | taint.cpp:445:14:445:28 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -43,3 +43,4 @@
 | taint.cpp:430:9:430:14 | member | taint.cpp:428:13:428:18 | call to source |
 | taint.cpp:438:7:438:7 | c | taint.cpp:437:15:437:20 | call to source |
 | taint.cpp:446:7:446:7 | d | taint.cpp:445:14:445:28 | call to source |
+| taint.cpp:447:9:447:17 | call to getString | taint.cpp:445:14:445:28 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -39,4 +39,7 @@
 | taint.cpp:352:7:352:7 | b | taint.cpp:330:6:330:11 | call to source |
 | taint.cpp:372:7:372:7 | a | taint.cpp:365:24:365:29 | source |
 | taint.cpp:391:7:391:7 | a | taint.cpp:385:27:385:32 | source |
+| taint.cpp:423:7:423:7 | a | taint.cpp:422:14:422:19 | call to source |
 | taint.cpp:430:9:430:14 | member | taint.cpp:428:13:428:18 | call to source |
+| taint.cpp:438:7:438:7 | c | taint.cpp:437:15:437:20 | call to source |
+| taint.cpp:446:7:446:7 | d | taint.cpp:445:14:445:28 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -39,3 +39,4 @@
 | taint.cpp:352:7:352:7 | b | taint.cpp:330:6:330:11 | call to source |
 | taint.cpp:372:7:372:7 | a | taint.cpp:365:24:365:29 | source |
 | taint.cpp:391:7:391:7 | a | taint.cpp:385:27:385:32 | source |
+| taint.cpp:430:9:430:14 | member | taint.cpp:428:13:428:18 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -26,3 +26,5 @@
 | taint.cpp:352:7:352:7 | taint.cpp:330:6:330:11 | AST only |
 | taint.cpp:372:7:372:7 | taint.cpp:365:24:365:29 | AST only |
 | taint.cpp:391:7:391:7 | taint.cpp:385:27:385:32 | AST only |
+| taint.cpp:429:7:429:7 | taint.cpp:428:13:428:18 | IR only |
+| taint.cpp:430:9:430:14 | taint.cpp:428:13:428:18 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -26,5 +26,8 @@
 | taint.cpp:352:7:352:7 | taint.cpp:330:6:330:11 | AST only |
 | taint.cpp:372:7:372:7 | taint.cpp:365:24:365:29 | AST only |
 | taint.cpp:391:7:391:7 | taint.cpp:385:27:385:32 | AST only |
+| taint.cpp:423:7:423:7 | taint.cpp:422:14:422:19 | AST only |
 | taint.cpp:429:7:429:7 | taint.cpp:428:13:428:18 | IR only |
 | taint.cpp:430:9:430:14 | taint.cpp:428:13:428:18 | AST only |
+| taint.cpp:438:7:438:7 | taint.cpp:437:15:437:20 | AST only |
+| taint.cpp:446:7:446:7 | taint.cpp:445:14:445:28 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -31,3 +31,4 @@
 | taint.cpp:430:9:430:14 | taint.cpp:428:13:428:18 | AST only |
 | taint.cpp:438:7:438:7 | taint.cpp:437:15:437:20 | AST only |
 | taint.cpp:446:7:446:7 | taint.cpp:445:14:445:28 | AST only |
+| taint.cpp:447:9:447:17 | taint.cpp:445:14:445:28 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -27,8 +27,10 @@
 | taint.cpp:372:7:372:7 | taint.cpp:365:24:365:29 | AST only |
 | taint.cpp:391:7:391:7 | taint.cpp:385:27:385:32 | AST only |
 | taint.cpp:423:7:423:7 | taint.cpp:422:14:422:19 | AST only |
+| taint.cpp:424:9:424:17 | taint.cpp:422:14:422:19 | AST only |
 | taint.cpp:429:7:429:7 | taint.cpp:428:13:428:18 | IR only |
 | taint.cpp:430:9:430:14 | taint.cpp:428:13:428:18 | AST only |
 | taint.cpp:438:7:438:7 | taint.cpp:437:15:437:20 | AST only |
+| taint.cpp:439:10:439:18 | taint.cpp:437:15:437:20 | AST only |
 | taint.cpp:446:7:446:7 | taint.cpp:445:14:445:28 | AST only |
 | taint.cpp:447:9:447:17 | taint.cpp:445:14:445:28 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
@@ -15,3 +15,4 @@
 | taint.cpp:291:7:291:7 | y | taint.cpp:275:6:275:11 | call to source |
 | taint.cpp:337:7:337:7 | t | taint.cpp:330:6:330:11 | call to source |
 | taint.cpp:350:7:350:7 | t | taint.cpp:330:6:330:11 | call to source |
+| taint.cpp:429:7:429:7 | b | taint.cpp:428:13:428:18 | call to source |


### PR DESCRIPTION
Support flow in and out of the qualifiers of function calls.  This will be essential in adding taint support for `std::string`, for example.

~~There are a couple of problems with my solution at present (please comment if you have any thoughts on these; otherwise I will need to investigate more deeply what's going on):~~
 - ~~it doesn't seem to cope with `a->method()`~~
 - ~~taint seems to flow backwards in some of the tests~~