### PR TITLE
C++: Support implicit casts better in range analysis

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeAnalysis.qll
@@ -187,6 +187,13 @@ private predicate boundFlowStepSsa(
     guard.controls(op2.getUse().getBlock(), testIsTrue) and
     reason = TCondReason(guard)
   )
+  or
+  exists(IRGuardCondition guard, boolean testIsTrue, SafeCastInstruction cast |
+    valueNumberOfOperand(op2) = valueNumber(cast.getUnary()) and
+    guard = boundFlowCond(valueNumber(cast), op1, delta, upper, testIsTrue) and
+    guard.controls(op2.getUse().getBlock(), testIsTrue) and
+    reason = TCondReason(guard)
+  )
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/RangeAnalysis.qll
@@ -259,7 +259,7 @@ private predicate safeCast(IntegralType fromtyp, IntegralType totyp) {
 
 private class SafeCastInstruction extends ConvertInstruction {
   SafeCastInstruction() {
-    safeCast(getResultType(), getUnary().getResultType())
+    safeCast(getUnary().getResultType(), getResultType())
     or
     getResultType() instanceof PointerType and
     getUnary().getResultType() instanceof PointerType

--- a/cpp/ql/test/library-tests/rangeanalysis/rangeanalysis/RangeAnalysis.expected
+++ b/cpp/ql/test/library-tests/rangeanalysis/rangeanalysis/RangeAnalysis.expected
@@ -59,3 +59,6 @@
 | test.cpp:183:10:183:10 | Load: i | test.cpp:175:23:175:23 | InitializeParameter: x | -1 | true | CompareLT: ... < ... | test.cpp:182:9:182:13 | test.cpp:182:9:182:13 |
 | test.cpp:185:10:185:10 | Load: i | test.cpp:175:23:175:23 | InitializeParameter: x | 0 | true | CompareLT: ... < ... | test.cpp:176:7:176:11 | test.cpp:176:7:176:11 |
 | test.cpp:187:10:187:10 | Store: i | test.cpp:175:23:175:23 | InitializeParameter: x | 0 | false | CompareLT: ... < ... | test.cpp:182:9:182:13 | test.cpp:182:9:182:13 |
+| test.cpp:199:10:199:10 | Load: i | test.cpp:197:25:197:25 | InitializeParameter: l | -1 | true | CompareLT: ... < ... | test.cpp:198:7:198:11 | test.cpp:198:7:198:11 |
+| test.cpp:202:11:202:11 | Load: i | test.cpp:197:25:197:25 | InitializeParameter: l | -3 | true | CompareLT: ... < ... | test.cpp:201:7:201:15 | test.cpp:201:7:201:15 |
+| test.cpp:208:10:208:10 | Load: x | test.cpp:206:24:206:24 | InitializeParameter: y | -3 | true | CompareLT: ... < ... | test.cpp:207:7:207:15 | test.cpp:207:7:207:15 |

--- a/cpp/ql/test/library-tests/rangeanalysis/rangeanalysis/test.cpp
+++ b/cpp/ql/test/library-tests/rangeanalysis/rangeanalysis/test.cpp
@@ -186,3 +186,9 @@ int test15(int i, int x) {
   }
   return i;
 }
+
+// safe integer type conversion
+int test16(int i) {
+  long l;
+  l = i;
+}

--- a/cpp/ql/test/library-tests/rangeanalysis/rangeanalysis/test.cpp
+++ b/cpp/ql/test/library-tests/rangeanalysis/rangeanalysis/test.cpp
@@ -192,3 +192,19 @@ int test16(int i) {
   long l;
   l = i;
 }
+
+// implicit integer casts
+void test17(int i, long l) {
+  if (i < l) {
+    sink(i);
+  }
+  if (i < l - 2) {
+    sink (i);
+  }
+}
+
+void test18(int x, int y) {
+  if (x < y - 2) {
+    sink(x);
+  }
+}


### PR DESCRIPTION
This extends the C++ range analysis by supporting constructs like
```
int i;
long l;   
if (i < l - 2) {
  sink (i);
}
```
The bound derived in the if condition is on the value number of the implicitly-to-long converted i.
This PR recovers a bound on i itself.

Depends on #2745, *.expected test changes are missing due to missing tooling.