### PR TITLE
JS: model `path-is-inside`+`is-path-inside` for `js/path-injection`

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPath.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPath.qll
@@ -35,7 +35,8 @@ module TaintedPath {
       guard instanceof StartsWithDotDotSanitizer or
       guard instanceof StartsWithDirSanitizer or
       guard instanceof IsAbsoluteSanitizer or
-      guard instanceof ContainsDotDotSanitizer
+      guard instanceof ContainsDotDotSanitizer or
+      guard instanceof IsInsideCheckSanitizer
     }
 
     override predicate isAdditionalFlowStep(

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/Consistency.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/Consistency.expected
@@ -1,7 +1,4 @@
 | normalizedPaths.js:208:38:208:63 | // OK - ...  anyway | Spurious alert |
-| normalizedPaths.js:259:26:259:30 | // OK | Spurious alert |
-| normalizedPaths.js:275:36:275:40 | // OK | Spurious alert |
-| normalizedPaths.js:282:36:282:40 | // OK | Spurious alert |
 | tainted-string-steps.js:25:43:25:74 | // NOT  ... flagged | Missing alert |
 | tainted-string-steps.js:26:49:26:74 | // OK - ... flagged | Spurious alert |
 | tainted-string-steps.js:28:39:28:70 | // NOT  ... flagged | Missing alert |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/Consistency.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/Consistency.expected
@@ -1,4 +1,7 @@
 | normalizedPaths.js:208:38:208:63 | // OK - ...  anyway | Spurious alert |
+| normalizedPaths.js:259:26:259:30 | // OK | Spurious alert |
+| normalizedPaths.js:275:36:275:40 | // OK | Spurious alert |
+| normalizedPaths.js:282:36:282:40 | // OK | Spurious alert |
 | tainted-string-steps.js:25:43:25:74 | // NOT  ... flagged | Missing alert |
 | tainted-string-steps.js:26:49:26:74 | // OK - ... flagged | Spurious alert |
 | tainted-string-steps.js:28:39:28:70 | // NOT  ... flagged | Missing alert |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -1509,17 +1509,11 @@ nodes
 | normalizedPaths.js:257:18:257:21 | path |
 | normalizedPaths.js:257:18:257:21 | path |
 | normalizedPaths.js:257:18:257:21 | path |
-| normalizedPaths.js:259:19:259:22 | path |
-| normalizedPaths.js:259:19:259:22 | path |
-| normalizedPaths.js:259:19:259:22 | path |
-| normalizedPaths.js:259:19:259:22 | path |
-| normalizedPaths.js:259:19:259:22 | path |
 | normalizedPaths.js:262:19:262:22 | path |
 | normalizedPaths.js:262:19:262:22 | path |
 | normalizedPaths.js:262:19:262:22 | path |
 | normalizedPaths.js:262:19:262:22 | path |
 | normalizedPaths.js:262:19:262:22 | path |
-| normalizedPaths.js:266:19:266:22 | path |
 | normalizedPaths.js:266:19:266:22 | path |
 | normalizedPaths.js:266:19:266:22 | path |
 | normalizedPaths.js:266:19:266:22 | path |
@@ -1538,18 +1532,10 @@ nodes
 | normalizedPaths.js:273:45:273:48 | path |
 | normalizedPaths.js:273:45:273:48 | path |
 | normalizedPaths.js:273:45:273:48 | path |
-| normalizedPaths.js:275:19:275:32 | normalizedPath |
-| normalizedPaths.js:275:19:275:32 | normalizedPath |
-| normalizedPaths.js:275:19:275:32 | normalizedPath |
-| normalizedPaths.js:275:19:275:32 | normalizedPath |
 | normalizedPaths.js:278:19:278:32 | normalizedPath |
 | normalizedPaths.js:278:19:278:32 | normalizedPath |
 | normalizedPaths.js:278:19:278:32 | normalizedPath |
 | normalizedPaths.js:278:19:278:32 | normalizedPath |
-| normalizedPaths.js:282:19:282:32 | normalizedPath |
-| normalizedPaths.js:282:19:282:32 | normalizedPath |
-| normalizedPaths.js:282:19:282:32 | normalizedPath |
-| normalizedPaths.js:282:19:282:32 | normalizedPath |
 | normalizedPaths.js:285:19:285:32 | normalizedPath |
 | normalizedPaths.js:285:19:285:32 | normalizedPath |
 | normalizedPaths.js:285:19:285:32 | normalizedPath |
@@ -4295,14 +4281,6 @@ edges
 | normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:257:18:257:21 | path |
 | normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:257:18:257:21 | path |
 | normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:257:18:257:21 | path |
-| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
-| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
-| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
-| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
-| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
-| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
-| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
-| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
 | normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:262:19:262:22 | path |
 | normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:262:19:262:22 | path |
 | normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:262:19:262:22 | path |
@@ -4311,8 +4289,6 @@ edges
 | normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:262:19:262:22 | path |
 | normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:262:19:262:22 | path |
 | normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:262:19:262:22 | path |
-| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:266:19:266:22 | path |
-| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:266:19:266:22 | path |
 | normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:266:19:266:22 | path |
 | normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:266:19:266:22 | path |
 | normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:266:19:266:22 | path |
@@ -4338,24 +4314,12 @@ edges
 | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:256:6:256:26 | path |
 | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:256:6:256:26 | path |
 | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:256:6:256:26 | path |
-| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:275:19:275:32 | normalizedPath |
-| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:275:19:275:32 | normalizedPath |
-| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:275:19:275:32 | normalizedPath |
-| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:275:19:275:32 | normalizedPath |
-| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:275:19:275:32 | normalizedPath |
-| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:275:19:275:32 | normalizedPath |
 | normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:278:19:278:32 | normalizedPath |
 | normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:278:19:278:32 | normalizedPath |
 | normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:278:19:278:32 | normalizedPath |
 | normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:278:19:278:32 | normalizedPath |
 | normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:278:19:278:32 | normalizedPath |
 | normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:278:19:278:32 | normalizedPath |
-| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:282:19:282:32 | normalizedPath |
-| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:282:19:282:32 | normalizedPath |
-| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:282:19:282:32 | normalizedPath |
-| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:282:19:282:32 | normalizedPath |
-| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:282:19:282:32 | normalizedPath |
-| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:282:19:282:32 | normalizedPath |
 | normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:285:19:285:32 | normalizedPath |
 | normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:285:19:285:32 | normalizedPath |
 | normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:285:19:285:32 | normalizedPath |
@@ -5237,13 +5201,10 @@ edges
 | normalizedPaths.js:245:21:245:24 | path | normalizedPaths.js:236:33:236:46 | req.query.path | normalizedPaths.js:245:21:245:24 | path | This path depends on $@. | normalizedPaths.js:236:33:236:46 | req.query.path | a user-provided value |
 | normalizedPaths.js:250:21:250:24 | path | normalizedPaths.js:236:33:236:46 | req.query.path | normalizedPaths.js:250:21:250:24 | path | This path depends on $@. | normalizedPaths.js:236:33:236:46 | req.query.path | a user-provided value |
 | normalizedPaths.js:257:18:257:21 | path | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:257:18:257:21 | path | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
-| normalizedPaths.js:259:19:259:22 | path | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:259:19:259:22 | path | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
 | normalizedPaths.js:262:19:262:22 | path | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:262:19:262:22 | path | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
 | normalizedPaths.js:266:19:266:22 | path | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:266:19:266:22 | path | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
 | normalizedPaths.js:269:19:269:22 | path | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:269:19:269:22 | path | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
-| normalizedPaths.js:275:19:275:32 | normalizedPath | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:275:19:275:32 | normalizedPath | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
 | normalizedPaths.js:278:19:278:32 | normalizedPath | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:278:19:278:32 | normalizedPath | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
-| normalizedPaths.js:282:19:282:32 | normalizedPath | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:282:19:282:32 | normalizedPath | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
 | normalizedPaths.js:285:19:285:32 | normalizedPath | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:285:19:285:32 | normalizedPath | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
 | tainted-require.js:7:19:7:37 | req.param("module") | tainted-require.js:7:19:7:37 | req.param("module") | tainted-require.js:7:19:7:37 | req.param("module") | This path depends on $@. | tainted-require.js:7:19:7:37 | req.param("module") | a user-provided value |
 | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | This path depends on $@. | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -1495,6 +1495,65 @@ nodes
 | normalizedPaths.js:250:21:250:24 | path |
 | normalizedPaths.js:250:21:250:24 | path |
 | normalizedPaths.js:250:21:250:24 | path |
+| normalizedPaths.js:256:6:256:26 | path |
+| normalizedPaths.js:256:6:256:26 | path |
+| normalizedPaths.js:256:6:256:26 | path |
+| normalizedPaths.js:256:6:256:26 | path |
+| normalizedPaths.js:256:13:256:26 | req.query.path |
+| normalizedPaths.js:256:13:256:26 | req.query.path |
+| normalizedPaths.js:256:13:256:26 | req.query.path |
+| normalizedPaths.js:256:13:256:26 | req.query.path |
+| normalizedPaths.js:256:13:256:26 | req.query.path |
+| normalizedPaths.js:257:18:257:21 | path |
+| normalizedPaths.js:257:18:257:21 | path |
+| normalizedPaths.js:257:18:257:21 | path |
+| normalizedPaths.js:257:18:257:21 | path |
+| normalizedPaths.js:257:18:257:21 | path |
+| normalizedPaths.js:259:19:259:22 | path |
+| normalizedPaths.js:259:19:259:22 | path |
+| normalizedPaths.js:259:19:259:22 | path |
+| normalizedPaths.js:259:19:259:22 | path |
+| normalizedPaths.js:259:19:259:22 | path |
+| normalizedPaths.js:262:19:262:22 | path |
+| normalizedPaths.js:262:19:262:22 | path |
+| normalizedPaths.js:262:19:262:22 | path |
+| normalizedPaths.js:262:19:262:22 | path |
+| normalizedPaths.js:262:19:262:22 | path |
+| normalizedPaths.js:266:19:266:22 | path |
+| normalizedPaths.js:266:19:266:22 | path |
+| normalizedPaths.js:266:19:266:22 | path |
+| normalizedPaths.js:266:19:266:22 | path |
+| normalizedPaths.js:266:19:266:22 | path |
+| normalizedPaths.js:269:19:269:22 | path |
+| normalizedPaths.js:269:19:269:22 | path |
+| normalizedPaths.js:269:19:269:22 | path |
+| normalizedPaths.js:269:19:269:22 | path |
+| normalizedPaths.js:269:19:269:22 | path |
+| normalizedPaths.js:273:6:273:49 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath |
+| normalizedPaths.js:273:23:273:49 | pathMod ... , path) |
+| normalizedPaths.js:273:23:273:49 | pathMod ... , path) |
+| normalizedPaths.js:273:23:273:49 | pathMod ... , path) |
+| normalizedPaths.js:273:45:273:48 | path |
+| normalizedPaths.js:273:45:273:48 | path |
+| normalizedPaths.js:273:45:273:48 | path |
+| normalizedPaths.js:275:19:275:32 | normalizedPath |
+| normalizedPaths.js:275:19:275:32 | normalizedPath |
+| normalizedPaths.js:275:19:275:32 | normalizedPath |
+| normalizedPaths.js:275:19:275:32 | normalizedPath |
+| normalizedPaths.js:278:19:278:32 | normalizedPath |
+| normalizedPaths.js:278:19:278:32 | normalizedPath |
+| normalizedPaths.js:278:19:278:32 | normalizedPath |
+| normalizedPaths.js:278:19:278:32 | normalizedPath |
+| normalizedPaths.js:282:19:282:32 | normalizedPath |
+| normalizedPaths.js:282:19:282:32 | normalizedPath |
+| normalizedPaths.js:282:19:282:32 | normalizedPath |
+| normalizedPaths.js:282:19:282:32 | normalizedPath |
+| normalizedPaths.js:285:19:285:32 | normalizedPath |
+| normalizedPaths.js:285:19:285:32 | normalizedPath |
+| normalizedPaths.js:285:19:285:32 | normalizedPath |
+| normalizedPaths.js:285:19:285:32 | normalizedPath |
 | tainted-require.js:7:19:7:37 | req.param("module") |
 | tainted-require.js:7:19:7:37 | req.param("module") |
 | tainted-require.js:7:19:7:37 | req.param("module") |
