### PR TITLE
Queries to detect ReDoS and Regex injections in Java

### DIFF
--- a/java/ql/src/Security/CWE/CWE-400/ReDoS.java
+++ b/java/ql/src/Security/CWE/CWE-400/ReDoS.java
@@ -1,0 +1,18 @@
+public class ReDoS {
+  private static String EXPONENTIAL_REGEX = "(a+)+";
+
+  public void regexMatchBad(HttpServletRequest request) {
+    // BAD: User provided input is matched against exponential regex using standard
+    // Java regular expression engine
+    java.util.regex.Pattern p = java.util.regex.Pattern.compile(EXPONENTIAL_REGEX);
+    java.util.regex.Matcher m = p.matcher(request.getParameter("input"));
+    boolean matches = m.matches();
+  }
+
+  public void regexMatchGood(HttpServletRequest request) {
+    // GOOD: RE2/J regular expression engine is being used 
+    com.google.re2j.Pattern p = com.google.re2j.Pattern.compile(EXPONENTIAL_REGEX);
+    com.google.re2j.Matcher m = p.matcher(request.getParameter("input"));
+    boolean matches = m.matches();
+  }
+}

--- a/java/ql/src/Security/CWE/CWE-400/ReDoS.qhelp
+++ b/java/ql/src/Security/CWE/CWE-400/ReDoS.qhelp
@@ -1,0 +1,52 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>Matching user input against a regular expression which takes exponential time in the worst case
+can allow a malicious user to perform a Denial of Service ("DoS") attack by crafting input that
+takes a long time to execute.</p>
+
+<p>Most regular expression engines, including the Java standard library implementation, are
+designed to work with an extended regular expression syntax. Although this provides flexibility for
+the user, it can prevent the engine from constructing an efficient implementation of the matcher in
+all circumstances. In particular, the "worst case time complexity" (see the references) of certain
+regular expressions may be "exponential". This would allow a malicious user to provide some input
+which causes the regular expression to take a very long time to execute.</p>
+
+<p>Typically, a regular expression is vulnerable to this attack if it applies repetition to a
+sub-expression which itself is repeated, or contains overlapping options. For example,
+<code>(a+)+</code> is vulnerable to a string such as <code>aaaaaaaaaaaaaaaaaaaaaaaaaaab</code>.
+More information about the precise circumstances can be found in the references.</p>
+</overview>
+
+<recommendation>
+<p>Modify the regular expression to avoid the exponential worst case time. If this is not possible,
+then kill the regular expression matching if it takes too long. Alternatively, use a different
+regular expression engine, for example RE2/J which runs in time linear in the size of the input.
+</p>
+</recommendation>
+
+<example>
+<p>The following example shows a HTTP request parameter that is matched against a regular
+expression which has exponential worst case performance. In the first case, standard Java library
+is being used, which can lead to a Denial of Service. In the second case, RE2/J regular expression
+engine is being used. It runs in time linear in the size of the input and won't lead to a DoS.</p>
+
+<sample src="ReDoS.java" />
+</example>
+
+<references>
+<li>
+OWASP:
+<a href="https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS">Regular expression Denial of Service - ReDoS</a>.
+</li>
+<li>
+Regular-Expressions.info: <a href="https://www.regular-expressions.info/redos.html">Preventing Regular Expression Denial of Service (ReDoS)</a>.
+</li>
+<li>
+<a href="https://github.com/google/re2j">RE2/J: linear time regular expression matching in Java</a>.
+</li>
+</references>
+</qhelp>

--- a/java/ql/src/Security/CWE/CWE-400/ReDoS.ql
+++ b/java/ql/src/Security/CWE/CWE-400/ReDoS.ql
@@ -19,16 +19,8 @@ class ExponentialRegexLiteral extends RegexPatternSource {
   ExponentialRegexLiteral() { isExponentialRegex(this.asExpr()) }
 }
 
