### PR TITLE
Unsafe reflection in java (CWE-470)

### DIFF
--- a/java/ql/src/Security/CWE/CWE-470/Reflection.java
+++ b/java/ql/src/Security/CWE/CWE-470/Reflection.java
@@ -1,0 +1,7 @@
+// BAD: class_name is user contoller input
+String class_name = System.getenv("CLASS_NAME");
+Class class = Class.forName(class_name);
+
+// GOOD: use string constant
+String class_name = "awt";
+Class class = Class.forName(class_name);

--- a/java/ql/src/Security/CWE/CWE-470/Reflection.qhelp
+++ b/java/ql/src/Security/CWE/CWE-470/Reflection.qhelp
@@ -1,0 +1,25 @@
+<!DOCTYPE qhelp PUBLIC
+  "-//Semmle//qhelp//EN"
+  "qhelp.dtd">
+<qhelp>
+<overview>
+<p>This vulnerability is caused by unsafe use of the reflection mechanisms</p>
+<p>An attacker may be able to create unexpected control flow paths through the application, potentially bypassing security checks.
+Exploitation of this weakness can result in a limited form of code injection.</p>
+<p>This vulnerability happens when a programmer refactor code using reflection</p>
+
+</overview>
+<recommendation>
+
+<p>Use reflection only on user trusted input</p>
+
+</recommendation>
+<references>
+
+<li>
+OWASP:
+<a href="https://owasp.org/www-community/vulnerabilities/Unsafe_use_of_Reflection">Unsafe reflection</a>.
+</li>
+
+</references>
+</qhelp>

--- a/java/ql/src/Security/CWE/CWE-470/ReflectionBad.ql
+++ b/java/ql/src/Security/CWE/CWE-470/ReflectionBad.ql
@@ -15,7 +15,7 @@ import DataFlow::PathGraph
 
 class ClassFornameMethod extends Method {
   ClassFornameMethod() {
-    this.getDeclaringType().hasQualifiedName("java.lang", "Class<>") and
+    this.getDeclaringType().getSourceDeclaration().hasQualifiedName("java.lang", "Class") and
     this.hasName("forName")
   }
 }

--- a/java/ql/src/Security/CWE/CWE-470/ReflectionBad.ql
+++ b/java/ql/src/Security/CWE/CWE-470/ReflectionBad.ql
@@ -8,6 +8,7 @@
  * @tags security
  *       external/cwe/cwe-470
  */
+
 import java
 import semmle.code.java.dataflow.FlowSources
 import DataFlow::PathGraph
@@ -15,18 +16,16 @@ import DataFlow::PathGraph
 class ClassFornameMethod extends Method {
   ClassFornameMethod() {
     this.getDeclaringType().hasQualifiedName("java.lang", "Class<>") and
-    this.hasName("forName") 
+    this.hasName("forName")
   }
 }
 
 class ArgumentToReflection extends Expr {
   ArgumentToReflection() {
     exists(MethodAccess ma, Method method |
-      ma.getArgument(0) = this and 
+      ma.getArgument(0) = this and
       method = ma.getMethod() and
-      (
-        method instanceof ClassFornameMethod
-      )
+      method instanceof ClassFornameMethod
     )
   }
 }
@@ -47,8 +46,9 @@ class UnsafeReflectionConfig extends TaintTracking::Configuration {
   }
 }
 
-
-from DataFlow::PathNode source, DataFlow::PathNode sink, UnsafeReflectionConfig conf, StringArgumentToReflection reflectionArg
+from
+  DataFlow::PathNode source, DataFlow::PathNode sink, UnsafeReflectionConfig conf,
+  StringArgumentToReflection reflectionArg
 where conf.hasFlowPath(source, sink) and sink.getNode().asExpr() = reflectionArg
 select reflectionArg, source, sink, "$@ flows to here and is used in reflection", source.getNode(),
   "User controlled value"

--- a/java/ql/src/Security/CWE/CWE-470/ReflectionBad.ql
+++ b/java/ql/src/Security/CWE/CWE-470/ReflectionBad.ql
@@ -1,0 +1,54 @@
+/**
+ * @name Unsafe reflection
+ * @description External input with reflection to select which classes to use
+ * @kind reflection
+ * @problem.severity warning
+ * @precision medium
+ * @id java/unsafe-reflection
+ * @tags security
+ *       external/cwe/cwe-470
+ */
+import java
+import semmle.code.java.dataflow.FlowSources
+import DataFlow::PathGraph
+
+class ClassFornameMethod extends Method {
+  ClassFornameMethod() {
+    this.getDeclaringType().hasQualifiedName("java.lang", "Class<>") and
+    this.hasName("forName") 
+  }
+}
+
+class ArgumentToReflection extends Expr {
+  ArgumentToReflection() {
+    exists(MethodAccess ma, Method method |
+      ma.getArgument(0) = this and 
+      method = ma.getMethod() and
+      (
+        method instanceof ClassFornameMethod
+      )
+    )
+  }
+}
+
+class StringArgumentToReflection extends ArgumentToReflection {
+  StringArgumentToReflection() { this.getType() instanceof TypeString }
+}
+
+class UnsafeReflectionConfig extends TaintTracking::Configuration {
+  UnsafeReflectionConfig() { this = "UnsafeReflectionConfig" }
+
+  override predicate isSource(DataFlow::Node source) { source instanceof LocalUserInput }
+
+  override predicate isSink(DataFlow::Node sink) { sink.asExpr() instanceof ArgumentToReflection }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    node.getType() instanceof PrimitiveType or node.getType() instanceof BoxedType
+  }
+}
+
+
+from DataFlow::PathNode source, DataFlow::PathNode sink, UnsafeReflectionConfig conf, StringArgumentToReflection reflectionArg
+where conf.hasFlowPath(source, sink) and sink.getNode().asExpr() = reflectionArg
+select reflectionArg, source, sink, "$@ flows to here and is used in reflection", source.getNode(),
+  "User controlled value"


### PR DESCRIPTION
This PR contains query for unsafe reflection in java.
Developer sometimes refactor code by using reflection. By doing so application could open up to this vulnerability. And reflection can only be used only from trusted sources such as white-listing or hard-coded string.

This query detects the following function
```
Class.forName(user_input)
```
