### PR TITLE
java: sharpen java/maven/non-https-url to allow localhost URLs

### DIFF
--- a/java/ql/src/Security/CWE/CWE-829/InsecureDependencyResolution.ql
+++ b/java/ql/src/Security/CWE/CWE-829/InsecureDependencyResolution.ql
@@ -25,8 +25,7 @@ private class DeclaredRepository extends PomElement {
   string getUrl() { result = getAChild("url").(PomElement).getValue() }
 
   predicate isInsecureRepositoryUsage() {
-    getUrl().matches("http://%") or
-    getUrl().matches("ftp://%")
+    getUrl().regexpMatch("(?i)^(http|ftp)://(?!localhost[:/]).*")
   }
 }
 

--- a/java/ql/test/query-tests/security/CWE-829/semmle/tests/InsecureDependencyResolution.expected
+++ b/java/ql/test/query-tests/security/CWE-829/semmle/tests/InsecureDependencyResolution.expected
@@ -3,6 +3,3 @@
 | insecure-pom.xml:31:9:36:30 | snapshotRepository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://localhost.example |
 | insecure-pom.xml:39:9:44:22 | repository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://insecure-repository.example |
 | insecure-pom.xml:47:9:52:28 | pluginRepository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://insecure-repository.example |
-| secure-pom.xml:31:9:36:30 | snapshotRepository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://localhost/snaphots |
-| secure-pom.xml:37:9:42:30 | snapshotRepository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://localhost:82 |
-| secure-pom.xml:51:9:55:22 | repository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://localhost:${deploy.webserver.port}/repo |

--- a/java/ql/test/query-tests/security/CWE-829/semmle/tests/InsecureDependencyResolution.expected
+++ b/java/ql/test/query-tests/security/CWE-829/semmle/tests/InsecureDependencyResolution.expected
@@ -1,4 +1,8 @@
 | insecure-pom.xml:19:9:24:22 | repository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://insecure-repository.example |
 | insecure-pom.xml:25:9:30:30 | snapshotRepository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://insecure-repository.example |
-| insecure-pom.xml:33:9:38:22 | repository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://insecure-repository.example |
-| insecure-pom.xml:41:9:46:28 | pluginRepository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://insecure-repository.example |
+| insecure-pom.xml:31:9:36:30 | snapshotRepository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://localhost.example |
+| insecure-pom.xml:39:9:44:22 | repository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://insecure-repository.example |
+| insecure-pom.xml:47:9:52:28 | pluginRepository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://insecure-repository.example |
+| secure-pom.xml:31:9:36:30 | snapshotRepository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://localhost/snaphots |
+| secure-pom.xml:37:9:42:30 | snapshotRepository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://localhost:82 |
+| secure-pom.xml:51:9:55:22 | repository | Downloading or uploading artifacts over insecure protocol (eg. http or ftp) to/from repository http://localhost:${deploy.webserver.port}/repo |

--- a/java/ql/test/query-tests/security/CWE-829/semmle/tests/insecure-pom.xml
+++ b/java/ql/test/query-tests/security/CWE-829/semmle/tests/insecure-pom.xml
@@ -28,6 +28,12 @@
             <!-- BAD! Use HTTPS -->
             <url>http://insecure-repository.example</url>
         </snapshotRepository>
+        <snapshotRepository>
+            <id>insecure-snapshots</id>
+            <name>Insecure Repository Snapshots</name>
+            <!-- BAD! Use HTTPS -->
+            <url>http://localhost.example</url>
+        </snapshotRepository>
     </distributionManagement>
     <repositories>
         <repository>

--- a/java/ql/test/query-tests/security/CWE-829/semmle/tests/secure-pom.xml
+++ b/java/ql/test/query-tests/security/CWE-829/semmle/tests/secure-pom.xml
@@ -49,9 +49,9 @@
             <url>https://insecure-repository.example</url>
         </repository>
         <repository>
-	        <id>test</id>
-	        <!-- GOOD! Use HTTP, but for localhost -->
-	        <url>http://localhost:${deploy.webserver.port}/repo</url>
+            <id>test</id>
+            <!-- GOOD! Use HTTP, but for localhost -->
+            <url>http://localhost:${deploy.webserver.port}/repo</url>
         </repository>
     </repositories>
     <pluginRepositories>

--- a/java/ql/test/query-tests/security/CWE-829/semmle/tests/secure-pom.xml
+++ b/java/ql/test/query-tests/security/CWE-829/semmle/tests/secure-pom.xml
@@ -28,6 +28,18 @@
             <!-- GOOD! Use HTTPS -->
             <url>https://insecure-repository.example</url>
         </snapshotRepository>
+        <snapshotRepository>
+            <id>insecure-snapshots</id>
+            <name>Secure Repository Snapshots</name>
+            <!-- GOOD! Use HTTP, but for localhost -->
+            <url>http://localhost/snaphots</url>
+        </snapshotRepository>
+        <snapshotRepository>
+            <id>insecure-snapshots</id>
+            <name>Secure Repository Snapshots</name>
+            <!-- GOOD! Use HTTP, but for localhost -->
+            <url>http://localhost:82</url>
+        </snapshotRepository>
     </distributionManagement>
     <repositories>
         <repository>
@@ -35,6 +47,11 @@
             <name>Secure Repository</name>
             <!-- GOOD! Use HTTPS -->
             <url>https://insecure-repository.example</url>
+        </repository>
+        <repository>
+	        <id>test</id>
+	        <!-- GOOD! Use HTTP, but for localhost -->
+	        <url>http://localhost:${deploy.webserver.port}/repo</url>
         </repository>
     </repositories>
     <pluginRepositories>


### PR DESCRIPTION
`java/maven/non-https-url` should not flag localhost URLs, those are likely for testing, and hard (impossible?) to perform af MITM attack on.

No change note is needed: the query is still new.