-// from DataFlow2::PathNode source, DataFlow2::PathNode sink, RegexPatternFlowConfig conf
-// where conf.hasFlowPath(source, sink)
-// select sink.getNode(), source, sink,
-//   "$@ flows to regular expression operation with dangerous regex.", source.getNode(),
-//   "User-provided value"
-
 from DataFlow::PathNode source, DataFlow::PathNode sink, RegexInputFlowConfig conf
 where conf.hasFlowPath(source, sink)
-select source, sink, sink.getNode().asExpr().getParent(), sink.getNode().asExpr().getParent().(MethodAccess).getQualifier()
-
-// from DataFlow2::PathNode source, DataFlow2::PathNode sink, RegexPatternFlowConfig conf
-// where conf.hasFlowPath(source, sink)
-// select source, sink, sink.getNode().asExpr().getParent()
+select sink.getNode(), source, sink,
+  "$@ flows to regular expression operation with dangerous regex.", source.getNode(),
+  "User-provided value"

--- a/java/ql/src/Security/CWE/CWE-400/ReDoS.ql
+++ b/java/ql/src/Security/CWE/CWE-400/ReDoS.ql
@@ -1,0 +1,34 @@
+/**
+ * @name Denial of Service from comparison of user input against expensive regex
+ * @description User input should not be matched against a regular expression that could require
+ *              exponential time on certain input.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id java/redos
+ * @tags security
+ *       external/cwe/cwe-400
+ */
+
+import java
+import semmle.code.java.dataflow.DataFlow
+import Regex
+
+/** A data flow source for exponential regex. */
+class ExponentialRegexLiteral extends RegexPatternSource {
+  ExponentialRegexLiteral() { isExponentialRegex(this.asExpr()) }
+}
+
+// from DataFlow2::PathNode source, DataFlow2::PathNode sink, RegexPatternFlowConfig conf
+// where conf.hasFlowPath(source, sink)
+// select sink.getNode(), source, sink,
+//   "$@ flows to regular expression operation with dangerous regex.", source.getNode(),
+//   "User-provided value"
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, RegexInputFlowConfig conf
+where conf.hasFlowPath(source, sink)
+select source, sink, sink.getNode().asExpr().getParent(), sink.getNode().asExpr().getParent().(MethodAccess).getQualifier()
+
+// from DataFlow2::PathNode source, DataFlow2::PathNode sink, RegexPatternFlowConfig conf
+// where conf.hasFlowPath(source, sink)
+// select source, sink, sink.getNode().asExpr().getParent()

