### PR TITLE
C++: Always use the old library for the diff test

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.ql
+++ b/cpp/ql/test/library-tests/dataflow/DefaultTaintTracking/test_diff.ql
@@ -1,6 +1,6 @@
 import cpp
 import semmle.code.cpp.security.Security
-import semmle.code.cpp.security.TaintTracking as ASTTaintTracking
+import semmle.code.cpp.security.TaintTrackingImpl as ASTTaintTracking
 import semmle.code.cpp.ir.dataflow.DefaultTaintTracking as IRDefaultTaintTracking
 
 predicate astFlow(Expr source, Element sink) { ASTTaintTracking::tainted(source, sink) }


### PR DESCRIPTION
This change ensures that the diff test will show the difference between the old and the new library even after we switch the default implementation of `security.TaintTracking` to be the new one.