### PR TITLE
Java: Deprecate ParExpr

### DIFF
--- a/change-notes/1.24/analysis-java.md
+++ b/change-notes/1.24/analysis-java.md
@@ -32,3 +32,6 @@ The following changes in version 1.24 affect Java analysis in all applications.
   general file classification mechanism and thus suppression of alerts, and
   also any security queries using taint tracking, as test classes act as
   default barriers stopping taint flow.
+* Parentheses are now no longer modelled directly in the AST, that is, the
+  `ParExpr` class is empty. Instead, a parenthesized expression can be
+  identified with the `Expr.isParenthesized()` member predicate.

--- a/java/ql/src/Language Abuse/UselessUpcast.ql
+++ b/java/ql/src/Language Abuse/UselessUpcast.ql
@@ -36,9 +36,7 @@ predicate usefulUpcast(CastExpr e) {
   )
   or
   // Upcasts that are performed on an operand of a ternary expression.
-  exists(ConditionalExpr ce |
-    e = ce.getTrueExpr() or e = ce.getFalseExpr()
-  )
+  exists(ConditionalExpr ce | e = ce.getTrueExpr() or e = ce.getFalseExpr())
   or
   // Upcasts to raw types.
   e.getType() instanceof RawType

--- a/java/ql/src/Language Abuse/UselessUpcast.ql
+++ b/java/ql/src/Language Abuse/UselessUpcast.ql
@@ -15,7 +15,7 @@ import java
 predicate usefulUpcast(CastExpr e) {
   // Upcasts that may be performed to affect resolution of methods or constructors.
   exists(Call c, int i, Callable target |
-    c.getArgument(i).getProperExpr() = e and
+    c.getArgument(i) = e and
     target = c.getCallee() and
     // An upcast to the type of the corresponding parameter.
     e.getType() = target.getParameterType(i)
@@ -31,13 +31,13 @@ predicate usefulUpcast(CastExpr e) {
   )
   or
   // Upcasts of a varargs argument.
-  exists(Call c, int iArg, int iParam | c.getArgument(iArg).getProperExpr() = e |
+  exists(Call c, int iArg, int iParam | c.getArgument(iArg) = e |
     c.getCallee().getParameter(iParam).isVarargs() and iArg >= iParam
   )
   or
   // Upcasts that are performed on an operand of a ternary expression.
   exists(ConditionalExpr ce |
-    e = ce.getTrueExpr().getProperExpr() or e = ce.getFalseExpr().getProperExpr()
+    e = ce.getTrueExpr() or e = ce.getFalseExpr()
   )
   or
   // Upcasts to raw types.
@@ -46,12 +46,12 @@ predicate usefulUpcast(CastExpr e) {
   e.getType().(Array).getElementType() instanceof RawType
   or
   // Upcasts that are performed to affect field, private method, or static method resolution.
-  exists(FieldAccess fa | e = fa.getQualifier().getProperExpr() |
+  exists(FieldAccess fa | e = fa.getQualifier() |
     not e.getExpr().getType().(RefType).inherits(fa.getField())
   )
   or
   exists(MethodAccess ma, Method m |
-    e = ma.getQualifier().getProperExpr() and
+    e = ma.getQualifier() and
     m = ma.getMethod() and
     (m.isStatic() or m.isPrivate())
   |

--- a/java/ql/src/Likely Bugs/Arithmetic/BadCheckOdd.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/BadCheckOdd.ql
@@ -15,7 +15,7 @@ import java
 import semmle.code.java.Collections
 
 predicate isDefinitelyPositive(Expr e) {
-  isDefinitelyPositive(e.getProperExpr()) or
+  isDefinitelyPositive(e) or
   e.(IntegerLiteral).getIntValue() >= 0 or
   e.(MethodAccess).getMethod() instanceof CollectionSizeMethod or
   e.(MethodAccess).getMethod() instanceof StringLengthMethod or
@@ -24,10 +24,10 @@ predicate isDefinitelyPositive(Expr e) {
 
 from BinaryExpr t, RemExpr lhs, IntegerLiteral rhs, string parity
 where
-  t.getLeftOperand().getProperExpr() = lhs and
-  t.getRightOperand().getProperExpr() = rhs and
+  t.getLeftOperand() = lhs and
+  t.getRightOperand() = rhs and
   not isDefinitelyPositive(lhs.getLeftOperand()) and
-  lhs.getRightOperand().getProperExpr().(IntegerLiteral).getIntValue() = 2 and
+  lhs.getRightOperand().(IntegerLiteral).getIntValue() = 2 and
   (
     t instanceof EQExpr and rhs.getIntValue() = 1 and parity = "oddness"
     or

--- a/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
@@ -17,9 +17,6 @@ predicate isConstantExp(Expr e) {
   // A literal is constant.
   e instanceof Literal
   or
-  // A parenthesized expression is constant if its proper expression is.
-  isConstantExp(e.(ParExpr).getProperExpr())
-  or
   e instanceof TypeAccess
   or
   e instanceof ArrayTypeAccess
@@ -33,25 +30,25 @@ predicate isConstantExp(Expr e) {
   )
   or
   // A cast expression is constant if its expression is.
-  exists(CastExpr c | c = e | isConstantExp(c.getExpr().getProperExpr()))
+  exists(CastExpr c | c = e | isConstantExp(c.getExpr()))
   or
   // Multiplication by 0 is constant.
-  exists(MulExpr m | m = e | eval(m.getAnOperand().getProperExpr()) = 0)
+  exists(MulExpr m | m = e | eval(m.getAnOperand()) = 0)
   or
   // Integer remainder by 1 is constant.
   exists(RemExpr r | r = e |
     r.getLeftOperand().getType() instanceof IntegralType and
-    eval(r.getRightOperand().getProperExpr()) = 1
+    eval(r.getRightOperand()) = 1
   )
   or
-  exists(AndBitwiseExpr a | a = e | eval(a.getAnOperand().getProperExpr()) = 0)
+  exists(AndBitwiseExpr a | a = e | eval(a.getAnOperand()) = 0)
   or
   exists(AndLogicalExpr a | a = e |
-    a.getAnOperand().getProperExpr().(BooleanLiteral).getBooleanValue() = false
+    a.getAnOperand().(BooleanLiteral).getBooleanValue() = false
   )
   or
   exists(OrLogicalExpr o | o = e |
-    o.getAnOperand().getProperExpr().(BooleanLiteral).getBooleanValue() = true
+    o.getAnOperand().(BooleanLiteral).getBooleanValue() = true
   )
 }
 

--- a/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/ConstantExpAppearsNonConstant.ql
@@ -43,13 +43,9 @@ predicate isConstantExp(Expr e) {
   or
   exists(AndBitwiseExpr a | a = e | eval(a.getAnOperand()) = 0)
   or
-  exists(AndLogicalExpr a | a = e |
-    a.getAnOperand().(BooleanLiteral).getBooleanValue() = false
-  )
+  exists(AndLogicalExpr a | a = e | a.getAnOperand().(BooleanLiteral).getBooleanValue() = false)
   or
-  exists(OrLogicalExpr o | o = e |
-    o.getAnOperand().(BooleanLiteral).getBooleanValue() = true
-  )
+  exists(OrLogicalExpr o | o = e | o.getAnOperand().(BooleanLiteral).getBooleanValue() = true)
 }
 
 from Expr e

--- a/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
+++ b/java/ql/src/Likely Bugs/Arithmetic/IntMultToLong.ql
@@ -35,8 +35,8 @@ float exprBound(Expr e) {
 /** A multiplication that does not overflow. */
 predicate small(MulExpr e) {
   exists(NumType t, float lhs, float rhs, float res | t = e.getType() |
-    lhs = exprBound(e.getLeftOperand().getProperExpr()) and
-    rhs = exprBound(e.getRightOperand().getProperExpr()) and
+    lhs = exprBound(e.getLeftOperand()) and
+    rhs = exprBound(e.getRightOperand()) and
     lhs * rhs = res and
     res <= t.getOrdPrimitiveType().getMaxValue()
   )
@@ -47,7 +47,7 @@ predicate small(MulExpr e) {
  */
 Expr getRestrictedParent(Expr e) {
   result = e.getParent() and
-  (result instanceof ArithExpr or result instanceof ConditionalExpr or result instanceof ParExpr)
+  (result instanceof ArithExpr or result instanceof ConditionalExpr)
 }
 
 from ConversionSite c, MulExpr e, NumType sourceType, NumType destType

--- a/java/ql/src/Likely Bugs/Comparison/DefineEqualsWhenAddingFields.ql
+++ b/java/ql/src/Likely Bugs/Comparison/DefineEqualsWhenAddingFields.ql
@@ -32,11 +32,11 @@ predicate checksReferenceEquality(EqualsMethod em) {
     eq.getAnOperand().(VarAccess).getVariable() = em.getParameter(0) and
     (
       // `{ return (ojb==this); }`
-      eq = blk.getStmt().(ReturnStmt).getResult().getProperExpr()
+      eq = blk.getStmt().(ReturnStmt).getResult()
       or
       // `{ if (ojb==this) return true; else return false; }`
       exists(IfStmt ifStmt | ifStmt = blk.getStmt() |
-        eq = ifStmt.getCondition().getProperExpr() and
+        eq = ifStmt.getCondition() and
         ifStmt.getThen().(ReturnStmt).getResult().(BooleanLiteral).getBooleanValue() = true and
         ifStmt.getElse().(ReturnStmt).getResult().(BooleanLiteral).getBooleanValue() = false
       )

--- a/java/ql/src/Likely Bugs/Comparison/MissingInstanceofInEquals.ql
+++ b/java/ql/src/Likely Bugs/Comparison/MissingInstanceofInEquals.ql
@@ -45,7 +45,7 @@ class ReferenceEquals extends EqualsMethod {
     exists(Block b, ReturnStmt ret, EQExpr eq |
       this.getBody() = b and
       b.getStmt(0) = ret and
-      ret.getResult().getProperExpr() = eq and
+      ret.getResult() = eq and
       eq.getAnOperand() = this.getAParameter().getAnAccess() and
       (eq.getAnOperand() instanceof ThisAccess or eq.getAnOperand() instanceof FieldAccess)
     )

--- a/java/ql/src/Likely Bugs/Comparison/NoAssignInBooleanExprs.ql
+++ b/java/ql/src/Likely Bugs/Comparison/NoAssignInBooleanExprs.ql
@@ -26,7 +26,7 @@ class BooleanExpr extends Expr {
 }
 
 private predicate assignAndCheck(AssignExpr e) {
-  exists(BinaryExpr c | e = c.getAChildExpr().getProperExpr() |
+  exists(BinaryExpr c | e = c.getAChildExpr() |
     c instanceof ComparisonExpr or
     c instanceof EqualityTest
   )

--- a/java/ql/src/Likely Bugs/Comparison/StringComparison.ql
+++ b/java/ql/src/Likely Bugs/Comparison/StringComparison.ql
@@ -24,9 +24,6 @@ class StringValue extends Expr {
       this.(MethodAccess).getMethod() = intern
     )
     or
-    // Parenthesized expressions.
-    this.(ParExpr).getExpr().(StringValue).isInterned()
-    or
     // Ternary conditional operator.
     this.(ConditionalExpr).getTrueExpr().(StringValue).isInterned() and
     this.(ConditionalExpr).getFalseExpr().(StringValue).isInterned()
@@ -52,7 +49,7 @@ predicate variableValuesInterned(Variable v) {
   not v instanceof Parameter and
   // If the string is modified with `+=`, then the new string is not interned
   // even if the components are.
-  not exists(AssignOp append | append.getDest().getProperExpr() = v.getAnAccess())
+  not exists(AssignOp append | append.getDest() = v.getAnAccess())
 }
 
 from EqualityTest e, StringValue lhs, StringValue rhs

--- a/java/ql/src/Likely Bugs/Comparison/UselessComparisonTest.ql
+++ b/java/ql/src/Likely Bugs/Comparison/UselessComparisonTest.ql
@@ -127,8 +127,6 @@ Expr overFlowCand() {
   or
   exists(SsaExplicitUpdate x | result = x.getAUse() and x.getDefiningExpr() = overFlowCand())
   or
-  result.(ParExpr).getExpr() = overFlowCand()
-  or
   result.(AssignExpr).getRhs() = overFlowCand()
   or
   result.(LocalVariableDeclExpr).getInit() = overFlowCand()
@@ -164,8 +162,6 @@ Expr increaseOrDecreaseOfVar(SsaVariable v) {
   exists(SsaExplicitUpdate x |
     result = x.getAUse() and x.getDefiningExpr() = increaseOrDecreaseOfVar(v)
   )
-  or
-  result.(ParExpr).getExpr() = increaseOrDecreaseOfVar(v)
   or
   result.(AssignExpr).getRhs() = increaseOrDecreaseOfVar(v)
   or

--- a/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.qll
+++ b/java/ql/src/Likely Bugs/Concurrency/DoubleCheckedLocking.qll
@@ -13,8 +13,6 @@ private Expr getAFieldRead(Field f) {
     v.getDefiningExpr().(VariableAssign).getSource() = getAFieldRead(f)
   )
   or
-  result.(ParExpr).getExpr() = getAFieldRead(f)
-  or
   result.(AssignExpr).getSource() = getAFieldRead(f)
 }
 

--- a/java/ql/src/Likely Bugs/Concurrency/NonSynchronizedOverride.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/NonSynchronizedOverride.ql
@@ -27,8 +27,6 @@ predicate delegatingSuperCall(Expr e, Method target) {
   )
   or
   delegatingSuperCall(e.(CastExpr).getExpr(), target)
-  or
-  delegatingSuperCall(e.(ParExpr).getExpr(), target)
 }
 
 /**

--- a/java/ql/src/Likely Bugs/Concurrency/SynchSetUnsynchGet.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/SynchSetUnsynchGet.ql
@@ -23,7 +23,7 @@ import java
  */
 predicate isSynchronizedByBlock(Method m) {
   exists(SynchronizedStmt sync, Expr on |
-    sync = m.getBody().getAChild*() and on = sync.getExpr().getProperExpr()
+    sync = m.getBody().getAChild*() and on = sync.getExpr()
   |
     if m.isStatic()
     then on.(TypeLiteral).getTypeName().getType() = m.getDeclaringType()

--- a/java/ql/src/Likely Bugs/Concurrency/SynchSetUnsynchGet.ql
+++ b/java/ql/src/Likely Bugs/Concurrency/SynchSetUnsynchGet.ql
@@ -22,9 +22,7 @@ import java
  * (for static methods) or a `synchronized(this){...}` block (for instance methods).
  */
 predicate isSynchronizedByBlock(Method m) {
-  exists(SynchronizedStmt sync, Expr on |
-    sync = m.getBody().getAChild*() and on = sync.getExpr()
-  |
+  exists(SynchronizedStmt sync, Expr on | sync = m.getBody().getAChild*() and on = sync.getExpr() |
     if m.isStatic()
     then on.(TypeLiteral).getTypeName().getType() = m.getDeclaringType()
     else on.(ThisAccess).getType().(RefType).getSourceDeclaration() = m.getDeclaringType()

--- a/java/ql/src/Likely Bugs/Likely Typos/ContradictoryTypeChecks.ql
+++ b/java/ql/src/Likely Bugs/Likely Typos/ContradictoryTypeChecks.ql
@@ -17,7 +17,7 @@ import semmle.code.java.dataflow.SSA
 
 /** `ioe` is of the form `va instanceof t`. */
 predicate instanceOfCheck(InstanceOfExpr ioe, VarAccess va, RefType t) {
-  ioe.getExpr().getProperExpr() = va and
+  ioe.getExpr() = va and
   ioe.getTypeName().getType().(RefType).getSourceDeclaration() = t
 }
 

--- a/java/ql/src/Likely Bugs/Resource Leaks/CloseType.qll
+++ b/java/ql/src/Likely Bugs/Resource Leaks/CloseType.qll
@@ -9,8 +9,6 @@ import semmle.code.java.frameworks.Mockito
 private predicate flowsInto(Expr e, Variable v) {
   e = v.getAnAssignedValue()
   or
-  exists(ParExpr p | flowsInto(p, v) | e = p.getExpr())
-  or
   exists(CastExpr c | flowsInto(c, v) | e = c.getExpr())
   or
   exists(ConditionalExpr c | flowsInto(c, v) | e = c.getTrueExpr() or e = c.getFalseExpr())

--- a/java/ql/src/Likely Bugs/Statements/Chaining.qll
+++ b/java/ql/src/Likely Bugs/Statements/Chaining.qll
@@ -48,7 +48,7 @@ private predicate nonChainingReturn(Method m, ReturnStmt ret) {
     or
     // A method on the wrong object is called.
     not (
-      delegateCall.getQualifier().getProperExpr() instanceof ThisAccess or
+      delegateCall.getQualifier() instanceof ThisAccess or
       not exists(delegateCall.getQualifier())
     )
     or

--- a/java/ql/src/Likely Bugs/Statements/ReturnValueIgnored.ql
+++ b/java/ql/src/Likely Bugs/Statements/ReturnValueIgnored.ql
@@ -78,7 +78,7 @@ predicate relevantMethodCall(MethodAccess ma, Method m) {
   ma.getMethod() = m and
   not m.getReturnType().hasName("void") and
   (not isMockingMethod(m) or isMustBeQualifierMockingMethod(m)) and
-  not isMockingMethod(ma.getQualifier().getProperExpr().(MethodAccess).getMethod())
+  not isMockingMethod(ma.getQualifier().(MethodAccess).getMethod())
 }
 
 predicate methodStats(Method m, int used, int total, int percentage) {

--- a/java/ql/src/Security/CWE/CWE-190/ArithmeticCommon.qll
+++ b/java/ql/src/Security/CWE/CWE-190/ArithmeticCommon.qll
@@ -14,7 +14,7 @@ private import semmle.code.java.controlflow.internal.GuardsLogic
 predicate narrowerThanOrEqualTo(ArithExpr exp, NumType numType) {
   exp.getType().(NumType).widerThan(numType)
   implies
-  exists(CastExpr cast | cast.getAChildExpr().getProperExpr() = exp |
+  exists(CastExpr cast | cast.getAChildExpr() = exp |
     numType.widerThanOrEqualTo(cast.getType().(NumType))
   )
 }
@@ -54,11 +54,11 @@ private Guard sizeGuard(SsaVariable v, boolean branch, boolean upper) {
       positive(pos) and
       upper = true
     |
-      comp.getLesserOperand().getProperExpr() = add and
+      comp.getLesserOperand() = add and
       comp.getGreaterOperand().(IntegerLiteral).getIntValue() = 0 and
       branch = false
       or
-      comp.getGreaterOperand().getProperExpr() = add and
+      comp.getGreaterOperand() = add and
       comp.getLesserOperand().(IntegerLiteral).getIntValue() = 0 and
       branch = true
     )
@@ -157,7 +157,6 @@ predicate upcastToWiderType(Expr e) {
 /** Holds if the result of `exp` has certain bits filtered by a bitwise and. */
 private predicate inBitwiseAnd(Expr exp) {
   exists(AndBitwiseExpr a | a.getAnOperand() = exp) or
-  inBitwiseAnd(exp.(ParExpr).getExpr()) or
   inBitwiseAnd(exp.(LShiftExpr).getAnOperand()) or
   inBitwiseAnd(exp.(RShiftExpr).getAnOperand()) or
   inBitwiseAnd(exp.(URShiftExpr).getAnOperand())

--- a/java/ql/src/Security/CWE/CWE-681/NumericCastCommon.qll
+++ b/java/ql/src/Security/CWE/CWE-681/NumericCastCommon.qll
@@ -29,7 +29,7 @@ class RightShiftOp extends Expr {
 
   Variable getShiftedVariable() {
     getLhs() = result.getAnAccess() or
-    getLhs().getProperExpr().(AndBitwiseExpr).getAnOperand() = result.getAnAccess()
+    getLhs().(AndBitwiseExpr).getAnOperand() = result.getAnAccess()
   }
 }
 

--- a/java/ql/src/Security/CWE/CWE-835/InfiniteLoop.ql
+++ b/java/ql/src/Security/CWE/CWE-835/InfiniteLoop.ql
@@ -48,8 +48,6 @@ predicate subCondition(Expr cond, Expr subcond, boolean negated) {
   or
   subCondition(cond.(OrLogicalExpr).getAnOperand(), subcond, negated)
   or
-  subCondition(cond.(ParExpr).getExpr(), subcond, negated)
-  or
   subCondition(cond.(LogNotExpr).getExpr(), subcond, negated.booleanNot())
 }
 

--- a/java/ql/src/Violations of Best Practice/Boolean Logic/SimplifyBoolExpr.ql
+++ b/java/ql/src/Violations of Best Practice/Boolean Logic/SimplifyBoolExpr.ql
@@ -84,9 +84,9 @@ where
   or
   conditionalWithBool(e, pattern, rewrite)
   or
-  e.(LogNotExpr).getExpr().getProperExpr().(ComparisonOrEquality).negate(pattern, rewrite)
+  e.(LogNotExpr).getExpr().(ComparisonOrEquality).negate(pattern, rewrite)
   or
-  e.(LogNotExpr).getExpr().getProperExpr() instanceof LogNotExpr and
+  e.(LogNotExpr).getExpr() instanceof LogNotExpr and
   pattern = "!!A" and
   rewrite = "A"
 select e, "Expressions of the form \"" + pattern + "\" can be simplified to \"" + rewrite + "\"."

--- a/java/ql/src/Violations of Best Practice/Naming Conventions/ConfusingOverloading.ql
+++ b/java/ql/src/Violations of Best Practice/Naming Conventions/ConfusingOverloading.ql
@@ -84,7 +84,6 @@ private predicate confusinglyOverloaded(Method m, Method n) {
 
 private predicate wrappedAccess(Expr e, MethodAccess ma) {
   e = ma or
-  wrappedAccess(e.(ParExpr).getExpr(), ma) or
   wrappedAccess(e.(CastExpr).getExpr(), ma)
 }
 

--- a/java/ql/src/semmle/code/java/Concurrency.qll
+++ b/java/ql/src/semmle/code/java/Concurrency.qll
@@ -14,8 +14,7 @@ predicate locallySynchronizedOn(Expr e, SynchronizedStmt sync, Variable v) {
  */
 predicate locallySynchronizedOnThis(Expr e, RefType thisType) {
   exists(SynchronizedStmt sync | e.getEnclosingStmt().getEnclosingStmt+() = sync |
-    sync.getExpr().getProperExpr().(ThisAccess).getType().(RefType).getSourceDeclaration() =
-      thisType
+    sync.getExpr().(ThisAccess).getType().(RefType).getSourceDeclaration() = thisType
   )
   or
   exists(SynchronizedCallable c | c = e.getEnclosingCallable() |

--- a/java/ql/src/semmle/code/java/ControlFlowGraph.qll
+++ b/java/ql/src/semmle/code/java/ControlFlowGraph.qll
@@ -289,8 +289,6 @@ private module ControlFlowGraphImpl {
       logexpr.(UnaryExpr).getExpr() = b and inBooleanContext(logexpr)
     )
     or
-    exists(ParExpr parexpr | parexpr.getExpr() = b and inBooleanContext(parexpr))
-    or
     exists(ConditionalExpr condexpr |
       condexpr.getCondition() = b
       or
@@ -574,8 +572,6 @@ private module ControlFlowGraphImpl {
     or
     result = first(n.(PostOrderNode).firstChild())
     or
-    result = first(n.(ParExpr).getExpr())
-    or
     result = first(n.(SynchronizedStmt).getExpr())
     or
     result = n and
@@ -707,9 +703,6 @@ private module ControlFlowGraphImpl {
       last(condexpr.getFalseExpr(), last, completion) or
       last(condexpr.getTrueExpr(), last, completion)
     )
-    or
-    // Parentheses are skipped in the CFG.
-    last(n.(ParExpr).getExpr(), last, completion)
     or
     // The last node of a node executed in post-order is the node itself.
     n.(PostOrderNode).mayCompleteNormally() and last = n and completion = NormalCompletion()

--- a/java/ql/src/semmle/code/java/Conversions.qll
+++ b/java/ql/src/semmle/code/java/Conversions.qll
@@ -49,7 +49,7 @@ class AssignmentConversionContext extends ConversionSite {
   AssignmentConversionContext() {
     this = v.getAnAssignedValue()
     or
-    exists(Assignment a | a.getDest().getProperExpr() = v.getAnAccess() and this = a.getSource())
+    exists(Assignment a | a.getDest() = v.getAnAccess() and this = a.getSource())
   }
 
   override Type getConversionTarget() { result = v.getType() }

--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -46,8 +46,12 @@ class Expr extends ExprParent, @expr {
    */
   int getKind() { exprs(this, result, _, _, _) }
 
-  /** Gets this expression with any surrounding parentheses removed. */
-  Expr getProperExpr() {
+  /**
+   * DEPRECATED: This is no longer necessary. See `Expr.isParenthesized()`.
+   *
+   * Gets this expression with any surrounding parentheses removed.
+   */
+  deprecated Expr getProperExpr() {
     result = this.(ParExpr).getExpr().getProperExpr()
     or
     result = this and not this instanceof ParExpr
@@ -152,9 +156,6 @@ class CompileTimeConstantExpr extends Expr {
         e.getFalseExpr().isCompileTimeConstant()
       )
       or
-      // Parenthesized expressions whose contained expression is a constant expression.
-      this.(ParExpr).getExpr().isCompileTimeConstant()
-      or
       // Access to a final variable initialized by a compile-time constant.
       exists(Variable v | this = v.getAnAccess() |
         v.isFinal() and
@@ -168,8 +169,6 @@ class CompileTimeConstantExpr extends Expr {
    */
   string getStringValue() {
     result = this.(StringLiteral).getRepresentedString()
-    or
-    result = this.(ParExpr).getExpr().(CompileTimeConstantExpr).getStringValue()
     or
     result =
       this.(AddExpr).getLeftOperand().(CompileTimeConstantExpr).getStringValue() +
@@ -296,9 +295,6 @@ class CompileTimeConstantExpr extends Expr {
       else result = ce.getFalseExpr().(CompileTimeConstantExpr).getBooleanValue()
     )
     or
-    // Parenthesized expressions containing a boolean value.
-    result = this.(ParExpr).getExpr().(CompileTimeConstantExpr).getBooleanValue()
-    or
     // Simple or qualified names where the variable is final and the initializer is a constant.
     exists(Variable v | this = v.getAnAccess() |
       result = v.getInitializer().(CompileTimeConstantExpr).getBooleanValue()
@@ -384,8 +380,6 @@ class CompileTimeConstantExpr extends Expr {
         then result = ce.getTrueExpr().(CompileTimeConstantExpr).getIntValue()
         else result = ce.getFalseExpr().(CompileTimeConstantExpr).getIntValue()
       )
-      or
-      result = this.(ParExpr).getExpr().(CompileTimeConstantExpr).getIntValue()
       or
       // If a `Variable` is a `CompileTimeConstantExpr`, its value is its initializer.
       exists(Variable v | this = v.getAnAccess() |
@@ -640,12 +634,8 @@ class BinaryExpr extends Expr, @binaryexpr {
   /** Gets the operand on the right-hand side of this binary expression. */
   Expr getRightOperand() { result.isNthChildOf(this, 1) }
 
-  /** Gets an operand (left or right), with any parentheses removed. */
-  Expr getAnOperand() {
-    exists(Expr r | r = this.getLeftOperand() or r = this.getRightOperand() |
-      result = r.getProperExpr()
-    )
-  }
+  /** Gets an operand (left or right). */
+  Expr getAnOperand() { result = this.getLeftOperand() or result = this.getRightOperand() }
 
   /** The operands of this binary expression are `e` and `f`, in either order. */
   predicate hasOperands(Expr e, Expr f) {
@@ -761,17 +751,14 @@ class NEExpr extends BinaryExpr, @neexpr {
  * A bitwise expression.
  *
  * This includes expressions involving the operators
- * `&`, `|`, `^`, or `~`,
- * possibly parenthesized.
+ * `&`, `|`, `^`, or `~`.
  */
 class BitwiseExpr extends Expr {
   BitwiseExpr() {
-    exists(Expr proper | proper = this.getProperExpr() |
-      proper instanceof AndBitwiseExpr or
-      proper instanceof OrBitwiseExpr or
-      proper instanceof XorBitwiseExpr or
-      proper instanceof BitNotExpr
-    )
+    this instanceof AndBitwiseExpr or
+    this instanceof OrBitwiseExpr or
+    this instanceof XorBitwiseExpr or
+    this instanceof BitNotExpr
   }
 }
 
@@ -1128,10 +1115,14 @@ class SwitchExpr extends Expr, @switchexpr {
   override string toString() { result = "switch (...)" }
 }
 
-/** A parenthesised expression. */
-class ParExpr extends Expr, @parexpr {
+/**
+ * DEPRECATED: Use `Expr.isParenthesized()` instead.
+ *
+ * A parenthesised expression.
+ */
+deprecated class ParExpr extends Expr, @parexpr {
   /** Gets the expression inside the parentheses. */
-  Expr getExpr() { result.getParent() = this }
+  deprecated Expr getExpr() { result.getParent() = this }
 
   /** Gets a printable representation of this expression. */
   override string toString() { result = "(...)" }

--- a/java/ql/src/semmle/code/java/Reflection.qll
+++ b/java/ql/src/semmle/code/java/Reflection.qll
@@ -284,7 +284,7 @@ class NewInstance extends MethodAccess {
    * cast.
    */
   private Type getCastInferredConstructedTypes() {
-    exists(CastExpr cast | cast.getExpr() = this or cast.getExpr().(ParExpr).getExpr() = this |
+    exists(CastExpr cast | cast.getExpr() = this |
       result = cast.getType()
       or
       // If we cast the result of this method, then this is either the type specified, or a

--- a/java/ql/src/semmle/code/java/StringFormat.qll
+++ b/java/ql/src/semmle/code/java/StringFormat.qll
@@ -246,8 +246,7 @@ private predicate formatStringFragment(Expr fmt) {
     e.(AddExpr).getLeftOperand() = fmt or
     e.(AddExpr).getRightOperand() = fmt or
     e.(ConditionalExpr).getTrueExpr() = fmt or
-    e.(ConditionalExpr).getFalseExpr() = fmt or
-    e.(ParExpr).getExpr() = fmt
+    e.(ConditionalExpr).getFalseExpr() = fmt
   )
 }
 
@@ -267,8 +266,6 @@ private predicate formatStringValue(Expr e, string fmtvalue) {
     e.getType() instanceof BooleanType and fmtvalue = "x" // dummy value
     or
     e.getType() instanceof EnumType and fmtvalue = "x" // dummy value
-    or
-    formatStringValue(e.(ParExpr).getExpr(), fmtvalue)
     or
     exists(Variable v |
       e = v.getAnAccess() and

--- a/java/ql/src/semmle/code/java/Variable.qll
+++ b/java/ql/src/semmle/code/java/Variable.qll
@@ -16,9 +16,7 @@ class Variable extends @variable, Annotatable, Element, Modifiable {
   Expr getAnAssignedValue() {
     exists(LocalVariableDeclExpr e | e.getVariable() = this and result = e.getInit())
     or
-    exists(AssignExpr e |
-      e.getDest() = this.getAnAccess() and result = e.getSource()
-    )
+    exists(AssignExpr e | e.getDest() = this.getAnAccess() and result = e.getSource())
   }
 
   /** Gets the initializer expression of this variable. */

--- a/java/ql/src/semmle/code/java/Variable.qll
+++ b/java/ql/src/semmle/code/java/Variable.qll
@@ -17,7 +17,7 @@ class Variable extends @variable, Annotatable, Element, Modifiable {
     exists(LocalVariableDeclExpr e | e.getVariable() = this and result = e.getInit())
     or
     exists(AssignExpr e |
-      e.getDest().getProperExpr() = this.getAnAccess() and result = e.getSource()
+      e.getDest() = this.getAnAccess() and result = e.getSource()
     )
   }
 

--- a/java/ql/src/semmle/code/java/comparison/Comparison.qll
+++ b/java/ql/src/semmle/code/java/comparison/Comparison.qll
@@ -6,10 +6,6 @@ import java
  * Used as basis for the transitive closure in `exprImplies`.
  */
 private predicate exprImpliesStep(Expr e1, boolean b1, Expr e2, boolean b2) {
-  e1.(ParExpr).getProperExpr() = e2 and
-  b2 = b1 and
-  (b1 = true or b1 = false)
-  or
   e1.(LogNotExpr).getExpr() = e2 and
   b2 = b1.booleanNot() and
   (b1 = true or b1 = false)

--- a/java/ql/src/semmle/code/java/controlflow/Guards.qll
+++ b/java/ql/src/semmle/code/java/controlflow/Guards.qll
@@ -103,8 +103,8 @@ class Guard extends ExprParent {
    */
   BasicBlock getBasicBlock() {
     result = this.(Expr).getBasicBlock() or
-    result = this.(SwitchCase).getSwitch().getExpr().getProperExpr().getBasicBlock() or
-    result = this.(SwitchCase).getSwitchExpr().getExpr().getProperExpr().getBasicBlock()
+    result = this.(SwitchCase).getSwitch().getExpr().getBasicBlock() or
+    result = this.(SwitchCase).getSwitchExpr().getExpr().getBasicBlock()
   }
 
   /**
@@ -115,9 +115,9 @@ class Guard extends ExprParent {
    */
   predicate isEquality(Expr e1, Expr e2, boolean polarity) {
     exists(Expr exp1, Expr exp2 | equalityGuard(this, exp1, exp2, polarity) |
-      e1 = exp1.getProperExpr() and e2 = exp2.getProperExpr()
+      e1 = exp1 and e2 = exp2
       or
-      e2 = exp1.getProperExpr() and e1 = exp2.getProperExpr()
+      e2 = exp1 and e1 = exp2
     )
   }
 
@@ -265,7 +265,7 @@ private predicate equalityGuard(Guard g, Expr e1, Expr e2, boolean polarity) {
   exists(ConstCase cc |
     cc = g and
     polarity = true and
-    cc.getSelectorExpr().getProperExpr() = e1 and
+    cc.getSelectorExpr() = e1 and
     cc.getValue() = e2 and
     strictcount(cc.getValue(_)) = 1
   )

--- a/java/ql/src/semmle/code/java/controlflow/UnreachableBlocks.qll
+++ b/java/ql/src/semmle/code/java/controlflow/UnreachableBlocks.qll
@@ -93,8 +93,6 @@ class ConstantExpr extends Expr {
       // A binary expression where both sides are constant
       this.(BinaryExpr).getLeftOperand() instanceof ConstantExpr and
       this.(BinaryExpr).getRightOperand() instanceof ConstantExpr
-      or
-      this.(ParExpr).getExpr() instanceof ConstantExpr
     )
   }
 
@@ -107,8 +105,6 @@ class ConstantExpr extends Expr {
     result = this.(Call).getCallee().(ConstantMethod).getConstantValue().getBooleanValue()
     or
     result = this.(FieldRead).getField().(ConstantField).getConstantValue().getBooleanValue()
-    or
-    result = this.(ParExpr).getExpr().(ConstantExpr).getBooleanValue()
     or
     // Handle binary expressions that have integer operands and a boolean result.
     exists(BinaryExpr b, int left, int right |

--- a/java/ql/src/semmle/code/java/controlflow/internal/GuardsLogic.qll
+++ b/java/ql/src/semmle/code/java/controlflow/internal/GuardsLogic.qll
@@ -19,10 +19,6 @@ private import semmle.code.java.dataflow.IntegerGuards
  * Restricted to BaseSSA-based reasoning.
  */
 predicate implies_v1(Guard g1, boolean b1, Guard g2, boolean b2) {
-  g1.(ParExpr).getExpr() = g2 and
-  b1 = b2 and
-  (b1 = true or b1 = false)
-  or
   g1.(AndBitwiseExpr).getAnOperand() = g2 and b1 = true and b2 = true
   or
   g1.(OrBitwiseExpr).getAnOperand() = g2 and b1 = false and b2 = false
@@ -220,13 +216,11 @@ private predicate hasPossibleUnknownValue(SsaVariable v) {
  * `ConditionalExpr`s. Parentheses are also removed.
  */
 private Expr possibleValue(Expr e) {
-  result = possibleValue(e.(ParExpr).getExpr())
-  or
   result = possibleValue(e.(ConditionalExpr).getTrueExpr())
   or
   result = possibleValue(e.(ConditionalExpr).getFalseExpr())
   or
-  result = e and not e instanceof ParExpr and not e instanceof ConditionalExpr
+  result = e and not e instanceof ConditionalExpr
 }
 
 /**
@@ -253,7 +247,7 @@ private predicate possibleValue(SsaVariable v, boolean fromBackEdge, Expr e, Abs
   not hasPossibleUnknownValue(v) and
   exists(SsaExplicitUpdate def |
     def = getADefinition(v, fromBackEdge) and
-    e = possibleValue(def.getDefiningExpr().(VariableAssign).getSource().getProperExpr()) and
+    e = possibleValue(def.getDefiningExpr().(VariableAssign).getSource()) and
     k.getExpr() = e
   )
 }
@@ -305,7 +299,7 @@ private predicate guardControlsPhiBranch(
   SsaExplicitUpdate upd, SsaPhiNode phi, Guard guard, boolean branch, Expr e
 ) {
   guard.directlyControls(upd.getBasicBlock(), branch) and
-  upd.getDefiningExpr().(VariableAssign).getSource().getProperExpr() = e and
+  upd.getDefiningExpr().(VariableAssign).getSource() = e and
   upd = phi.getAPhiInput() and
   guard.getBasicBlock().bbStrictlyDominates(phi.getBasicBlock())
 }
@@ -319,12 +313,12 @@ private predicate guardControlsPhiBranch(
  */
 private predicate conditionalAssign(SsaVariable v, Guard guard, boolean branch, Expr e) {
   exists(ConditionalExpr c |
-    v.(SsaExplicitUpdate).getDefiningExpr().(VariableAssign).getSource().getProperExpr() = c and
-    guard = c.getCondition().getProperExpr()
+    v.(SsaExplicitUpdate).getDefiningExpr().(VariableAssign).getSource() = c and
+    guard = c.getCondition()
   |
-    branch = true and e = c.getTrueExpr().getProperExpr()
+    branch = true and e = c.getTrueExpr()
     or
-    branch = false and e = c.getFalseExpr().getProperExpr()
+    branch = false and e = c.getFalseExpr()
   )
   or
   exists(SsaExplicitUpdate upd, SsaPhiNode phi |

--- a/java/ql/src/semmle/code/java/controlflow/internal/Preconditions.qll
+++ b/java/ql/src/semmle/code/java/controlflow/internal/Preconditions.qll
@@ -24,9 +24,9 @@ predicate conditionCheckMethod(Method m, boolean checkTrue) {
     not m.isOverridable() and
     p.getType() instanceof BooleanType and
     m.getBody().getStmt(0) = ifstmt and
-    ifstmt.getCondition().getProperExpr() = cond and
+    ifstmt.getCondition() = cond and
     (
-      cond.(LogNotExpr).getExpr().getProperExpr().(VarAccess).getVariable() = p and checkTrue = true
+      cond.(LogNotExpr).getExpr().(VarAccess).getVariable() = p and checkTrue = true
       or
       cond.(VarAccess).getVariable() = p and checkTrue = false
     ) and
@@ -41,9 +41,9 @@ predicate conditionCheckMethod(Method m, boolean checkTrue) {
     not m.isOverridable() and
     m.getBody().getStmt(0).(ExprStmt).getExpr() = ma and
     conditionCheck(ma, ct) and
-    ma.getArgument(0).getProperExpr() = arg and
+    ma.getArgument(0) = arg and
     (
-      arg.(LogNotExpr).getExpr().getProperExpr().(VarAccess).getVariable() = p and
+      arg.(LogNotExpr).getExpr().(VarAccess).getVariable() = p and
       checkTrue = ct.booleanNot()
       or
       arg.(VarAccess).getVariable() = p and checkTrue = ct

--- a/java/ql/src/semmle/code/java/dataflow/IntegerGuards.qll
+++ b/java/ql/src/semmle/code/java/dataflow/IntegerGuards.qll
@@ -10,7 +10,6 @@ private import RangeAnalysis
 /** Gets an expression that might have the value `i`. */
 private Expr exprWithIntValue(int i) {
   result.(ConstantIntegerExpr).getIntValue() = i or
-  result.(ParExpr).getExpr() = exprWithIntValue(i) or
   result.(ConditionalExpr).getTrueExpr() = exprWithIntValue(i) or
   result.(ConditionalExpr).getFalseExpr() = exprWithIntValue(i)
 }
@@ -142,25 +141,25 @@ Expr intBoundGuard(RValue x, boolean branch_with_lower_bound_k, int k) {
     x.getVariable().getType() instanceof IntegralType
   |
     // c < x
-    comp.getLesserOperand().getProperExpr() = c and
+    comp.getLesserOperand() = c and
     comp.isStrict() and
     branch_with_lower_bound_k = true and
     val + 1 = k
     or
     // c <= x
-    comp.getLesserOperand().getProperExpr() = c and
+    comp.getLesserOperand() = c and
     not comp.isStrict() and
     branch_with_lower_bound_k = true and
     val = k
     or
     // x < c
-    comp.getGreaterOperand().getProperExpr() = c and
+    comp.getGreaterOperand() = c and
     comp.isStrict() and
     branch_with_lower_bound_k = false and
     val = k
     or
     // x <= c
-    comp.getGreaterOperand().getProperExpr() = c and
+    comp.getGreaterOperand() = c and
     not comp.isStrict() and
     branch_with_lower_bound_k = false and
     val + 1 = k

--- a/java/ql/src/semmle/code/java/dataflow/ModulusAnalysis.qll
+++ b/java/ql/src/semmle/code/java/dataflow/ModulusAnalysis.qll
@@ -76,8 +76,6 @@ private Expr modExpr(Expr arg, int mod) {
     c.getIntValue() = mod - 1 and
     result.(AndBitwiseExpr).hasOperands(arg, c)
   )
-  or
-  result.(ParExpr).getExpr() = modExpr(arg, mod)
 }
 
 /**

--- a/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
+++ b/java/ql/src/semmle/code/java/dataflow/NullGuards.qll
@@ -11,7 +11,6 @@ private import IntegerGuards
 /** Gets an expression that is always `null`. */
 Expr alwaysNullExpr() {
   result instanceof NullLiteral or
-  result.(ParExpr).getExpr() = alwaysNullExpr() or
   result.(CastExpr).getExpr() = alwaysNullExpr()
 }
 
@@ -59,8 +58,6 @@ Expr clearlyNotNullExpr(Expr reason) {
     f.getDeclaringType().hasQualifiedName("java.lang", "Boolean") and
     reason = result
   )
-  or
-  result.(ParExpr).getExpr() = clearlyNotNullExpr(reason)
   or
   result.(CastExpr).getExpr() = clearlyNotNullExpr(reason)
   or

--- a/java/ql/src/semmle/code/java/dataflow/Nullness.qll
+++ b/java/ql/src/semmle/code/java/dataflow/Nullness.qll
@@ -45,7 +45,6 @@ private import semmle.code.java.frameworks.Assertions
 /** Gets an expression that may be `null`. */
 Expr nullExpr() {
   result instanceof NullLiteral or
-  result.(ParExpr).getExpr() = nullExpr() or
   result.(ConditionalExpr).getTrueExpr() = nullExpr() or
   result.(ConditionalExpr).getFalseExpr() = nullExpr() or
   result.(AssignExpr).getSource() = nullExpr() or
@@ -131,11 +130,8 @@ predicate dereference(Expr e) {
  * The `VarAccess` is included for nicer error reporting.
  */
 private ControlFlowNode varDereference(SsaVariable v, VarAccess va) {
-  exists(Expr e |
-    dereference(e) and
-    e = sameValue(v, va) and
-    result = e.getProperExpr()
-  )
+  dereference(result) and
+  result = sameValue(v, va)
 }
 
 /**
@@ -442,8 +438,8 @@ private predicate nullDerefCandidate(SsaVariable origin, VarAccess va) {
 /** A variable that is assigned `null` if the given condition takes the given branch. */
 private predicate varConditionallyNull(SsaExplicitUpdate v, ConditionBlock cond, boolean branch) {
   exists(ConditionalExpr condexpr |
-    v.getDefiningExpr().(VariableAssign).getSource().getProperExpr() = condexpr and
-    condexpr.getCondition().getProperExpr() = cond.getCondition()
+    v.getDefiningExpr().(VariableAssign).getSource() = condexpr and
+    condexpr.getCondition() = cond.getCondition()
   |
     condexpr.getTrueExpr() = nullExpr() and
     branch = true and

--- a/java/ql/src/semmle/code/java/dataflow/RangeAnalysis.qll
+++ b/java/ql/src/semmle/code/java/dataflow/RangeAnalysis.qll
@@ -131,7 +131,7 @@ private predicate boundCondition(
   or
   exists(SubExpr sub, ConstantIntegerExpr c, int d |
     // (v - d) - e < c
-    comp.getLesserOperand().getProperExpr() = sub and
+    comp.getLesserOperand() = sub and
     comp.getGreaterOperand() = c and
     sub.getLeftOperand() = ssaRead(v, d) and
     sub.getRightOperand() = e and
@@ -139,7 +139,7 @@ private predicate boundCondition(
     delta = d + c.getIntValue()
     or
     // (v - d) - e > c
-    comp.getGreaterOperand().getProperExpr() = sub and
+    comp.getGreaterOperand() = sub and
     comp.getLesserOperand() = c and
     sub.getLeftOperand() = ssaRead(v, d) and
     sub.getRightOperand() = e and
@@ -147,7 +147,7 @@ private predicate boundCondition(
     delta = d + c.getIntValue()
     or
     // e - (v - d) < c
-    comp.getLesserOperand().getProperExpr() = sub and
+    comp.getLesserOperand() = sub and
     comp.getGreaterOperand() = c and
     sub.getLeftOperand() = e and
     sub.getRightOperand() = ssaRead(v, d) and
@@ -155,7 +155,7 @@ private predicate boundCondition(
     delta = d - c.getIntValue()
     or
     // e - (v - d) > c
-    comp.getGreaterOperand().getProperExpr() = sub and
+    comp.getGreaterOperand() = sub and
     comp.getLesserOperand() = c and
     sub.getLeftOperand() = e and
     sub.getRightOperand() = ssaRead(v, d) and

--- a/java/ql/src/semmle/code/java/dataflow/RangeUtils.qll
+++ b/java/ql/src/semmle/code/java/dataflow/RangeUtils.qll
@@ -26,8 +26,6 @@ private predicate nonNullSsaFwdStep(SsaVariable v, SsaVariable phi) {
 }
 
 private predicate nonNullDefStep(Expr e1, Expr e2) {
-  e2.(ParExpr).getExpr() = e1
-  or
   exists(ConditionalExpr cond | cond = e2 |
     cond.getTrueExpr() = e1 and cond.getFalseExpr() instanceof NullLiteral
     or
@@ -103,8 +101,6 @@ class ConstantIntegerExpr extends Expr {
  */
 Expr ssaRead(SsaVariable v, int delta) {
   result = v.getAUse() and delta = 0
-  or
-  result.(ParExpr).getExpr() = ssaRead(v, delta)
   or
   exists(int d1, ConstantIntegerExpr c |
     result.(AddExpr).hasOperands(ssaRead(v, d1), c) and
@@ -264,8 +260,6 @@ predicate ssaUpdateStep(SsaExplicitUpdate v, Expr e, int delta) {
  * Holds if `e1 + delta` equals `e2`.
  */
 predicate valueFlowStep(Expr e2, Expr e1, int delta) {
-  e2.(ParExpr).getExpr() = e1 and delta = 0
-  or
   e2.(AssignExpr).getSource() = e1 and delta = 0
   or
   e2.(PlusExpr).getExpr() = e1 and delta = 0

--- a/java/ql/src/semmle/code/java/dataflow/SSA.qll
+++ b/java/ql/src/semmle/code/java/dataflow/SSA.qll
@@ -1129,7 +1129,5 @@ Expr sameValue(SsaVariable v, VarAccess va) {
   or
   result.(AssignExpr).getSource() = sameValue(v, va)
   or
-  result.(ParExpr).getExpr() = sameValue(v, va)
-  or
   result.(RefTypeCastExpr).getExpr() = sameValue(v, va)
 }

--- a/java/ql/src/semmle/code/java/dataflow/SignAnalysis.qll
+++ b/java/ql/src/semmle/code/java/dataflow/SignAnalysis.qll
@@ -476,8 +476,6 @@ private Sign exprSign(Expr e) {
   (
     unknownSign(e)
     or
-    result = exprSign(e.(ParExpr).getExpr())
-    or
     exists(SsaVariable v | v.getAUse() = e |
       result = ssaSign(v, any(SsaReadPositionBlock bb | bb.getBlock() = e.getBasicBlock()))
       or

--- a/java/ql/src/semmle/code/java/dataflow/TypeFlow.qll
+++ b/java/ql/src/semmle/code/java/dataflow/TypeFlow.qll
@@ -109,8 +109,6 @@ private predicate step(TypeFlowNode n1, TypeFlowNode n2) {
   or
   n2.asExpr() = n1.asSsa().getAUse()
   or
-  n2.asExpr().(ParExpr).getExpr() = n1.asExpr()
-  or
   n2.asExpr().(CastExpr).getExpr() = n1.asExpr() and
   not n2.asExpr().getType() instanceof PrimitiveType
   or

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
@@ -390,8 +390,6 @@ predicate simpleLocalFlowStep(Node node1, Node node2) {
   or
   ThisFlow::adjacentThisRefs(node1.(PostUpdateNode).getPreUpdateNode(), node2)
   or
-  node2.asExpr().(ParExpr).getExpr() = node1.asExpr()
-  or
   node2.asExpr().(CastExpr).getExpr() = node1.asExpr()
   or
   node2.asExpr().(ConditionalExpr).getTrueExpr() = node1.asExpr()

--- a/java/ql/src/semmle/code/java/deadcode/DeadEnumConstant.qll
+++ b/java/ql/src/semmle/code/java/deadcode/DeadEnumConstant.qll
@@ -11,8 +11,6 @@ Expr valueFlow(Expr src) {
     src = c.getTrueExpr() or
     src = c.getFalseExpr()
   )
-  or
-  src = result.(ParExpr).getExpr()
 }
 
 /**

--- a/java/ql/src/semmle/code/java/dispatch/DispatchFlow.qll
+++ b/java/ql/src/semmle/code/java/dispatch/DispatchFlow.qll
@@ -192,8 +192,6 @@ private predicate flowStep(RelevantNode n1, RelevantNode n2) {
     n2.asExpr().(MethodAccess).getMethod() = getValue
   )
   or
-  n2.asExpr().(ParExpr).getExpr() = n1.asExpr()
-  or
   n2.asExpr().(CastExpr).getExpr() = n1.asExpr()
   or
   n2.asExpr().(ConditionalExpr).getTrueExpr() = n1.asExpr()

--- a/java/ql/src/semmle/code/java/dispatch/ObjFlow.qll
+++ b/java/ql/src/semmle/code/java/dispatch/ObjFlow.qll
@@ -98,8 +98,6 @@ private predicate step(Node n1, Node n2) {
     n2.asExpr().(FieldRead).getField() = f
   )
   or
-  n2.asExpr().(ParExpr).getExpr() = n1.asExpr()
-  or
   n2.asExpr().(CastExpr).getExpr() = n1.asExpr()
   or
   n2.asExpr().(ConditionalExpr).getTrueExpr() = n1.asExpr()

--- a/java/ql/src/semmle/code/java/frameworks/Assertions.qll
+++ b/java/ql/src/semmle/code/java/frameworks/Assertions.qll
@@ -109,6 +109,6 @@ predicate assertFail(BasicBlock bb, ControlFlowNode n) {
       n = m.getACheck(any(BooleanLiteral b | b.getBooleanValue() = true))
     ) or
     exists(AssertFailMethod m | n = m.getACheck()) or
-    n.(AssertStmt).getExpr().getProperExpr().(BooleanLiteral).getBooleanValue() = false
+    n.(AssertStmt).getExpr().(BooleanLiteral).getBooleanValue() = false
   )
 }

--- a/java/ql/test/library-tests/guards/guardslogic.ql
+++ b/java/ql/test/library-tests/guards/guardslogic.ql
@@ -4,6 +4,5 @@ import semmle.code.java.controlflow.Guards
 from Guard g, BasicBlock bb, boolean branch
 where
   g.controls(bb, branch) and
-  not g instanceof ParExpr and
   g.getEnclosingCallable().getDeclaringType().hasName("Logic")
 select g, branch, bb


### PR DESCRIPTION
With parentheses no longer in the AST we can deprecate a few things and clean up.