### PR TITLE
Update expected results for changes in Extractor FE

### DIFF
--- a/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
+++ b/cpp/ql/test/library-tests/ir/ir/PrintAST.expected
@@ -5753,9 +5753,9 @@ ir.cpp:
 #  851|       0: [VariableDeclarationEntry] definition of d
 #  851|           Type = [Struct] PolymorphicDerived
 #  851|         init: [Initializer] initializer for d
-#  851|           expr: [ConstructorCall] call to PolymorphicDerived
-#  851|               Type = [VoidType] void
-#  851|               ValueCategory = prvalue
+#-----|           expr: [ConstructorCall] call to PolymorphicDerived
+#-----|               Type = [VoidType] void
+#-----|               ValueCategory = prvalue
 #  853|     2: [DeclStmt] declaration
 #  853|       0: [VariableDeclarationEntry] definition of pb
 #  853|           Type = [PointerType] PolymorphicBase *

--- a/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ir/raw_ir.expected
@@ -4217,10 +4217,10 @@ ir.cpp:
 #-----|     mu0_4(PolymorphicBase)              = ^IndirectMayWriteSideEffect[-1]     : &:r850_1
 #  851|     r851_1(glval<PolymorphicDerived>)   = VariableAddress[d]                  : 
 #  851|     mu851_2(PolymorphicDerived)         = Uninitialized[d]                    : &:r851_1
-#  851|     r851_3(glval<unknown>)              = FunctionAddress[PolymorphicDerived] : 
-#  851|     v851_4(void)                        = Call                                : func:r851_3, this:r851_1
-#  851|     mu851_5(unknown)                    = ^CallSideEffect                     : ~mu849_3
-#  851|     mu851_6(PolymorphicDerived)         = ^IndirectMayWriteSideEffect[-1]     : &:r851_1
+#-----|     r0_5(glval<unknown>)                = FunctionAddress[PolymorphicDerived] : 
+#-----|     v0_6(void)                          = Call                                : func:r0_5, this:r851_1
+#-----|     mu0_7(unknown)                      = ^CallSideEffect                     : ~mu849_3
+#-----|     mu0_8(PolymorphicDerived)           = ^IndirectMayWriteSideEffect[-1]     : &:r851_1
 #  853|     r853_1(glval<PolymorphicBase *>)    = VariableAddress[pb]                 : 
 #  853|     r853_2(glval<PolymorphicBase>)      = VariableAddress[b]                  : 
 #  853|     r853_3(PolymorphicBase *)           = CopyValue                           : r853_2

--- a/cpp/ql/test/library-tests/locations/overloaded_operators/locations.expected
+++ b/cpp/ql/test/library-tests/locations/overloaded_operators/locations.expected
@@ -1,4 +1,4 @@
-| test.cpp:9:12:9:35 | call to MyInt |
+| test.cpp:9:5:9:36 | call to MyInt |
 | test.cpp:26:18:26:23 | call to MyInt |
 | test.cpp:42:15:42:15 | call to operator+ |
 | test.cpp:43:5:43:5 | call to operator+= |

--- a/cpp/ql/test/library-tests/permissive/calls.expected
+++ b/cpp/ql/test/library-tests/permissive/calls.expected
@@ -1,2 +1,1 @@
-| non_permissive.cpp:6:3:6:3 | call to f | non_permissive.cpp:2:13:2:13 | f |
 | permissive.cpp:6:3:6:3 | call to f | permissive.cpp:2:13:2:13 | f |

--- a/cpp/ql/test/query-tests/definitions/definitions.expected
+++ b/cpp/ql/test/query-tests/definitions/definitions.expected
@@ -42,7 +42,7 @@
 | class.cpp:91:27:91:29 | num | class.cpp:87:17:87:19 | num | V |
 | class.cpp:100:24:100:34 | type mention | class.cpp:94:18:94:28 | string_type | T |
 | class.cpp:105:1:105:15 | type mention | class.cpp:97:7:97:21 | StringContainer | T |
-| class.cpp:106:9:106:23 | type mention | class.cpp:100:2:100:16 | StringContainer | M |
+| class.cpp:106:9:106:23 | type mention | class.cpp:97:7:97:21 | StringContainer | T |
 | class.cpp:106:25:106:27 | STR(x) | class.cpp:95:1:95:18 | #define STR(x) L ## x | X |
 | class.cpp:117:2:117:29 | type mention | class.cpp:109:7:109:34 | myClassWithConstructorParams | T |
 | class.cpp:117:37:117:37 | a | class.cpp:115:27:115:27 | a | V |


### PR DESCRIPTION
This PR is to keep the expected test results in sync with the extractor EDG 6.0 Upgrade.

All changes should have been discussed and agreed internally, but please review and confirm.

Internal PR: https://git.semmle.com/Semmle/code/pull/35987