--- a/java/ql/src/Security/CWE/CWE-400/Regex.qll
+++ b/java/ql/src/Security/CWE/CWE-400/Regex.qll
@@ -1,0 +1,102 @@
+import java
+import semmle.code.java.dataflow.FlowSources
+import semmle.code.java.dataflow.TaintTracking
+import semmle.code.java.dataflow.TaintTracking2
+
+/**
+ * A taint-tracking configuration for unvalidated user input that is used to match against
+ * malicious regex.
+ */
+class RegexInputFlowConfig extends TaintTracking::Configuration {
+  RegexInputFlowConfig() { this = "RegexInputFlowConfig" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RemoteFlowSource }
+
+  override predicate isSink(DataFlow::Node sink) { sink instanceof RegexInputSink }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    node.getType() instanceof PrimitiveType or node.getType() instanceof BoxedType
+  }
+}
+
+/**
+ * Holds if method call `ma` matches against the regex `regexExpr`. For example, method `matches`
+ * matches against regex `regex` in `Pattern.matches(regex, input)`.
+ */
+predicate matchesAgainstRegex(MethodAccess ma, Expr regexExpr) {
+  // `Pattern.matches(regex, input)`
+  ma.getMethod() instanceof MethodPatternMatches and
+  regexExpr.getParent() = ma
+  or
+  // `Pattern.compile(regex).matcher(input)` or
+  // `Pattern p = Pattern.compile(regex); p.matcher(input);` or
+  // `private Pattern p = Pattern.compile(regex); public void foo() { p.matcher(input); }`
+  ma.getMethod() instanceof MethodPatternMatcher and
+  (
+    DataFlow::localFlow(DataFlow::exprNode(regexExpr.getParent()),
+      DataFlow::exprNode(ma.getQualifier())) or
+    ma.getQualifier().(FieldAccess).getField().getInitializer() = regexExpr.getParent()
+  )
+  or
+  // `input.matches(pattern)`
+  ma.getMethod() instanceof MethodStringMatches and
+  regexExpr = ma.getAnArgument()
+}
+
+/** A data flow sink for unvalidated user input that is used to match against malicious regex. */
+class RegexInputSink extends DataFlow::ExprNode {
+  RegexInputSink() {
+    exists(MethodAccess ma, RegexPatternFlowConfig cfg, DataFlow::ExprNode regexSink |
+      ma.getAnArgument() = this.getExpr() or ma.getQualifier() = this.getExpr()
+    |
+      cfg.hasFlow(_, regexSink) and
+      matchesAgainstRegex(ma, regexSink.getExpr()) and
+      this != regexSink
+    )
+  }
+}
+
+/** A data flow source for malicious regex. */
+abstract class RegexPatternSource extends DataFlow::Node { }
+
+/**
+ * A taint-tracking configuration for regex pattern that is used to create `Pattern` or is used
+ * as an argument to `matches` method.
+ */
+class RegexPatternFlowConfig extends TaintTracking2::Configuration {
+  RegexPatternFlowConfig() { this = "RegexPatternFlowConfig" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof RegexPatternSource }
+
+  override predicate isSink(DataFlow::Node sink) {
+    exists(MethodAccess ma | ma.getAnArgument() = sink.asExpr() |
+      ma.getMethod() instanceof MethodPatternCompile or
+      ma.getMethod() instanceof MethodPatternMatches or
+      ma.getMethod() instanceof MethodStringMatches
+    )
+  }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    node.getType() instanceof PrimitiveType or node.getType() instanceof BoxedType
+  }
+}
+
+/**
+ * An expression that represents a regular expression with potential exponential behavior.
+ */
+predicate isExponentialRegex(StringLiteral s) {
+  /*
+   * Detect three variants of a common pattern that leads to exponential blow-up.
+   */
+
+  // Example: ([a-z]+.)+
+  s.getValue().regexpMatch(".*\\([^()*+\\]]+\\]?(\\*|\\+)\\.?\\)(\\*|\\+).*")
+  or
+  // Example: (([a-z])?([a-z]+.))+
+  s
+      .getValue()
+      .regexpMatch(".*\\((\\([^()]+\\)\\?)?\\([^()*+\\]]+\\]?(\\*|\\+)\\.?\\)\\)(\\*|\\+).*")
+  or
+  // Example: (([a-z])+.)+
+  s.getValue().regexpMatch(".*\\(\\([^()*+\\]]+\\]?\\)(\\*|\\+)\\.?\\)(\\*|\\+).*")
+}

--- a/java/ql/src/Security/CWE/CWE-400/RegexInjection.java
+++ b/java/ql/src/Security/CWE/CWE-400/RegexInjection.java
@@ -5,11 +5,11 @@ public boolean isUsernameInPassword(HttpServletRequest request) {
   // BAD: User provided input is being used to create regex without escaping
   Pattern p = Pattern.compile(username);
   Matcher m = p.matcher(password);
-  return = m.matches();
+  return m.matches();
 
   // GOOD: User provided input escaped before being used to create regex
   String safeUsername = Pattern.quote(username);
   Pattern p = Pattern.compile(safeUsername);
   Matcher m = p.matcher(password);
-  return = m.matches();
+  return m.matches();
 }

--- a/java/ql/src/Security/CWE/CWE-400/RegexInjection.java
+++ b/java/ql/src/Security/CWE/CWE-400/RegexInjection.java
@@ -1,0 +1,15 @@
+public boolean isUsernameInPassword(HttpServletRequest request) {
+  String username = request.getParameter("username");
+  String pasword = request.getParameter("password");
+
+  // BAD: User provided input is being used to create regex without escaping
+  Pattern p = Pattern.compile(username);
+  Matcher m = p.matcher(password);
+  return = m.matches();
+
+  // GOOD: User provided input escaped before being used to create regex
+  String safeUsername = Pattern.quote(username);
+  Pattern p = Pattern.compile(safeUsername);
+  Matcher m = p.matcher(password);
+  return = m.matches();
+}

