### PR TITLE
C#: Distinguish between local variables extracted in different compil…

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalVariable.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalVariable.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Microsoft.CodeAnalysis;
 
@@ -9,10 +10,12 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            trapFile.WriteSubId(Location);
-            trapFile.Write('_');
-            trapFile.Write(symbol.Name);
-            trapFile.Write(";localvar");
+            throw new InvalidOperationException();
+        }
+
+        public override void WriteQuotedId(TextWriter trapFile)
+        {
+            trapFile.Write('*');
         }
 
         public override void Populate(TextWriter trapFile) { }

--- a/csharp/extractor/Semmle.Extraction/Symbol.cs
+++ b/csharp/extractor/Semmle.Extraction/Symbol.cs
@@ -53,7 +53,7 @@ namespace Semmle.Extraction
 
         public abstract void WriteId(System.IO.TextWriter trapFile);
 
-        public void WriteQuotedId(TextWriter trapFile)
+        public virtual void WriteQuotedId(TextWriter trapFile)
         {
             trapFile.Write("@\"");
             WriteId(trapFile);


### PR DESCRIPTION
Fixes a database inconsistency, whereby local variables extracted in different methods have the same identity. This causes the "parent" of the local variable, the local variable declaration expression, to be inconsistent.

Previous identity: `@"{@"loc,{@"C_/dev/projects/ravendb/src/Sparrow/Hashing.Iterative.cs;sourcefile"},183,25,183,27"}_buf;localvar"`

New identity: `*`.

This could occur if a method is extracted 2 or more times, as part of a different assembly. Then the tag stack does not prevent the method being extracted twice.