### PR TITLE
C++: Use asExpr, not getConvertedResultExpression

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
@@ -19,33 +19,29 @@ private predicate predictableInstruction(Instruction instr) {
   predictableInstruction(instr.(UnaryInstruction).getUnary())
 }
 
-private predicate userInputInstruction(Instruction instr) {
-  exists(CallInstruction ci, WriteSideEffectInstruction wsei |
-    userInputArgument(ci.getConvertedResultExpression(), wsei.getIndex()) and
-    instr = wsei and
-    wsei.getPrimaryInstruction() = ci
-  )
-  or
-  userInputReturned(instr.getConvertedResultExpression())
-  or
-  isUserInput(instr.getConvertedResultExpression(), _)
-  or
-  instr.getConvertedResultExpression() instanceof EnvironmentRead
-  or
-  instr
-      .(LoadInstruction)
-      .getSourceAddress()
-      .(VariableAddressInstruction)
-      .getASTVariable()
-      .hasName("argv") and
-  instr.getEnclosingFunction().hasGlobalName("main")
-}
-
 private class DefaultTaintTrackingCfg extends DataFlow::Configuration {
   DefaultTaintTrackingCfg() { this = "DefaultTaintTrackingCfg" }
 
   override predicate isSource(DataFlow::Node source) {
-    userInputInstruction(source.asInstruction())
+    exists(CallInstruction ci, WriteSideEffectInstruction wsei |
+      userInputArgument(ci.getConvertedResultExpression(), wsei.getIndex()) and
+      source.asInstruction() = wsei and
+      wsei.getPrimaryInstruction() = ci
+    )
+    or
+    userInputReturned(source.asExpr())
+    or
+    isUserInput(source.asExpr(), _)
+    or
+    source.asExpr() instanceof EnvironmentRead
+    or
+    source.asInstruction()
+        .(LoadInstruction)
+        .getSourceAddress()
+        .(VariableAddressInstruction)
+        .getASTVariable()
+        .hasName("argv") and
+    source.asInstruction().getEnclosingFunction().hasGlobalName("main")
   }
 
   override predicate isSink(DataFlow::Node sink) { any() }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/DefaultTaintTracking.qll
@@ -35,7 +35,8 @@ private class DefaultTaintTrackingCfg extends DataFlow::Configuration {
     or
     source.asExpr() instanceof EnvironmentRead
     or
-    source.asInstruction()
+    source
+        .asInstruction()
         .(LoadInstruction)
         .getSourceAddress()
         .(VariableAddressInstruction)


### PR DESCRIPTION
We designed the IR's `DataFlow::Node.asExpr` very carefully so that it's suitable for taint tracking (see #774), but then we didn't use it in `DefaultTaintTracking.qll`. This meant that the sources in `ArithmeticWithExtremeValues.ql` didn't get associated with any `Instruction` and thus didn't propagate anywhere.

With this PR, the mapping of `Expr`-based sources to IR data-flow nodes uses `asExpr`.