### PR TITLE
JavaScript: Teach `resolveMainModule` to try adding extensions.

### DIFF
--- a/javascript/ql/src/semmle/javascript/NodeModuleResolutionImpl.qll
+++ b/javascript/ql/src/semmle/javascript/NodeModuleResolutionImpl.qll
@@ -84,10 +84,16 @@ File tryExtensions(Folder dir, string basename, int priority) {
 File resolveMainModule(PackageJSON pkg, int priority) {
   if exists(MainModulePath::of(pkg))
   then
-    exists(Container c | c = MainModulePath::of(pkg).resolve() |
-      result = c and priority = 0
+    exists(PathExpr main | main = MainModulePath::of(pkg) |
+      result = main.resolve() and priority = 0
       or
-      result = tryExtensions(c, "index", priority)
+      result = tryExtensions(main.resolve(), "index", priority)
+      or
+      not exists(main.resolve()) and
+      not exists(main.getExtension()) and
+      exists(int n | n = main.getNumComponent() |
+        result = tryExtensions(main.resolveUpTo(n-1), main.getComponent(n-1), priority)
+      )
     )
   else result = tryExtensions(pkg.getFile().getParentContainer(), "index", priority)
 }

--- a/javascript/ql/test/library-tests/NPM/Modules.expected
+++ b/javascript/ql/test/library-tests/NPM/Modules.expected
@@ -1,6 +1,7 @@
 | b | src/node_modules/b/lib/index.js:1:1:2:0 | <toplevel> |
 | b | src/node_modules/b/lib/index.ts:1:1:2:0 | <toplevel> |
 | c | src/node_modules/c/src/index.js:1:1:2:0 | <toplevel> |
+| d | src/node_modules/d/main.js:1:1:2:0 | <toplevel> |
 | test-package | src/index.js:1:1:4:0 | <toplevel> |
 | test-package | src/lib/tst2.js:1:1:1:14 | <toplevel> |
 | test-package | src/lib/tst.js:1:1:4:0 | <toplevel> |

--- a/javascript/ql/test/library-tests/NPM/NPMPackage_getMainModule.expected
+++ b/javascript/ql/test/library-tests/NPM/NPMPackage_getMainModule.expected
@@ -1,4 +1,5 @@
 | b | src/node_modules/b/lib/index.ts:1:1:2:0 | <toplevel> |
 | c | src/node_modules/c/src/index.js:1:1:2:0 | <toplevel> |
+| d | src/node_modules/d/main.js:1:1:2:0 | <toplevel> |
 | test-package | src/index.js:1:1:4:0 | <toplevel> |
 | third-party-module | src/node_modules/third-party-module/fancy.js:1:1:4:0 | <toplevel> |

--- a/javascript/ql/test/library-tests/NPM/PackageJSON.expected
+++ b/javascript/ql/test/library-tests/NPM/PackageJSON.expected
@@ -1,4 +1,5 @@
 | src/node_modules/b/package.json:1:1:4:1 | {\\n  "na ... "lib"\\n} |
 | src/node_modules/c/package.json:1:1:4:1 | {\\n  "na ... src/"\\n} |
+| src/node_modules/d/package.json:1:1:4:1 | {\\n  "na ... main"\\n} |
 | src/node_modules/third-party-module/package.json:1:1:5:1 | {\\n  "na ... y.js"\\n} |
 | src/package.json:1:1:18:1 | {\\n  "na ... "\\n  }\\n} |

--- a/javascript/ql/test/library-tests/NPM/src/node_modules/d/main.js
+++ b/javascript/ql/test/library-tests/NPM/src/node_modules/d/main.js
@@ -1,0 +1,1 @@
+export default "d";

--- a/javascript/ql/test/library-tests/NPM/src/node_modules/d/package.json
+++ b/javascript/ql/test/library-tests/NPM/src/node_modules/d/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "d",
+  "main": "main"
+}


### PR DESCRIPTION
If a `package.json` [leaves off](https://github.com/tj/commander.js/blob/master/package.json#L22) the extension of its main module, we previously weren't able to find it.

An [evaluation](https://git.semmle.com/max/dist-compare-reports/blob/master/js/resolveMainModule-extensions/report.md) on big-apps.slugs suggests a slight slowdown overall, but nothing dramatic, and I suspect it may not be real anyway: `A2Z-F15` showed a 6% slowdown first, which turned into a 3% speedup on rerunning, so it may just have been worker load. Should have run with DPMs.

I doubt this affects many queries, so I didn't include a change note, but I'm happy to be convinced otherwise.