### PR TITLE
JS: use the EventEmitter registration methods instead of just "on"

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/Files.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/Files.qll
@@ -23,7 +23,7 @@ private class WalkFileNameSource extends FileNameSource {
     exists(DataFlow::FunctionNode callback |
       callback = DataFlow::moduleMember("walk", "walk")
             .getACall()
-            .getAMethodCall("on")
+            .getAMethodCall(EventEmitter::on())
             .getCallback(1)
     |
       this = callback.getParameter(1).getAPropertyRead("name")
@@ -97,7 +97,7 @@ private class FastGlobFileNameSource extends FileNameSource {
       // `file` in `require('fast-glob').stream(_).on(_,  file => ...)`
       this = DataFlow::moduleMember(moduleName, "stream")
             .getACall()
-            .getAMethodCall("on")
+            .getAMethodCall(EventEmitter::on())
             .getCallback(1)
             .getParameter(0)
     )

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -530,7 +530,7 @@ module NodeJSLib {
     FileStreamRead() {
       stream.getMethodName() = "createReadStream" and
       this = stream.getAMemberCall(method) and
-      (method = "read" or method = "pipe" or method = "on")
+      (method = "read" or method = "pipe" or method = EventEmitter::on())
     }
 
     override DataFlow::Node getADataNode() {
@@ -540,7 +540,7 @@ module NodeJSLib {
       method = "pipe" and
       result = getArgument(0)
       or
-      method = "on" and
+      method = EventEmitter::on() and
       getArgument(0).mayHaveStringValue("data") and
       result = getCallback(1).getParameter(0)
     }
@@ -751,7 +751,7 @@ module NodeJSLib {
       promise = false and
       exists(DataFlow::ParameterNode res, DataFlow::CallNode onData |
         res = getCallback(1).getParameter(0) and
-        onData = res.getAMethodCall("on") and
+        onData = res.getAMethodCall(EventEmitter::on()) and
         onData.getArgument(0).mayHaveStringValue("data") and
         result = onData.getCallback(1).getParameter(0) and
         responseType = "arraybuffer"
@@ -768,7 +768,7 @@ module NodeJSLib {
 
     ClientRequestHandler() {
       exists(DataFlow::MethodCallNode mcn |
-        clientRequest.getAMethodCall("on") = mcn and
+        clientRequest.getAMethodCall(EventEmitter::on()) = mcn and
         mcn.getArgument(0).mayHaveStringValue(handledEvent) and
         flowsTo(mcn.getArgument(1))
       )
@@ -805,7 +805,7 @@ module NodeJSLib {
   private class ClientRequestDataEvent extends RemoteFlowSource {
     ClientRequestDataEvent() {
       exists(DataFlow::MethodCallNode mcn, ClientRequestResponseEvent cr |
-        cr.getAMethodCall("on") = mcn and
+        cr.getAMethodCall(EventEmitter::on()) = mcn and
         mcn.getArgument(0).mayHaveStringValue("data") and
         this = mcn.getCallback(1).getParameter(0)
       )

--- a/javascript/ql/src/semmle/javascript/security/dataflow/ZipSlipCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/ZipSlipCustomizations.qll
@@ -70,7 +70,7 @@ module ZipSlip {
     // the expression `entry.path`.
     UnzipEntrySource() {
       exists(DataFlow::CallNode cn |
-        cn = parsedArchive().getAMemberCall("on") and
+        cn = parsedArchive().getAMemberCall(EventEmitter::on()) and
         cn.getArgument(0).mayHaveStringValue("entry") and
         this = cn.getCallback(1).getParameter(0).getAPropertyRead(getAFilenameProperty())
       )


### PR DESCRIPTION
I went searching through our `.qll` files to find places where ad hoc models of `EventEmitter` had been implemented. I did this by searching for the method names that `EventEmitter` implements.  

All I found was a few places where only the `.on()` method was used instead of all the event-registration methods that EventEmitter uses.  
(For each case I confirmed that the object in question is an instance of `EventEmitter`) 

None of these implement send-receive pairs, so I didn't see any need for further refactoring.