### PR TITLE
JS: update expected output of TaintedPath tests

### DIFF
--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/Consistency.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/Consistency.expected
@@ -1,6 +1,3 @@
 | normalizedPaths.js:208:38:208:63 | // OK - ...  anyway | Spurious alert |
-| tainted-string-steps.js:13:41:13:72 | // NOT  ... flagged | Missing alert |
-| tainted-string-steps.js:14:41:14:72 | // NOT  ... flagged | Missing alert |
-| tainted-string-steps.js:15:50:15:81 | // NOT  ... flagged | Missing alert |
 | tainted-string-steps.js:25:43:25:74 | // NOT  ... flagged | Missing alert |
 | tainted-string-steps.js:26:49:26:74 | // OK - ... flagged | Spurious alert |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -1412,6 +1412,73 @@ nodes
 | tainted-string-steps.js:11:18:11:30 | path.slice(4) |
 | tainted-string-steps.js:11:18:11:30 | path.slice(4) |
 | tainted-string-steps.js:11:18:11:30 | path.slice(4) |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:15:42:15:45 | path |
 | tainted-string-steps.js:17:18:17:21 | path |
 | tainted-string-steps.js:17:18:17:21 | path |
 | tainted-string-steps.js:17:18:17:21 | path |
@@ -3456,6 +3523,46 @@ edges
 | tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:11:18:11:21 | path |
 | tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:11:18:11:21 | path |
 | tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:11:18:11:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:13:18:13:21 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:14:33:14:36 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:15:42:15:45 | path |
+| tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:15:42:15:45 | path |
 | tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:17:18:17:21 | path |
 | tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:17:18:17:21 | path |
 | tainted-string-steps.js:6:7:6:48 | path | tainted-string-steps.js:17:18:17:21 | path |
@@ -3744,6 +3851,86 @@ edges
 | tainted-string-steps.js:11:18:11:21 | path | tainted-string-steps.js:11:18:11:30 | path.slice(4) |
 | tainted-string-steps.js:11:18:11:21 | path | tainted-string-steps.js:11:18:11:30 | path.slice(4) |
 | tainted-string-steps.js:11:18:11:21 | path | tainted-string-steps.js:11:18:11:30 | path.slice(4) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:13:18:13:21 | path | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:14:33:14:36 | path | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
+| tainted-string-steps.js:15:42:15:45 | path | tainted-string-steps.js:15:18:15:46 | unknown ... , path) |
 | tainted-string-steps.js:17:18:17:21 | path | tainted-string-steps.js:17:18:17:28 | path.trim() |
 | tainted-string-steps.js:17:18:17:21 | path | tainted-string-steps.js:17:18:17:28 | path.trim() |
 | tainted-string-steps.js:17:18:17:21 | path | tainted-string-steps.js:17:18:17:28 | path.trim() |
@@ -4035,6 +4222,9 @@ edges
 | tainted-string-steps.js:9:18:9:37 | path.substring(0, i) | tainted-string-steps.js:6:24:6:30 | req.url | tainted-string-steps.js:9:18:9:37 | path.substring(0, i) | This path depends on $@. | tainted-string-steps.js:6:24:6:30 | req.url | a user-provided value |
 | tainted-string-steps.js:10:18:10:31 | path.substr(4) | tainted-string-steps.js:6:24:6:30 | req.url | tainted-string-steps.js:10:18:10:31 | path.substr(4) | This path depends on $@. | tainted-string-steps.js:6:24:6:30 | req.url | a user-provided value |
 | tainted-string-steps.js:11:18:11:30 | path.slice(4) | tainted-string-steps.js:6:24:6:30 | req.url | tainted-string-steps.js:11:18:11:30 | path.slice(4) | This path depends on $@. | tainted-string-steps.js:6:24:6:30 | req.url | a user-provided value |
+| tainted-string-steps.js:13:18:13:37 | path.concat(unknown) | tainted-string-steps.js:6:24:6:30 | req.url | tainted-string-steps.js:13:18:13:37 | path.concat(unknown) | This path depends on $@. | tainted-string-steps.js:6:24:6:30 | req.url | a user-provided value |
+| tainted-string-steps.js:14:18:14:37 | unknown.concat(path) | tainted-string-steps.js:6:24:6:30 | req.url | tainted-string-steps.js:14:18:14:37 | unknown.concat(path) | This path depends on $@. | tainted-string-steps.js:6:24:6:30 | req.url | a user-provided value |
+| tainted-string-steps.js:15:18:15:46 | unknown ... , path) | tainted-string-steps.js:6:24:6:30 | req.url | tainted-string-steps.js:15:18:15:46 | unknown ... , path) | This path depends on $@. | tainted-string-steps.js:6:24:6:30 | req.url | a user-provided value |
 | tainted-string-steps.js:17:18:17:28 | path.trim() | tainted-string-steps.js:6:24:6:30 | req.url | tainted-string-steps.js:17:18:17:28 | path.trim() | This path depends on $@. | tainted-string-steps.js:6:24:6:30 | req.url | a user-provided value |
 | tainted-string-steps.js:18:18:18:35 | path.toLowerCase() | tainted-string-steps.js:6:24:6:30 | req.url | tainted-string-steps.js:18:18:18:35 | path.toLowerCase() | This path depends on $@. | tainted-string-steps.js:6:24:6:30 | req.url | a user-provided value |
 | tainted-string-steps.js:24:18:24:35 | path.split("?")[0] | tainted-string-steps.js:6:24:6:30 | req.url | tainted-string-steps.js:24:18:24:35 | path.split("?")[0] | This path depends on $@. | tainted-string-steps.js:6:24:6:30 | req.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/tainted-string-steps.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/tainted-string-steps.js
@@ -10,9 +10,9 @@ var server = http.createServer(function(req, res) {
 	fs.readFileSync(path.substr(4)); // NOT OK
 	fs.readFileSync(path.slice(4)); // NOT OK
 
-	fs.readFileSync(path.concat(unknown)); // NOT OK -- but not yet flagged
-	fs.readFileSync(unknown.concat(path)); // NOT OK -- but not yet flagged
-	fs.readFileSync(unknown.concat(unknown, path)); // NOT OK -- but not yet flagged
+	fs.readFileSync(path.concat(unknown)); // NOT OK
+	fs.readFileSync(unknown.concat(path)); // NOT OK
+	fs.readFileSync(unknown.concat(unknown, path)); // NOT OK
 
 	fs.readFileSync(path.trim()); // NOT OK
 	fs.readFileSync(path.toLowerCase()); // NOT OK


### PR DESCRIPTION
The combination of merging https://github.com/Semmle/ql/pull/2758 and https://github.com/Semmle/ql/pull/2741 yesterday has caused some TaintedPath tests to fail.

(That is what is causing the CI to fail here: https://github.com/Semmle/ql/pull/2770) 

This PR updates the expected output of those tests.