@@ -4228,6 +4287,87 @@ edges
 | normalizedPaths.js:236:33:236:46 | req.query.path | normalizedPaths.js:236:14:236:47 | pathMod ... y.path) |
 | normalizedPaths.js:236:33:236:46 | req.query.path | normalizedPaths.js:236:14:236:47 | pathMod ... y.path) |
 | normalizedPaths.js:236:33:236:46 | req.query.path | normalizedPaths.js:236:14:236:47 | pathMod ... y.path) |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:257:18:257:21 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:257:18:257:21 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:257:18:257:21 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:257:18:257:21 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:257:18:257:21 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:257:18:257:21 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:257:18:257:21 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:257:18:257:21 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:259:19:259:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:262:19:262:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:262:19:262:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:262:19:262:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:262:19:262:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:262:19:262:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:262:19:262:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:262:19:262:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:262:19:262:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:266:19:266:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:266:19:266:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:266:19:266:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:266:19:266:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:266:19:266:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:266:19:266:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:266:19:266:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:266:19:266:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:269:19:269:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:269:19:269:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:269:19:269:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:269:19:269:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:269:19:269:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:269:19:269:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:269:19:269:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:269:19:269:22 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:273:45:273:48 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:273:45:273:48 | path |
+| normalizedPaths.js:256:6:256:26 | path | normalizedPaths.js:273:45:273:48 | path |
+| normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:256:6:256:26 | path |
+| normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:256:6:256:26 | path |
+| normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:256:6:256:26 | path |
+| normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:256:6:256:26 | path |
+| normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:256:6:256:26 | path |
+| normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:256:6:256:26 | path |
+| normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:256:6:256:26 | path |
+| normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:256:6:256:26 | path |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:275:19:275:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:275:19:275:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:275:19:275:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:275:19:275:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:275:19:275:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:275:19:275:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:278:19:278:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:278:19:278:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:278:19:278:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:278:19:278:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:278:19:278:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:278:19:278:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:282:19:282:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:282:19:282:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:282:19:282:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:282:19:282:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:282:19:282:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:282:19:282:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:285:19:285:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:285:19:285:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:285:19:285:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:285:19:285:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:285:19:285:32 | normalizedPath |
+| normalizedPaths.js:273:6:273:49 | normalizedPath | normalizedPaths.js:285:19:285:32 | normalizedPath |
+| normalizedPaths.js:273:23:273:49 | pathMod ... , path) | normalizedPaths.js:273:6:273:49 | normalizedPath |
+| normalizedPaths.js:273:23:273:49 | pathMod ... , path) | normalizedPaths.js:273:6:273:49 | normalizedPath |
+| normalizedPaths.js:273:23:273:49 | pathMod ... , path) | normalizedPaths.js:273:6:273:49 | normalizedPath |
+| normalizedPaths.js:273:45:273:48 | path | normalizedPaths.js:273:23:273:49 | pathMod ... , path) |
+| normalizedPaths.js:273:45:273:48 | path | normalizedPaths.js:273:23:273:49 | pathMod ... , path) |
+| normalizedPaths.js:273:45:273:48 | path | normalizedPaths.js:273:23:273:49 | pathMod ... , path) |
 | tainted-require.js:7:19:7:37 | req.param("module") | tainted-require.js:7:19:7:37 | req.param("module") |
 | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | tainted-sendFile.js:8:16:8:33 | req.param("gimme") |
 | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | tainted-sendFile.js:10:16:10:33 | req.param("gimme") |