--- a/java/ql/src/Security/CWE/CWE-400/RegexInjection.qhelp
+++ b/java/ql/src/Security/CWE/CWE-400/RegexInjection.qhelp
@@ -1,0 +1,48 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+
+<overview>
+<p>Constructing a regular expression with unsanitized user input is dangerous as a malicious user
+may be able to modify the meaning of the expression. In particular, such a user may be able to
+provide a regular expression fragment that takes exponential time in the worst case, and use that
+to perform a Denial of Service attack.</p>
+</overview>
+
+<recommendation>
+<p>For user input that is intended to be referenced as a string literal in a regular expression,
+use the <code>Pattern.quote</code> method to escape any special characters. If the regular
+expression is intended to be configurable by the user, then a timeout should be used to avoid
+Denial of Service attacks. Alternatively, a different regular expression engine, for example RE2/J
+which runs in time linear in the size of the input can be used.</p>
+</recommendation>
+
+<example>
+<p>The following example uses regular expression engine to check if the provided username is part
+of the provided password.</p>
+
+<p>In the first case, the username which is being used to construct the regex is not escaped. If
+a malicious user provides a regex that has exponential worst case performance, then this could
+lead to a Denial of Service.</p>
+
+<p>In the second case, the user input is escaped using <code>Pattern.quote</code> before being
+included in the regular expression. This ensures that the user cannot insert characters which have
+a special meaning in regular expressions.</p>
+
+<sample src="RegexInjection.cs" />
+</example>
+
+<references>
+<li>
+OWASP:
+<a href="https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS">Regular expression Denial of Service - ReDoS</a>.
+</li>
+<li>
+Regular-Expressions.info: <a href="https://www.regular-expressions.info/redos.html">Preventing Regular Expression Denial of Service (ReDoS)</a>.
+</li>
+<li>
+<a href="https://github.com/google/re2j">RE2/J: linear time regular expression matching in Java</a>.
+</li>
+</references>
+</qhelp>

--- a/java/ql/src/Security/CWE/CWE-400/RegexInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-400/RegexInjection.ql
@@ -21,15 +21,8 @@ class RemoteRegexPatternSource extends RegexPatternSource {
   RemoteRegexPatternSource() { this instanceof RemoteFlowSource }
 }
 
-// from DataFlow2::PathNode source, DataFlow2::PathNode sink, RegexPatternFlowConfig conf
-// where conf.hasFlowPath(source, sink)
-// select sink.getNode(), source, sink,
-//   "$@ flows to regular expression operation with dangerous regex.", source.getNode(),
-//   "User-provided value"
 from DataFlow::PathNode source, DataFlow::PathNode sink, RegexInputFlowConfig conf
 where conf.hasFlowPath(source, sink)
-select source, sink, sink.getNode().asExpr().getParent(),
-  sink.getNode().asExpr().getParent().(MethodAccess).getQualifier()
-// from DataFlow2::PathNode source, DataFlow2::PathNode sink, RegexPatternFlowConfig conf
-// where conf.hasFlowPath(source, sink)
-// select source, sink, sink.getNode().asExpr().getParent()
+select sink.getNode(), source, sink,
+  "$@ flows to regular expression operation with user-provided regex.", source.getNode(),
+  "User-provided value"

