### PR TITLE
CPP: Avoid uncessary recursion in printf.qll

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Printf.qll
@@ -258,14 +258,7 @@ class FormatLiteral extends Literal {
    * Gets the position in the string at which the nth conversion specifier
    * starts.
    */
-  int getConvSpecOffset(int n) {
-    n = 0 and result = this.getFormat().indexOf("%", 0, 0)
-    or
-    n > 0 and
-    exists(int p |
-      n = p + 1 and result = this.getFormat().indexOf("%", 0, this.getConvSpecOffset(p) + 2)
-    )
-  }
+  int getConvSpecOffset(int n) { result = this.getFormat().indexOf("%", n, 0) }
 
   /*
    * Each of these predicates gets a regular expressions to match each individual


### PR DESCRIPTION
I think due to the fact that `getFormat()` replaces all double "%" with "_" means that it is impossible for the character at `this.getConvSpecOffset(p) + 1` to be a "%" and hence we don't need the recursion and can just use the second argument of `indexOf` directly. This is a very minor performance win as the new performance is equivalent to the old first iteration.