### PR TITLE
JS: Add missing models to support CVE-2019-10767

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -962,4 +962,88 @@ module NodeJSLib {
     
     override EventRegistration::Range getAReceiver() { emitter.getBaseEmitter() = result.getEmitter().(NodeJSEventEmitter).getBaseEmitter() }
   }
+
+  /**
+   * An instance of net.createServer(), which creates a new TCP/IPC server.
+   */
+  private class NodeJSNetServer extends DataFlow::SourceNode {
+    NodeJSNetServer() { this = DataFlow::moduleMember("net", "createServer").getAnInvocation() }
+
+    private DataFlow::SourceNode ref(DataFlow::TypeTracker t) {
+      t.start() and result = this
+      or
+      exists(DataFlow::TypeTracker t2 | result = ref(t2).track(t2, t))
+    }
+
+    /**
+     * Gets a reference to this server.
+     */ 
+    DataFlow::SourceNode ref() { result = ref(DataFlow::TypeTracker::end()) }
+  }
+  
+  /**
+   * A connection opened on a NodeJS net server.
+   */ 
+  private class NodeJSNetServerConnection extends EventEmitter::Range {
+  	NodeJSNetServer server;
+  	
+  	NodeJSNetServerConnection() {
+  	  exists(DataFlow::MethodCallNode call | 
+  	    call = server.ref().getAMethodCall("on") and 
+  	    call.getArgument(0).mayHaveStringValue("connection") 
+  	  | 
+  	    this = call.getCallback(1).getParameter(0)
+  	  )  	  	
+  	}
+  	
+    DataFlow::SourceNode ref() { result = EventEmitter::trackEventEmitter(this) }
+  }
+
+  /**
+   * A registration of an event handler on a NodeJS net server instance.
+   */
+  private class NodeJSNetServerRegistration extends EventRegistration::DefaultEventRegistration,
+    DataFlow::MethodCallNode {
+    override NodeJSNetServerConnection emitter;
+
+    NodeJSNetServerRegistration() { this = emitter.ref().getAMethodCall(EventEmitter::on()) }
+  }
+
+  /**
+   * A data flow node representing data received from a client to a NodeJS net server, viewed as remote user input.
+   */
+  private class NodeJSNetServerItemAsRemoteFlow extends RemoteFlowSource {
+    NodeJSNetServerRegistration reg;
+
+    NodeJSNetServerItemAsRemoteFlow() { this = reg.getReceivedItem(_) }
+
+    override string getSourceType() { result = "NodeJS server" }
+  }
+  
+  /**
+   * An instantiation of the `respjs` library, which is an EventEmitter.
+   */
+  private class RespJS extends NodeJSEventEmitter {
+  	RespJS() {
+  	  this = DataFlow::moduleImport("respjs").getAnInstantiation()	
+  	}
+  }
+  
+  /**
+   * A event dispatch that serializes the input data and emits the result on the "data" channel. 
+   */
+  private class RespWrite extends EventDispatch::DefaultEventDispatch,
+    DataFlow::MethodCallNode {
+    override RespJS emitter;
+
+    RespWrite() { this = emitter.ref().getAMethodCall("write") }
+    
+    override string getChannel() {
+      result = "data"
+    }
+
+    override DataFlow::Node getSentItem(int i) {
+      i = 0 and result = this.getArgument(i)
+    }
+  }
 }

--- a/javascript/ql/test/library-tests/frameworks/EventEmitter/customEmitter.js
+++ b/javascript/ql/test/library-tests/frameworks/EventEmitter/customEmitter.js
@@ -1,0 +1,22 @@
+const EventEmitter = require("events");
+
+class MyEmitter extends EventEmitter {
+	foo() {
+		this.emit("foo", "bar");
+		this.on("foo", (data) => {});
+	}
+}
+
+class MySecondEmitter extends EventEmitter {
+	foo() {
+	  this.emit("bar", "baz");
+      this.on("bar", (data) => {});
+	}
+}
+
+var x = new MySecondEmitter();
+x.emit("bar", "baz2");
+
+var y = new MySecondEmitter();
+y.emit("bar", "baz3");
+y.on("bar", (yData) => {})

--- a/javascript/ql/test/library-tests/frameworks/EventEmitter/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/EventEmitter/test.expected
@@ -1,3 +1,9 @@
+| customEmitter.js:5:20:5:24 | "bar" | customEmitter.js:6:19:6:22 | data |
+| customEmitter.js:12:21:12:25 | "baz" | customEmitter.js:13:23:13:26 | data |
+| customEmitter.js:12:21:12:25 | "baz" | customEmitter.js:22:14:22:18 | yData |
+| customEmitter.js:18:15:18:20 | "baz2" | customEmitter.js:13:23:13:26 | data |
+| customEmitter.js:21:15:21:20 | "baz3" | customEmitter.js:13:23:13:26 | data |
+| customEmitter.js:21:15:21:20 | "baz3" | customEmitter.js:22:14:22:18 | yData |
 | tst.js:9:23:9:33 | 'FirstData' | tst.js:6:40:6:44 | first |
 | tst.js:10:24:10:35 | 'SecondData' | tst.js:7:32:7:37 | second |
 | tst.js:15:24:15:39 | 'OtherFirstData' | tst.js:14:41:14:50 | otherFirst |


### PR DESCRIPTION
The `EventEmitter` models were originally added to support [CVE-2019-10767](https://github.com/advisories/GHSA-cmch-296j-wfvw).  

This PR adds the last models such that we now flag the CVE. 

The first commit adds support for matching event-registration with event-dispatch when the following pattern is used:
```JavaScript
class Handler extends EventEmitter {
  foo() {
    this.emit("channel", "data");
  }
}
new Handler().on("channel", (data) => ...);
```

The second commit adds some support for [`net.createServer()`](https://nodejs.org/api/net.html#net_net_createserver_options_connectionlistener) (to add a source) and [`respjs`](https://www.npmjs.com/package/respjs) (to add a data flow edge). 

The model for `respjs` is in the `NodeJSLib.qll` file for now, even though it doesn't really belong there.  
I couldn't find a file I think it belonged in, and it felt too extreme to create a new `.qll` file for such a small model. 