--- a/java/ql/src/Security/CWE/CWE-400/RegexInjection.ql
+++ b/java/ql/src/Security/CWE/CWE-400/RegexInjection.ql
@@ -1,0 +1,35 @@
+/**
+ * @name Denial of Service from comparison of user input against regex built from user-controlled
+ *       source
+ * @description User input should not be matched against a regular expression built from
+ *              user-controlled source, because that could require exponential time on certain
+ *              input.
+ * @kind path-problem
+ * @problem.severity error
+ * @precision high
+ * @id java/regex-injection
+ * @tags security
+ *       external/cwe/cwe-400
+ */
+
+import java
+import semmle.code.java.dataflow.DataFlow
+import Regex
+
+/** A data flow source for user-controlled regex. */
+class RemoteRegexPatternSource extends RegexPatternSource {
+  RemoteRegexPatternSource() { this instanceof RemoteFlowSource }
+}
+
+// from DataFlow2::PathNode source, DataFlow2::PathNode sink, RegexPatternFlowConfig conf
+// where conf.hasFlowPath(source, sink)
+// select sink.getNode(), source, sink,
+//   "$@ flows to regular expression operation with dangerous regex.", source.getNode(),
+//   "User-provided value"
+from DataFlow::PathNode source, DataFlow::PathNode sink, RegexInputFlowConfig conf
+where conf.hasFlowPath(source, sink)
+select source, sink, sink.getNode().asExpr().getParent(),
+  sink.getNode().asExpr().getParent().(MethodAccess).getQualifier()
+// from DataFlow2::PathNode source, DataFlow2::PathNode sink, RegexPatternFlowConfig conf
+// where conf.hasFlowPath(source, sink)
+// select source, sink, sink.getNode().asExpr().getParent()

--- a/java/ql/src/semmle/code/java/JDK.qll
+++ b/java/ql/src/semmle/code/java/JDK.qll
@@ -170,6 +170,11 @@ class TypeFile extends Class {
   TypeFile() { this.hasQualifiedName("java.io", "File") }
 }
 
+/** The class `java.util.regex.Pattern`. */
+class TypePattern extends Class {
+  TypePattern() { this.hasQualifiedName("java.util.regex", "Pattern") }
+}
+
 // --- Standard methods ---
 /**
  * Any of the methods named `command` on class `java.lang.ProcessBuilder`.
@@ -288,6 +293,46 @@ class MethodMathMax extends Method {
   MethodMathMax() {
     this.getDeclaringType() instanceof TypeMath and
     this.getName() = "max"
+  }
+}
+
+/**
+ * Any method named `compile` on class `java.util.regex.Pattern`.
+ */
+class MethodPatternCompile extends Method {
+  MethodPatternCompile() {
+    this.hasName("compile") and
+    this.getDeclaringType() instanceof TypePattern
+  }
+}
+
+/**
+ * Any method named `matches` on class `java.util.regex.Pattern`.
+ */
+class MethodPatternMatches extends Method {
+  MethodPatternMatches() {
+    this.hasName("matches") and
+    this.getDeclaringType() instanceof TypePattern
+  }
+}
+
+/**
+ * Any method named `matcher` on class `java.util.regex.Pattern`.
+ */
+class MethodPatternMatcher extends Method {
+  MethodPatternMatcher() {
+    this.hasName("matcher") and
+    this.getDeclaringType() instanceof TypePattern
+  }
+}
+
+/**
+ * Any method named `matches` on class `java.lang.String`.
+ */
+class MethodStringMatches extends Method {
+  MethodStringMatches() {
+    this.hasName("matches") and
+    this.getDeclaringType() instanceof TypeString
   }
 }
 