@@ -5096,6 +5236,15 @@ edges
 | normalizedPaths.js:238:19:238:22 | path | normalizedPaths.js:236:33:236:46 | req.query.path | normalizedPaths.js:238:19:238:22 | path | This path depends on $@. | normalizedPaths.js:236:33:236:46 | req.query.path | a user-provided value |
 | normalizedPaths.js:245:21:245:24 | path | normalizedPaths.js:236:33:236:46 | req.query.path | normalizedPaths.js:245:21:245:24 | path | This path depends on $@. | normalizedPaths.js:236:33:236:46 | req.query.path | a user-provided value |
 | normalizedPaths.js:250:21:250:24 | path | normalizedPaths.js:236:33:236:46 | req.query.path | normalizedPaths.js:250:21:250:24 | path | This path depends on $@. | normalizedPaths.js:236:33:236:46 | req.query.path | a user-provided value |
+| normalizedPaths.js:257:18:257:21 | path | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:257:18:257:21 | path | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
+| normalizedPaths.js:259:19:259:22 | path | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:259:19:259:22 | path | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
+| normalizedPaths.js:262:19:262:22 | path | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:262:19:262:22 | path | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
+| normalizedPaths.js:266:19:266:22 | path | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:266:19:266:22 | path | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
+| normalizedPaths.js:269:19:269:22 | path | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:269:19:269:22 | path | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
+| normalizedPaths.js:275:19:275:32 | normalizedPath | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:275:19:275:32 | normalizedPath | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
+| normalizedPaths.js:278:19:278:32 | normalizedPath | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:278:19:278:32 | normalizedPath | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
+| normalizedPaths.js:282:19:282:32 | normalizedPath | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:282:19:282:32 | normalizedPath | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
+| normalizedPaths.js:285:19:285:32 | normalizedPath | normalizedPaths.js:256:13:256:26 | req.query.path | normalizedPaths.js:285:19:285:32 | normalizedPath | This path depends on $@. | normalizedPaths.js:256:13:256:26 | req.query.path | a user-provided value |
 | tainted-require.js:7:19:7:37 | req.param("module") | tainted-require.js:7:19:7:37 | req.param("module") | tainted-require.js:7:19:7:37 | req.param("module") | This path depends on $@. | tainted-require.js:7:19:7:37 | req.param("module") | a user-provided value |
 | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | This path depends on $@. | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | a user-provided value |
 | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | This path depends on $@. | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/normalizedPaths.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/normalizedPaths.js
