### PR TITLE
Ql tests for virtual dispatch taint tracking

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/tainted.expected
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/tainted.expected
@@ -4,12 +4,14 @@
 | defaulttainttracking.cpp:16:16:16:21 | call to getenv | defaulttainttracking.cpp:16:8:16:29 | (const char *)... |
 | defaulttainttracking.cpp:16:16:16:21 | call to getenv | defaulttainttracking.cpp:16:16:16:21 | call to getenv |
 | defaulttainttracking.cpp:16:16:16:21 | call to getenv | defaulttainttracking.cpp:16:16:16:28 | (const char *)... |
+| defaulttainttracking.cpp:16:16:16:21 | call to getenv | test_diff.cpp:1:11:1:20 | p#0 |
 | defaulttainttracking.cpp:17:15:17:20 | call to getenv | defaulttainttracking.cpp:5:14:5:23 | p#0 |
 | defaulttainttracking.cpp:17:15:17:20 | call to getenv | defaulttainttracking.cpp:9:11:9:20 | p#0 |
 | defaulttainttracking.cpp:17:15:17:20 | call to getenv | defaulttainttracking.cpp:17:8:17:13 | call to strdup |
 | defaulttainttracking.cpp:17:15:17:20 | call to getenv | defaulttainttracking.cpp:17:8:17:28 | (const char *)... |
 | defaulttainttracking.cpp:17:15:17:20 | call to getenv | defaulttainttracking.cpp:17:15:17:20 | call to getenv |
 | defaulttainttracking.cpp:17:15:17:20 | call to getenv | defaulttainttracking.cpp:17:15:17:27 | (const char *)... |
+| defaulttainttracking.cpp:17:15:17:20 | call to getenv | test_diff.cpp:1:11:1:20 | p#0 |
 | defaulttainttracking.cpp:18:27:18:32 | call to getenv | defaulttainttracking.cpp:7:26:7:35 | p#0 |
 | defaulttainttracking.cpp:18:27:18:32 | call to getenv | defaulttainttracking.cpp:18:27:18:32 | call to getenv |
 | defaulttainttracking.cpp:18:27:18:32 | call to getenv | defaulttainttracking.cpp:18:27:18:39 | (const char *)... |
@@ -19,6 +21,7 @@
 | defaulttainttracking.cpp:22:20:22:25 | call to getenv | defaulttainttracking.cpp:22:8:22:33 | (const char *)... |
 | defaulttainttracking.cpp:22:20:22:25 | call to getenv | defaulttainttracking.cpp:22:20:22:25 | call to getenv |
 | defaulttainttracking.cpp:22:20:22:25 | call to getenv | defaulttainttracking.cpp:22:20:22:32 | (const char *)... |
+| defaulttainttracking.cpp:22:20:22:25 | call to getenv | test_diff.cpp:1:11:1:20 | p#0 |
 | defaulttainttracking.cpp:38:25:38:30 | call to getenv | defaulttainttracking.cpp:32:11:32:26 | p#0 |
 | defaulttainttracking.cpp:38:25:38:30 | call to getenv | defaulttainttracking.cpp:38:11:38:21 | env_pointer |
 | defaulttainttracking.cpp:38:25:38:30 | call to getenv | defaulttainttracking.cpp:38:25:38:30 | call to getenv |
@@ -27,3 +30,100 @@
 | defaulttainttracking.cpp:38:25:38:30 | call to getenv | defaulttainttracking.cpp:39:26:39:34 | call to inet_addr |
 | defaulttainttracking.cpp:38:25:38:30 | call to getenv | defaulttainttracking.cpp:39:50:39:61 | & ... |
 | defaulttainttracking.cpp:38:25:38:30 | call to getenv | defaulttainttracking.cpp:40:10:40:10 | a |