--- a/java/ql/test/query-tests/security/CWE-400/ReDoS.java
+++ b/java/ql/test/query-tests/security/CWE-400/ReDoS.java
@@ -1,0 +1,91 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.web.bind.annotation.RequestParam;
+
+public class ReDoS {
+  private static final String PATTERN_BAD1 = "([a-z]+)+";
+  private static final String PATTERN_BAD2 = "((a+)*)+";
+  private static final String PATTERN_BAD3 = "((((a+)+)+)+)+";
+  private static final String PATTERN_BAD4 = "(([a-z])?([a-z]+))+";
+  private static final String PATTERN_BAD5 = "(([a-zA-Z])+)+";
+  private static final String PATTERN_BAD6 = "([a-zA-Z]+)*";
+  private static final String PATTERN_BAD7 = "(a|aa)+";
+  private static final String PATTERN_BAD8 = "([a-z]|[a-z]?)+";
+  private static final String PATTERN_BAD9 = "(.*a){10}";
+  private static final String PATTERN_BAD10 = "(.*[a-z]){10,11}";
+  private static final String PATTERN_OK1 = "a.*";
+  private static final String PATTERN_OK2 = "(a|ab)+";
+  private static final String PATTERN_OK3 = "(a|b?)+";
+  private static final String PATTERN_OK4 = "(.*a){9}";
+
+  private Pattern pattern = Pattern.compile(PATTERN_BAD1);
+
+  public void testPatternCompileMatcherBad1(@RequestParam String patternCompileMatcherBad1) {
+    Pattern.compile(PATTERN_BAD2).matcher(patternCompileMatcherBad1).matches();
+  }
+
+  public void testPatternCompileMatcherBad2(@RequestParam String patternCompileMatcherBad2) {
+    Pattern p = Pattern.compile(PATTERN_BAD3);
+    Matcher m = p.matcher(patternCompileMatcherBad2);
+    m.matches();
+  }
+
+  public void testPatternCompileMatcherBad3(@RequestParam String patternCompileMatcherBad3) {
+    Matcher m = this.pattern.matcher(patternCompileMatcherBad3);
+    m.matches();
+  }
+
+  public void testPatternMatchesBad1(@RequestParam String patternMatchesBad1) {
+    Pattern.matches(PATTERN_BAD4, patternMatchesBad1);
+  }
+
+  public void testStringMatchesBad1(@RequestParam String stringMatchesBad1) {
+    stringMatchesBad1.matches(PATTERN_BAD5);
+  }
+
+  public void testStringMatchesBad2(@RequestParam String stringMatchesBad2) {
+    stringMatchesBad2.matches(PATTERN_BAD6);
+  }
+
+  public void testStringMatchesBad3(@RequestParam String stringMatchesBad3) {
+    stringMatchesBad3.matches(PATTERN_BAD7);
+  }
+
+  public void testStringMatchesBad4(@RequestParam String stringMatchesBad4) {
+    stringMatchesBad4.matches(PATTERN_BAD8);
+  }
+
+  public void testStringMatchesBad5(@RequestParam String stringMatchesBad5) {
+    stringMatchesBad5.matches(PATTERN_BAD9);
+  }
+
+  public void testStringMatchesBad6(@RequestParam String stringMatchesBad6) {
+    stringMatchesBad6.matches(PATTERN_BAD10);
+  }
+
+  // OK - safe regex
+  public void testPatternCompileMatcherOk1(@RequestParam String patternCompileMatcherOk1) {
+    Pattern.compile(PATTERN_OK1).matcher(patternCompileMatcherOk1).matches();
+  }
+
+  // OK - safe regex
+  public void testPatternCompileMatcherOk2(@RequestParam String patternCompileMatcherOk2) {
+    Pattern.compile(PATTERN_OK2).matcher(patternCompileMatcherOk2).matches();
+  }
+
+  // OK - safe regex
+  public void testPatternCompileMatcherOk3(@RequestParam String patternCompileMatcherOk3) {
+    Pattern.compile(PATTERN_OK3).matcher(patternCompileMatcherOk3).matches();
+  }
+
+  // OK - safe regex
+  public void testPatternCompileMatcherOk4(@RequestParam String patternCompileMatcherOk4) {
+    Pattern.compile(PATTERN_OK4).matcher(patternCompileMatcherOk4).matches();
+  }
+
+  // OK - safe input
+  public void testPatternCompileMatcherOk2() {
+    Pattern.compile(PATTERN_BAD1).matcher("input").matches();
+  }
+}

--- a/java/ql/test/query-tests/security/CWE-400/ReDoS.qlref
+++ b/java/ql/test/query-tests/security/CWE-400/ReDoS.qlref
@@ -1,0 +1,1 @@
+Security/CWE/CWE-400/ReDoS.ql

