### PR TITLE
JS: Close an unterminated code block

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/FlowSteps.qll
@@ -297,6 +297,7 @@ private module CachedSteps {
    * }
    *
    * f(arg, cb);
+   * ```
    *
    * This is an over-approximation of a possible data flow step through a callback
    * invocation.


### PR DESCRIPTION
Fixes a qldoc typo