### PR TITLE
JS: Bump extractor version string

### DIFF
--- a/javascript/extractor/src/com/semmle/js/extractor/Main.java
+++ b/javascript/extractor/src/com/semmle/js/extractor/Main.java
@@ -37,7 +37,7 @@ public class Main {
    * A version identifier that should be updated every time the extractor changes in such a way that
    * it may produce different tuples for the same file under the same {@link ExtractorConfig}.
    */
-  public static final String EXTRACTOR_VERSION = "2020-01-06";
+  public static final String EXTRACTOR_VERSION = "2020-02-05";
 
   public static final Pattern NEWLINE = Pattern.compile("\n");
 


### PR DESCRIPTION
Looks like we forgot to bump the extractor version string in https://github.com/Semmle/ql/pull/2715.