--- a/java/ql/test/query-tests/security/CWE-400/RegexInjection.java
+++ b/java/ql/test/query-tests/security/CWE-400/RegexInjection.java
@@ -1,0 +1,34 @@
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.springframework.web.bind.annotation.RequestParam;
+
+public class RegexInjection {
+  public void testPatternCompileMatcherBad1(@RequestParam String rPatternCompileMatcherBad1, @RequestParam String iPatternCompileMatcherBad1) {
+    Pattern.compile(rPatternCompileMatcherBad1).matcher(iPatternCompileMatcherBad1).matches();
+  }
+
+  public void testPatternCompileMatcherBad2(@RequestParam String rPatternCompileMatcherBad2, @RequestParam String iPatternCompileMatcherBad2) {
+    Pattern p = Pattern.compile(rPatternCompileMatcherBad2);
+    Matcher m = p.matcher(iPatternCompileMatcherBad2);
+    m.matches();
+  }
+
+  public void testPatternMatchesBad1(@RequestParam String rPatternMatchesBad1, @RequestParam String iPatternMatchesBad1) {
+    Pattern.matches(rPatternMatchesBad1, iPatternMatchesBad1);
+  }
+
+  public void testStringMatchesBad1(@RequestParam String rStringMatchesBad1, @RequestParam String iStringMatchesBad1) {
+    iStringMatchesBad1.matches(rStringMatchesBad1);
+  }
+
+  // OK - safe regex
+  public void testPatternCompileMatcherOk1(@RequestParam String iPatternCompileMatcherOk1) {
+    Pattern.compile(".*").matcher(iPatternCompileMatcherOk1).matches();
+  }
+
+  // OK - safe input
+  public void testPatternCompileMatcherOk2(@RequestParam String rPatternCompileMatcherOk2) {
+    Pattern.compile(rPatternCompileMatcherOk2).matcher("input").matches();
+  }
+}

--- a/java/ql/test/query-tests/security/CWE-400/RegexInjection.qlref
+++ b/java/ql/test/query-tests/security/CWE-400/RegexInjection.qlref
@@ -1,0 +1,1 @@
+Security/CWE/CWE-400/RegexInjection.ql

--- a/java/ql/test/query-tests/security/CWE-400/options
+++ b/java/ql/test/query-tests/security/CWE-400/options
@@ -1,0 +1,1 @@
+//semmle-extractor-options: --javac-args -cp ${testdir}/../../../stubs/springframework-5.2.3


### PR DESCRIPTION
This PR contains 2 queries to detect the cases where user input is matched against malicious regex, which may lead to DoS.

`ReDoS` query detects the cases where user input is matched against the malicious regex, which is hardcoded as a string literal. For example:
```java
public class ReDoS {
  private static String EXPONENTIAL_REGEX = "(a+)+";

  public void regexMatch(@RequestParam String input) {
    Pattern p = Pattern.compile(EXPONENTIAL_REGEX);
    Matcher m = p.matcher(input);
    boolean matches = m.matches();
  }
}
```

`RegexInjection` query detects the cases where user input is matched against regex, which is being built using user supplied input (without escaping). For example:
```java
public boolean isUsernameInPassword(@RequestParam String username, @RequestParam String password) {
  Pattern p = Pattern.compile(username);
  Matcher m = p.matcher(password);
  return m.matches();
}
```

Apart from the above, the 2 queries work the same and re-use the same code.

The following cases are handled:
* `Pattern.matches(regex, input)`
* `input.matches(pattern)` (where `input` is `String`)
* pattern is created first (`Pattern.compile(regex)`) and then matcher (`p.matcher(input)`)

Detecting the last case has some limitations:
* it doesn't work if pattern is created in one method and matcher in another one, e.g.: `void match(Pattern p) { p.matcher(input); } void foo() { match(Pattern.compile(regex)); }`, but it works correctly if pattern is a class field and matcher is created in method, e.g.: `private Pattern p = Pattern.compile(regex); void foo() { p.matcher(input); }`
* the issue is reported if `Matcher` object is created with user supplied input on malicious pattern. To actually trigger the DoS condition, actual matching (e.g. `matcher.matches()`) is required, but usually if matcher is created it will eventually be used.

The `RegexInjection` query raises the flag only if regex is created using user supplied input (regex injection) **and** it's being used to match against user supplied input.
I've been thinking if the query shouldn't raise a flag if regex injection occurs, without checking if the regex is being used to match against user supplied input. This could reveal more bugs, but would also increase the number of false positives.
Please let me know what do you think. I can change this query if you wish.