### PR TITLE
C#: Fix outputting floats to the trap file

### DIFF
--- a/csharp/extractor/Semmle.Extraction/TrapExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction/TrapExtensions.cs
@@ -162,7 +162,7 @@ namespace Semmle.Extraction
 
         public static void WriteTrapFloat(this TextWriter trapFile, float f)
         {
-            trapFile.Write(f.ToString("0.#####e0"));  // Trap importer won't accept ints
+            trapFile.Write(f.ToString("F5", System.Globalization.CultureInfo.InvariantCulture));  // Trap importer won't accept ints
         }
 
         public static void WriteTuple(this TextWriter trapFile, string name, params object[] @params)


### PR DESCRIPTION
In certain locales, such as `fr-FR`, `double.ToString()` outputs commas instead of decimal points, which does not work.

@lcartey 