@@ -249,3 +249,41 @@ app.get('/resolve-path', (req, res) => {
   else
     fs.readFileSync(path); // NOT OK - wrong polarity
 });
+
+var isPathInside = require("is-path-inside"),
+    pathIsInside = require("path-is-inside");
+app.get('/pseudo-normalizations', (req, res) => {
+	let path = req.query.path;
+	fs.readFileSync(path); // NOT OK
+	if (isPathInside(path, SAFE)) {
+		fs.readFileSync(path); // OK
+		return;
+	} else {
+		fs.readFileSync(path); // NOT OK
+
+	}
+	if (pathIsInside(path, SAFE)) {
+		fs.readFileSync(path); // NOT OK - can be of the form 'safe/directory/../../../etc/passwd'
+		return;
+	} else {
+		fs.readFileSync(path); // NOT OK
+
+	}
+
+	let normalizedPath = pathModule.join(SAFE, path);
+	if (pathIsInside(normalizedPath, SAFE)) {
+		fs.readFileSync(normalizedPath); // OK
+		return;
+	} else {
+		fs.readFileSync(normalizedPath); // NOT OK
+	}
+
+	if (pathIsInside(normalizedPath, SAFE)) {
+		fs.readFileSync(normalizedPath); // OK
+		return;
+	} else {
+		fs.readFileSync(normalizedPath); // NOT OK
+
+	}
+
+});


### PR DESCRIPTION
The following pattern sanitizes paths wrt. path injection.

```js
const isPathInside = require('path-is-inside');

if (!isPathInside(file, process.cwd())) {
    this.body = 'Bad Request';
    this.status = 400;
}
```

This PR models two confusingly similar packages: 'path-is-inside' and 'is-'path-inside' for that purpose.

Evaluation is pending.