+| test_diff.cpp:92:10:92:13 | argv | defaulttainttracking.cpp:9:11:9:20 | p#0 |
+| test_diff.cpp:92:10:92:13 | argv | test_diff.cpp:1:11:1:20 | p#0 |
+| test_diff.cpp:92:10:92:13 | argv | test_diff.cpp:92:10:92:13 | argv |
+| test_diff.cpp:92:10:92:13 | argv | test_diff.cpp:92:10:92:16 | (const char *)... |
+| test_diff.cpp:92:10:92:13 | argv | test_diff.cpp:92:10:92:16 | access to array |
+| test_diff.cpp:94:32:94:35 | argv | defaulttainttracking.cpp:10:11:10:13 | p#0 |
+| test_diff.cpp:94:32:94:35 | argv | test_diff.cpp:2:11:2:13 | p#0 |
+| test_diff.cpp:94:32:94:35 | argv | test_diff.cpp:94:10:94:36 | reinterpret_cast<int>... |
+| test_diff.cpp:94:32:94:35 | argv | test_diff.cpp:94:32:94:35 | argv |
+| test_diff.cpp:96:26:96:29 | argv | defaulttainttracking.cpp:9:11:9:20 | p#0 |
+| test_diff.cpp:96:26:96:29 | argv | test_diff.cpp:1:11:1:20 | p#0 |
+| test_diff.cpp:96:26:96:29 | argv | test_diff.cpp:16:39:16:39 | a |
+| test_diff.cpp:96:26:96:29 | argv | test_diff.cpp:17:10:17:10 | a |
+| test_diff.cpp:96:26:96:29 | argv | test_diff.cpp:96:26:96:29 | argv |
+| test_diff.cpp:96:26:96:29 | argv | test_diff.cpp:96:26:96:32 | (const char *)... |
+| test_diff.cpp:96:26:96:29 | argv | test_diff.cpp:96:26:96:32 | access to array |
+| test_diff.cpp:98:18:98:21 | argv | defaulttainttracking.cpp:9:11:9:20 | p#0 |
+| test_diff.cpp:98:18:98:21 | argv | test_diff.cpp:1:11:1:20 | p#0 |
+| test_diff.cpp:98:18:98:21 | argv | test_diff.cpp:16:39:16:39 | a |
+| test_diff.cpp:98:18:98:21 | argv | test_diff.cpp:17:10:17:10 | a |
+| test_diff.cpp:98:18:98:21 | argv | test_diff.cpp:98:13:98:13 | p |
+| test_diff.cpp:98:18:98:21 | argv | test_diff.cpp:98:17:98:21 | & ... |
+| test_diff.cpp:98:18:98:21 | argv | test_diff.cpp:98:18:98:21 | argv |
+| test_diff.cpp:98:18:98:21 | argv | test_diff.cpp:100:10:100:14 | (const char *)... |
+| test_diff.cpp:98:18:98:21 | argv | test_diff.cpp:100:10:100:14 | * ... |
+| test_diff.cpp:98:18:98:21 | argv | test_diff.cpp:100:11:100:11 | p |
+| test_diff.cpp:98:18:98:21 | argv | test_diff.cpp:100:11:100:14 | access to array |
+| test_diff.cpp:98:18:98:21 | argv | test_diff.cpp:102:26:102:30 | (const char *)... |
+| test_diff.cpp:98:18:98:21 | argv | test_diff.cpp:102:26:102:30 | * ... |
+| test_diff.cpp:98:18:98:21 | argv | test_diff.cpp:102:27:102:27 | p |
+| test_diff.cpp:98:18:98:21 | argv | test_diff.cpp:102:27:102:30 | access to array |
+| test_diff.cpp:104:12:104:15 | argv | defaulttainttracking.cpp:9:11:9:20 | p#0 |
+| test_diff.cpp:104:12:104:15 | argv | test_diff.cpp:1:11:1:20 | p#0 |
+| test_diff.cpp:104:12:104:15 | argv | test_diff.cpp:104:10:104:20 | (const char *)... |
+| test_diff.cpp:104:12:104:15 | argv | test_diff.cpp:104:10:104:20 | * ... |
+| test_diff.cpp:104:12:104:15 | argv | test_diff.cpp:104:11:104:20 | (...) |
+| test_diff.cpp:104:12:104:15 | argv | test_diff.cpp:104:12:104:15 | argv |
+| test_diff.cpp:104:12:104:15 | argv | test_diff.cpp:104:12:104:19 | ... + ... |
+| test_diff.cpp:108:10:108:13 | argv | defaulttainttracking.cpp:9:11:9:20 | p#0 |
+| test_diff.cpp:108:10:108:13 | argv | test_diff.cpp:1:11:1:20 | p#0 |
+| test_diff.cpp:108:10:108:13 | argv | test_diff.cpp:24:20:24:29 | p#0 |
+| test_diff.cpp:108:10:108:13 | argv | test_diff.cpp:29:24:29:24 | p |
+| test_diff.cpp:108:10:108:13 | argv | test_diff.cpp:30:14:30:14 | p |
+| test_diff.cpp:108:10:108:13 | argv | test_diff.cpp:108:10:108:13 | argv |
+| test_diff.cpp:108:10:108:13 | argv | test_diff.cpp:108:10:108:16 | (const char *)... |
+| test_diff.cpp:108:10:108:13 | argv | test_diff.cpp:108:10:108:16 | access to array |
+| test_diff.cpp:111:10:111:13 | argv | test_diff.cpp:24:20:24:29 | p#0 |
+| test_diff.cpp:111:10:111:13 | argv | test_diff.cpp:36:24:36:24 | p |
+| test_diff.cpp:111:10:111:13 | argv | test_diff.cpp:111:10:111:13 | argv |
+| test_diff.cpp:111:10:111:13 | argv | test_diff.cpp:111:10:111:16 | (const char *)... |
+| test_diff.cpp:111:10:111:13 | argv | test_diff.cpp:111:10:111:16 | access to array |
+| test_diff.cpp:115:11:115:14 | argv | defaulttainttracking.cpp:9:11:9:20 | p#0 |
+| test_diff.cpp:115:11:115:14 | argv | test_diff.cpp:1:11:1:20 | p#0 |
+| test_diff.cpp:115:11:115:14 | argv | test_diff.cpp:24:20:24:29 | p#0 |
+| test_diff.cpp:115:11:115:14 | argv | test_diff.cpp:41:24:41:24 | p |
+| test_diff.cpp:115:11:115:14 | argv | test_diff.cpp:42:14:42:14 | p |
+| test_diff.cpp:115:11:115:14 | argv | test_diff.cpp:52:24:52:24 | p |
+| test_diff.cpp:115:11:115:14 | argv | test_diff.cpp:53:37:53:37 | p |
+| test_diff.cpp:115:11:115:14 | argv | test_diff.cpp:115:11:115:14 | argv |
+| test_diff.cpp:115:11:115:14 | argv | test_diff.cpp:115:11:115:17 | (const char *)... |
+| test_diff.cpp:115:11:115:14 | argv | test_diff.cpp:115:11:115:17 | access to array |
+| test_diff.cpp:118:26:118:29 | argv | test_diff.cpp:60:24:60:24 | p |
+| test_diff.cpp:118:26:118:29 | argv | test_diff.cpp:61:34:61:34 | p |
+| test_diff.cpp:118:26:118:29 | argv | test_diff.cpp:88:24:88:24 | p |
+| test_diff.cpp:118:26:118:29 | argv | test_diff.cpp:118:26:118:29 | argv |
+| test_diff.cpp:118:26:118:29 | argv | test_diff.cpp:118:26:118:32 | (const char *)... |
+| test_diff.cpp:118:26:118:29 | argv | test_diff.cpp:118:26:118:32 | access to array |
+| test_diff.cpp:121:23:121:26 | argv | defaulttainttracking.cpp:9:11:9:20 | p#0 |
+| test_diff.cpp:121:23:121:26 | argv | test_diff.cpp:1:11:1:20 | p#0 |
+| test_diff.cpp:121:23:121:26 | argv | test_diff.cpp:60:24:60:24 | p |
+| test_diff.cpp:121:23:121:26 | argv | test_diff.cpp:61:34:61:34 | p |
+| test_diff.cpp:121:23:121:26 | argv | test_diff.cpp:67:24:67:24 | p |
+| test_diff.cpp:121:23:121:26 | argv | test_diff.cpp:68:14:68:14 | p |
+| test_diff.cpp:121:23:121:26 | argv | test_diff.cpp:121:23:121:26 | argv |
+| test_diff.cpp:121:23:121:26 | argv | test_diff.cpp:121:23:121:29 | (const char *)... |
+| test_diff.cpp:121:23:121:26 | argv | test_diff.cpp:121:23:121:29 | access to array |
+| test_diff.cpp:124:19:124:22 | argv | defaulttainttracking.cpp:9:11:9:20 | p#0 |
+| test_diff.cpp:124:19:124:22 | argv | test_diff.cpp:1:11:1:20 | p#0 |
+| test_diff.cpp:124:19:124:22 | argv | test_diff.cpp:24:20:24:29 | p#0 |
+| test_diff.cpp:124:19:124:22 | argv | test_diff.cpp:76:24:76:24 | p |
+| test_diff.cpp:124:19:124:22 | argv | test_diff.cpp:81:24:81:24 | p |
+| test_diff.cpp:124:19:124:22 | argv | test_diff.cpp:82:14:82:14 | p |
+| test_diff.cpp:124:19:124:22 | argv | test_diff.cpp:124:19:124:22 | argv |
+| test_diff.cpp:124:19:124:22 | argv | test_diff.cpp:124:19:124:25 | (const char *)... |
+| test_diff.cpp:124:19:124:22 | argv | test_diff.cpp:124:19:124:25 | access to array |
+| test_diff.cpp:126:43:126:46 | argv | defaulttainttracking.cpp:9:11:9:20 | p#0 |
+| test_diff.cpp:126:43:126:46 | argv | test_diff.cpp:1:11:1:20 | p#0 |
+| test_diff.cpp:126:43:126:46 | argv | test_diff.cpp:76:24:76:24 | p |
+| test_diff.cpp:126:43:126:46 | argv | test_diff.cpp:81:24:81:24 | p |
+| test_diff.cpp:126:43:126:46 | argv | test_diff.cpp:82:14:82:14 | p |
+| test_diff.cpp:126:43:126:46 | argv | test_diff.cpp:126:43:126:46 | argv |
+| test_diff.cpp:126:43:126:46 | argv | test_diff.cpp:126:43:126:49 | (const char *)... |
+| test_diff.cpp:126:43:126:46 | argv | test_diff.cpp:126:43:126:49 | access to array |
+| test_diff.cpp:128:44:128:47 | argv | test_diff.cpp:76:24:76:24 | p |
+| test_diff.cpp:128:44:128:47 | argv | test_diff.cpp:128:44:128:47 | argv |
+| test_diff.cpp:128:44:128:47 | argv | test_diff.cpp:128:44:128:50 | (const char *)... |
+| test_diff.cpp:128:44:128:47 | argv | test_diff.cpp:128:44:128:50 | access to array |

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.cpp
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.cpp
@@ -1,0 +1,129 @@
+void sink(const char *);
+void sink(int);
+
+struct S {
+    void(*f)(const char*);
+
+    void apply(char* p) {
+        f(p);
+    }
+
+    void (*get())(const char*) {
+        return f;
+    }
+};
+
+void calls_sink_with_argv(const char* a) {
+    sink(a);
+}
+
+extern int i;
+
+class BaseWithPureVirtual {
+public:
+    virtual void f(const char*) = 0;
+};
+
+class DerivedCallsSink : public BaseWithPureVirtual {
+public:
+    void f(const char* p) override {
+        sink(p);
+    }
+};
+
+class DerivedDoesNotCallSink : public BaseWithPureVirtual {
+public:
+    void f(const char* p) override {}
+};
+
+class DerivedCallsSinkDiamond1 : virtual public BaseWithPureVirtual {
+public:
+    void f(const char* p) override {
+        sink(p);
+    }
+};
+
+class DerivedDoesNotCallSinkDiamond2 : virtual public BaseWithPureVirtual {
+public:
+    void f(const char* p) override {}
+};
+
+class DerivesMultiple : public DerivedCallsSinkDiamond1, public DerivedDoesNotCallSinkDiamond2 {
+    void f(const char* p) override {
+        DerivedCallsSinkDiamond1::f(p);
+    }
+};
+
+template<typename T>
+class CRTP {
+public:
+    void f(const char* p) {
+        static_cast<T*>(this)->g(p);
+    }
+};
+
+class CRTPCallsSink : public CRTP<CRTPCallsSink> {
+    public:
+    void g(const char* p) {
+        sink(p);
+    }
+};
+
+class Derived1 : public BaseWithPureVirtual {};
+
+class Derived2 : public Derived1 {
+    public:
+    void f(const char* p) override {}
+};
+
+class Derived3 : public Derived2 {
+    public:
+    void f(const char* p) override {
+        sink(p);
+    }
+};
+
+class CRTPDoesNotCallSink : public CRTP<CRTPDoesNotCallSink> {
+    public:
+    void g(const char* p) {}
+};
+
+int main(int argc, char *argv[]) {
+    sink(argv[0]);
+
+    sink(reinterpret_cast<int>(argv));
+
+    calls_sink_with_argv(argv[1]);
+
+    char*** p = &argv;
+
+    sink(*p[0]);
+
+    calls_sink_with_argv(*p[i]);
+
+    sink(*(argv + 1)); // flow [NOT DECTED by AST]
+
+    BaseWithPureVirtual* b = new DerivedCallsSink;
+
+    b->f(argv[1]); // flow [NOT DETECTED by IR]
+
+    b = new DerivedDoesNotCallSink;
+    b->f(argv[0]); // no flow [FALSE POSITIVE by AST]
+
+    BaseWithPureVirtual* b2 = new DerivesMultiple;
+
+    b2->f(argv[i]); // flow [NOT DETECTED]
+
+    CRTP<CRTPDoesNotCallSink> crtp_not_call_sink;
+    crtp_not_call_sink.f(argv[0]);
+
+    CRTP<CRTPCallsSink> crtp_calls_sink;
+    crtp_calls_sink.f(argv[0]); // flow [NOT DETECTED]
+
+    Derived1* calls_sink = new Derived3;
+    calls_sink->f(argv[1]); // flow [NOT DETECTED by AST]
+
+    static_cast<Derived2*>(calls_sink)->f(argv[1]); // flow [NOT DETECTED]
+
+    dynamic_cast<Derived2*>(calls_sink)->f(argv[1]); // flow [NOT DETECTED by IR]
+}

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.expected
@@ -1,0 +1,22 @@
+| defaulttainttracking.cpp:16:16:16:21 | call to getenv | defaulttainttracking.cpp:9:11:9:20 | p#0 | IR only |
+| defaulttainttracking.cpp:16:16:16:21 | call to getenv | defaulttainttracking.cpp:16:8:16:14 | call to _strdup | IR only |
+| defaulttainttracking.cpp:16:16:16:21 | call to getenv | defaulttainttracking.cpp:16:8:16:29 | (const char *)... | IR only |
+| defaulttainttracking.cpp:16:16:16:21 | call to getenv | test_diff.cpp:1:11:1:20 | p#0 | IR only |
+| defaulttainttracking.cpp:22:20:22:25 | call to getenv | defaulttainttracking.cpp:3:21:3:22 | s1 | AST only |
+| defaulttainttracking.cpp:22:20:22:25 | call to getenv | defaulttainttracking.cpp:21:8:21:10 | buf | AST only |
+| defaulttainttracking.cpp:22:20:22:25 | call to getenv | defaulttainttracking.cpp:22:15:22:17 | buf | AST only |
+| defaulttainttracking.cpp:22:20:22:25 | call to getenv | defaulttainttracking.cpp:24:8:24:10 | buf | AST only |
+| defaulttainttracking.cpp:38:25:38:30 | call to getenv | defaulttainttracking.cpp:31:40:31:53 | dotted_address | AST only |
+| defaulttainttracking.cpp:38:25:38:30 | call to getenv | defaulttainttracking.cpp:39:36:39:61 | (const char *)... | AST only |
+| defaulttainttracking.cpp:38:25:38:30 | call to getenv | defaulttainttracking.cpp:39:51:39:61 | env_pointer | AST only |
+| test_diff.cpp:104:12:104:15 | argv | test_diff.cpp:104:11:104:20 | (...) | IR only |
+| test_diff.cpp:108:10:108:13 | argv | test_diff.cpp:36:24:36:24 | p | AST only |
+| test_diff.cpp:111:10:111:13 | argv | defaulttainttracking.cpp:9:11:9:20 | p#0 | AST only |
+| test_diff.cpp:111:10:111:13 | argv | test_diff.cpp:1:11:1:20 | p#0 | AST only |
+| test_diff.cpp:111:10:111:13 | argv | test_diff.cpp:29:24:29:24 | p | AST only |
+| test_diff.cpp:111:10:111:13 | argv | test_diff.cpp:30:14:30:14 | p | AST only |
+| test_diff.cpp:124:19:124:22 | argv | test_diff.cpp:76:24:76:24 | p | IR only |
+| test_diff.cpp:128:44:128:47 | argv | defaulttainttracking.cpp:9:11:9:20 | p#0 | AST only |
+| test_diff.cpp:128:44:128:47 | argv | test_diff.cpp:1:11:1:20 | p#0 | AST only |
+| test_diff.cpp:128:44:128:47 | argv | test_diff.cpp:81:24:81:24 | p | AST only |
+| test_diff.cpp:128:44:128:47 | argv | test_diff.cpp:82:14:82:14 | p | AST only |

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.ql
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.ql
@@ -1,0 +1,23 @@
+import cpp
+import semmle.code.cpp.security.Security
+import semmle.code.cpp.security.TaintTracking as ASTTaintTracking
+import semmle.code.cpp.ir.dataflow.DefaultTaintTracking as IRDefaultTaintTracking
+
+predicate astFlow(Expr source, Element sink) {
+  ASTTaintTracking::tainted(source, sink)
+}
+
+predicate irFlow(Expr source, Element sink) {
+  IRDefaultTaintTracking::tainted(source, sink)
+}
+
+from Expr source, Element sink, string note
+where
+  astFlow(source, sink) and
+  not irFlow(source, sink) and
+  note = "AST only"
+  or
+  irFlow(source, sink) and
+  not astFlow(source, sink) and
+  note = "IR only"
+select source, sink, note

--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.ql
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.ql
@@ -3,13 +3,9 @@ import semmle.code.cpp.security.Security
 import semmle.code.cpp.security.TaintTracking as ASTTaintTracking
 import semmle.code.cpp.ir.dataflow.DefaultTaintTracking as IRDefaultTaintTracking
 
-predicate astFlow(Expr source, Element sink) {
-  ASTTaintTracking::tainted(source, sink)
-}
+predicate astFlow(Expr source, Element sink) { ASTTaintTracking::tainted(source, sink) }
 
-predicate irFlow(Expr source, Element sink) {
-  IRDefaultTaintTracking::tainted(source, sink)
-}
+predicate irFlow(Expr source, Element sink) { IRDefaultTaintTracking::tainted(source, sink) }
 
 from Expr source, Element sink, string note
 where


### PR DESCRIPTION
Adds tests for testing differences between the virtual dispatch analysis in `DefaultTaintTracking ` and `security.TaintTracking`.

Original PR (which I closed due to an incorrect merge from master causing a bad commit ): https://github.com/Semmle/ql/pull/2697