### PR TITLE
JS: Handle 'export * as ns'

### DIFF
--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -9,6 +9,8 @@
 
 * Imports that rely on path-mappings from a `tsconfig.json` file can now be resolved.
 
+* Export declarations of the form `export * as ns from "x"` are now analyzed more precisely.
+
 * The analysis of sanitizer guards has improved, leading to fewer false-positive results from the security queries.
 
 * Support for the following frameworks and libraries has been improved:

--- a/javascript/ql/src/definitions.ql
+++ b/javascript/ql/src/definitions.ql
@@ -78,7 +78,7 @@ predicate importLookup(ASTNode path, Module target, string kind) {
     or
     exists(ReExportDeclaration red |
       path = red.getImportedPath() and
-      target = red.getImportedModule()
+      target = red.getReExportedModule()
     )
   )
 }

--- a/javascript/ql/src/semmle/javascript/ES2015Modules.qll
+++ b/javascript/ql/src/semmle/javascript/ES2015Modules.qll
@@ -273,12 +273,12 @@ class BulkReExportDeclaration extends ReExportDeclaration, @exportalldeclaration
   override ConstantString getImportedPath() { result = getChildExpr(0) }
 
   override predicate exportsAs(LexicalName v, string name) {
-    getImportedModule().exportsAs(v, name) and
+    getReExportedES2015Module().exportsAs(v, name) and
     not isShadowedFromBulkExport(this, name)
   }
 
   override DataFlow::Node getSourceNode(string name) {
-    result = getImportedModule().getAnExport().getSourceNode(name)
+    result = getReExportedES2015Module().getAnExport().getSourceNode(name)
   }
 }
 
@@ -379,7 +379,7 @@ class ExportNamedDeclaration extends ExportDeclaration, @exportnameddeclaration 
     exists(ExportSpecifier spec | spec = getASpecifier() and name = spec.getExportedName() |
       v = spec.getLocal().(LexicalAccess).getALexicalName()
       or
-      this.(ReExportDeclaration).getImportedModule().exportsAs(v, spec.getLocalName())
+      this.(ReExportDeclaration).getReExportedES2015Module().exportsAs(v, spec.getLocalName())
     )
   }
 
@@ -393,7 +393,7 @@ class ExportNamedDeclaration extends ExportDeclaration, @exportnameddeclaration 
       not exists(getImportedPath()) and result = DataFlow::valueNode(spec.getLocal())
       or
       exists(ReExportDeclaration red | red = this |
-        result = red.getImportedModule().getAnExport().getSourceNode(spec.getLocalName())
+        result = red.getReExportedES2015Module().getAnExport().getSourceNode(spec.getLocalName())
       )
     )
   }
@@ -572,8 +572,23 @@ abstract class ReExportDeclaration extends ExportDeclaration {
   /** Gets the path of the module from which this declaration re-exports. */
   abstract ConstantString getImportedPath();
 
-  /** Gets the module from which this declaration re-exports. */
+  /**
+   * DEPRECATED. Use `getReExportedES2015Module()` instead.
+   *
+   * Gets the module from which this declaration re-exports.
+   */
+  deprecated
   ES2015Module getImportedModule() {
+    result = getReExportedModule()
+  }
+
+  /** Gets the module from which this declaration re-exports, if it is an ES2015 module. */
+  ES2015Module getReExportedES2015Module() {
+    result = getReExportedModule()
+  }
+
+  /** Gets the module from which this declaration re-exports. */
+  Module getReExportedModule() {
     result.getFile() = getEnclosingModule().resolve(getImportedPath().(PathExpr))
     or
     result = resolveFromTypeRoot()

--- a/javascript/ql/src/semmle/javascript/ES2015Modules.qll
+++ b/javascript/ql/src/semmle/javascript/ES2015Modules.qll
@@ -545,13 +545,17 @@ class ReExportDefaultSpecifier extends ExportDefaultSpecifier {
 }
 
 /**
- * A namespace export specifier.
+ * A namespace export specifier, that is `*` or `* as x` occuring in an export declaration.
  *
- * Example:
+ * Examples:
  *
  * ```
  * export
  *   *          // namespace export specifier
+ *   from 'a';
+ *
+ * export
+ *   * as x     // namespace export specifier
  *   from 'a';
  * ```
  */
@@ -564,6 +568,7 @@ class ExportNamespaceSpecifier extends ExportSpecifier, @exportnamespacespecifie
  *
  * ```
  * export * from 'a';               // bulk re-export declaration
+ * export * as x from 'a';          // namespace re-export declaration
  * export { x } from 'a';           // named re-export declaration
  * export x from 'a';               // default re-export declaration
  * ```

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
@@ -65,7 +65,7 @@ private predicate mayDynamicallyComputeExports(Module m) {
   or
   // `m` re-exports all exports of some other module that dynamically computes its exports
   exists(BulkReExportDeclaration rexp | rexp = m.(ES2015Module).getAnExport() |
-    mayDynamicallyComputeExports(rexp.getImportedModule())
+    mayDynamicallyComputeExports(rexp.getReExportedModule())
   )
 }
 
@@ -79,7 +79,7 @@ private predicate relevantExport(ES2015Module m, string x) {
   )
   or
   exists(ReExportDeclaration rexp, string y |
-    rexp.getImportedModule() = m and
+    rexp.getReExportedModule() = m and
     reExportsAs(rexp, x, y)
   )
 }
@@ -110,9 +110,9 @@ private predicate incompleteExport(ES2015Module m, string y) {
       mayDependOnLookupPath(rexp.getImportedPath().getStringValue())
       or
       // unresolvable path
-      not exists(rexp.getImportedModule())
+      not exists(rexp.getReExportedModule())
       or
-      exists(Module n | n = rexp.getImportedModule() |
+      exists(Module n | n = rexp.getReExportedModule() |
         // re-export from CommonJS/AMD
         mayDynamicallyComputeExports(n)
         or

--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterModuleTypeInference.qll
@@ -399,3 +399,16 @@ private class AnalyzedClosureGlobalAccessPath extends AnalyzedNode, AnalyzedProp
     )
   }
 }
+
+/**
+ * A namespace export declaration analyzed as a property write.
+ */
+private class AnalyzedExportNamespaceSpecifier extends AnalyzedPropertyWrite, DataFlow::ValueNode {
+  override ExportNamespaceSpecifier astNode;
+
+  override predicate writesValue(AbstractValue baseVal, string propName, AbstractValue value) {
+    baseVal = TAbstractExportsObject(getTopLevel()) and
+    propName = astNode.getExportedName() and
+    value = TAbstractExportsObject(astNode.getExportDeclaration().(ReExportDeclaration).getReExportedModule())
+  }
+}

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
@@ -2,4 +2,5 @@ spuriousCallee
 missingCallee
 | constructor-field.ts:40:5:40:14 | f3.build() | constructor-field.ts:13:3:13:12 | build() {} |
 | constructor-field.ts:71:1:71:11 | bf3.build() | constructor-field.ts:13:3:13:12 | build() {} |
+| reExportLibClient.js:4:1:4:6 | ns.f() | lib.js:3:2:3:14 | function() {} |
 badAnnotation

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/Test.expected
@@ -2,5 +2,4 @@ spuriousCallee
 missingCallee
 | constructor-field.ts:40:5:40:14 | f3.build() | constructor-field.ts:13:3:13:12 | build() {} |
 | constructor-field.ts:71:1:71:11 | bf3.build() | constructor-field.ts:13:3:13:12 | build() {} |
-| reExportLibClient.js:4:1:4:6 | ns.f() | lib.js:3:2:3:14 | function() {} |
 badAnnotation

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/options
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --experimental

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/reExportLib.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/reExportLib.js
@@ -1,0 +1,1 @@
+export * as ns from "./lib";

--- a/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/reExportLibClient.js
+++ b/javascript/ql/test/library-tests/CallGraphs/AnnotatedTest/reExportLibClient.js
@@ -1,0 +1,4 @@
+import { ns } from "./reExportLib";
+
+/** calls:lib.f */
+ns.f();

--- a/javascript/ql/test/library-tests/Flow/abseval.expected
+++ b/javascript/ql/test/library-tests/Flow/abseval.expected
@@ -146,8 +146,10 @@
 | import.js:5:5:5:7 | myf | import.js:5:11:5:11 | f | n.js:1:1:1:15 | function f |
 | import.js:8:5:8:11 | someVar | import.js:8:15:8:23 | someStuff | file://:0:0:0:0 | indefinite value (call) |
 | import.js:11:5:11:6 | h1 | import.js:11:10:11:10 | h | file://:0:0:0:0 | indefinite value (import) |
+| import.js:11:5:11:6 | h1 | import.js:11:10:11:10 | h | h.js:1:1:3:0 | exports object of module h |
 | import.js:12:5:12:6 | hf | import.js:12:10:12:12 | h.f | file://:0:0:0:0 | indefinite value (heap) |
 | import.js:12:5:12:6 | hf | import.js:12:10:12:12 | h.f | file://:0:0:0:0 | indefinite value (import) |
+| import.js:12:5:12:6 | hf | import.js:12:10:12:12 | h.f | h.js:1:8:1:22 | function f |
 | imports.ts:2:5:2:6 | ax | imports.ts:2:10:2:11 | Ax | file://:0:0:0:0 | indefinite value (global) |
 | imports.ts:2:5:2:6 | ax | imports.ts:2:10:2:11 | Ax | file://:0:0:0:0 | indefinite value (heap) |
 | imports.ts:5:5:5:7 | fs_ | imports.ts:5:11:5:12 | fs | file://:0:0:0:0 | indefinite value (import) |

--- a/javascript/ql/test/library-tests/Modules/BulkReExportDeclarations.qll
+++ b/javascript/ql/test/library-tests/Modules/BulkReExportDeclarations.qll
@@ -1,3 +1,0 @@
-import semmle.javascript.ES2015Modules
-
-query predicate test_BulkReExportDeclarations(BulkReExportDeclaration bred) { any() }

--- a/javascript/ql/test/library-tests/Modules/ExportDeclarations.qll
+++ b/javascript/ql/test/library-tests/Modules/ExportDeclarations.qll
@@ -1,3 +1,0 @@
-import semmle.javascript.ES2015Modules
-
-query predicate test_ExportDeclarations(ExportDeclaration ed) { any() }

--- a/javascript/ql/test/library-tests/Modules/ExportDefaultDeclarations.qll
+++ b/javascript/ql/test/library-tests/Modules/ExportDefaultDeclarations.qll
@@ -1,3 +1,0 @@
-import semmle.javascript.ES2015Modules
-
-query predicate test_ExportDefaultDeclarations(ExportDefaultDeclaration edd) { any() }

--- a/javascript/ql/test/library-tests/Modules/ExportSpecifiers.qll
+++ b/javascript/ql/test/library-tests/Modules/ExportSpecifiers.qll
@@ -1,5 +1,0 @@
-import semmle.javascript.ES2015Modules
-
-query predicate test_ExportSpecifiers(ExportSpecifier es, Identifier res0, Identifier res1) {
-  res0 = es.getLocal() and res1 = es.getExported()
-}

--- a/javascript/ql/test/library-tests/Modules/GlobalVariableRef.qll
+++ b/javascript/ql/test/library-tests/Modules/GlobalVariableRef.qll
@@ -1,5 +1,0 @@
-import javascript
-
-query predicate test_GlobalVariableRef(VarAccess access) {
-  access.getVariable() instanceof GlobalVariable
-}

--- a/javascript/ql/test/library-tests/Modules/ImportDefaultSpecifiers.qll
+++ b/javascript/ql/test/library-tests/Modules/ImportDefaultSpecifiers.qll
@@ -1,3 +1,0 @@
-import semmle.javascript.ES2015Modules
-
-query predicate test_ImportDefaultSpecifiers(ImportDefaultSpecifier ids) { any() }

--- a/javascript/ql/test/library-tests/Modules/ImportMeta.qll
+++ b/javascript/ql/test/library-tests/Modules/ImportMeta.qll
@@ -1,5 +1,0 @@
-import semmle.javascript.ES2015Modules
-
-query predicate test_ImportMetaExpr(ImportMetaExpr meta) {
-  any()
-}

--- a/javascript/ql/test/library-tests/Modules/ImportNamespaceSpecifier.qll
+++ b/javascript/ql/test/library-tests/Modules/ImportNamespaceSpecifier.qll
@@ -1,3 +1,0 @@
-import semmle.javascript.ES2015Modules
-
-query predicate test_ImportNamespaceSpecifier(ImportNamespaceSpecifier ins) { any() }

--- a/javascript/ql/test/library-tests/Modules/ImportSpecifiers.qll
+++ b/javascript/ql/test/library-tests/Modules/ImportSpecifiers.qll
@@ -1,3 +1,0 @@
-import semmle.javascript.ES2015Modules
-
-query predicate test_ImportSpecifiers(ImportSpecifier is, VarDecl res) { res = is.getLocal() }

--- a/javascript/ql/test/library-tests/Modules/Imports.qll
+++ b/javascript/ql/test/library-tests/Modules/Imports.qll
@@ -1,5 +1,0 @@
-import semmle.javascript.ES2015Modules
-
-query predicate test_Imports(ImportDeclaration id, PathExprInModule res0, int res1) {
-  res0 = id.getImportedPath() and res1 = count(id.getASpecifier())
-}

--- a/javascript/ql/test/library-tests/Modules/Module_exports.qll
+++ b/javascript/ql/test/library-tests/Modules/Module_exports.qll
@@ -1,5 +1,0 @@
-import javascript
-
-query predicate test_Module_exports(Module m, string name, ASTNode export) {
-  m.exports(name, export)
-}

--- a/javascript/ql/test/library-tests/Modules/NamedImportSpecifier.qll
+++ b/javascript/ql/test/library-tests/Modules/NamedImportSpecifier.qll
@@ -1,3 +1,0 @@
-import semmle.javascript.ES2015Modules
-
-query predicate test_NamedImportSpecifier(NamedImportSpecifier nis) { any() }

--- a/javascript/ql/test/library-tests/Modules/OtherImports.qll
+++ b/javascript/ql/test/library-tests/Modules/OtherImports.qll
@@ -1,5 +1,0 @@
-import javascript
-
-query predicate test_OtherImports(Import imprt, Module res) {
-  not imprt instanceof ImportDeclaration and res = imprt.getImportedModule()
-}

--- a/javascript/ql/test/library-tests/Modules/ReExportDeclarations.qll
+++ b/javascript/ql/test/library-tests/Modules/ReExportDeclarations.qll
@@ -1,5 +1,0 @@
-import semmle.javascript.ES2015Modules
-
-query predicate test_ReExportDeclarations(ReExportDeclaration red, ConstantString res) {
-  res = red.getImportedPath()
-}

--- a/javascript/ql/test/library-tests/Modules/getAnImportedModule.qll
+++ b/javascript/ql/test/library-tests/Modules/getAnImportedModule.qll
@@ -1,8 +1,0 @@
-import javascript
-
-query predicate test_getAnImportedModule(string res0, string res1) {
-  exists(Module mod |
-    res0 = mod.getFile().getRelativePath() and
-    res1 = mod.getAnImportedModule().getFile().getRelativePath()
-  )
-}

--- a/javascript/ql/test/library-tests/Modules/getExportedName.qll
+++ b/javascript/ql/test/library-tests/Modules/getExportedName.qll
@@ -1,3 +1,3 @@
 import javascript
 
-query predicate test_getExportedName(ExportSpecifier es, string res) { res = es.getLocalName() }
+query predicate test_getExportedName(ExportSpecifier es, string res) { res = es.getExportedName() }

--- a/javascript/ql/test/library-tests/Modules/getExportedName.qll
+++ b/javascript/ql/test/library-tests/Modules/getExportedName.qll
@@ -1,3 +1,0 @@
-import javascript
-
-query predicate test_getExportedName(ExportSpecifier es, string res) { res = es.getExportedName() }

--- a/javascript/ql/test/library-tests/Modules/getImportedName.qll
+++ b/javascript/ql/test/library-tests/Modules/getImportedName.qll
@@ -1,3 +1,0 @@
-import javascript
-
-query predicate test_getImportedName(ImportSpecifier is, string res) { res = is.getImportedName() }

--- a/javascript/ql/test/library-tests/Modules/getLocalName.qll
+++ b/javascript/ql/test/library-tests/Modules/getLocalName.qll
@@ -1,3 +1,0 @@
-import javascript
-
-query predicate test_getLocalName(ExportSpecifier es, string res) { res = es.getLocalName() }

--- a/javascript/ql/test/library-tests/Modules/getSourceNode.qll
+++ b/javascript/ql/test/library-tests/Modules/getSourceNode.qll
@@ -1,5 +1,0 @@
-import javascript
-
-query predicate test_getSourceNode(ExportDeclaration ed, string name, DataFlow::Node res) {
-  res = ed.getSourceNode(name)
-}

--- a/javascript/ql/test/library-tests/Modules/reExportNamespace.js
+++ b/javascript/ql/test/library-tests/Modules/reExportNamespace.js
@@ -1,0 +1,1 @@
+export * as ns from "./a";

--- a/javascript/ql/test/library-tests/Modules/reExportNamespaceClient.js
+++ b/javascript/ql/test/library-tests/Modules/reExportNamespaceClient.js
@@ -1,0 +1,3 @@
+import { ns } from "./reExportNamespace";
+
+ns.x(); // Calls f() from a.js

--- a/javascript/ql/test/library-tests/Modules/tests.expected
+++ b/javascript/ql/test/library-tests/Modules/tests.expected
@@ -1,57 +1,5 @@
-test_ImportSpecifiers
-| b.js:1:8:1:8 | f | b.js:1:8:1:8 | f |
-| d.js:1:10:1:21 | default as g | d.js:1:21:1:21 | g |
-| d.js:1:24:1:29 | x as y | d.js:1:29:1:29 | y |
-| exports.js:1:8:1:17 | * as dummy | exports.js:1:13:1:17 | dummy |
-| f.ts:1:8:1:8 | g | f.ts:1:8:1:8 | g |
-| g.ts:1:9:1:11 | foo | g.ts:1:9:1:11 | foo |
-| import-in-mjs.mjs:1:8:1:24 | exported_from_mjs | import-in-mjs.mjs:1:8:1:24 | exported_from_mjs |
-| import-ts-with-js-extension.ts:1:10:1:12 | foo | import-ts-with-js-extension.ts:1:10:1:12 | foo |
-| importcss.js:1:8:1:8 | A | importcss.js:1:8:1:8 | A |
-| m/c.js:1:8:1:13 | * as b | m/c.js:1:13:1:13 | b |
-| tst.html:5:10:5:10 | f | tst.html:5:10:5:10 | f |
-| unresolved.js:1:8:1:8 | f | unresolved.js:1:8:1:8 | f |
-test_getLocalName
-| b.js:5:10:5:15 | f as g | f |
-| b.js:7:8:7:9 | f2 | default |
-| e.js:2:10:2:10 | x | x |
-| e.js:2:13:2:13 | y | y |
-| e.js:3:10:3:21 | default as g | default |
-| m/c.js:5:10:5:15 | g as h | g |
-test_getExportedName
-| b.js:5:10:5:15 | f as g | g |
-| b.js:7:8:7:9 | f2 | f2 |
-| e.js:2:10:2:10 | x | x |
-| e.js:2:13:2:13 | y | y |
-| e.js:3:10:3:21 | default as g | g |
-| m/c.js:5:10:5:15 | g as h | h |
-test_OtherImports
-| es2015_require.js:1:11:1:24 | require('./d') | d.js:1:1:5:0 | <toplevel> |
-test_ImportMetaExpr
-| importmeta.js:1:33:1:43 | import.meta |
-test_ReExportDeclarations
-| b.js:7:1:7:21 | export  ...  './a'; | b.js:7:16:7:20 | './a' |
-| d.js:4:1:4:20 | export * from 'm/c'; | d.js:4:15:4:19 | 'm/c' |
-| e.js:3:1:3:35 | export  ...  './a'; | e.js:3:30:3:34 | './a' |
-| m/c.js:5:1:5:30 | export  ... '../b'; | m/c.js:5:24:5:29 | '../b' |
-test_ImportDefaultSpecifiers
-| b.js:1:8:1:8 | f |
-| f.ts:1:8:1:8 | g |
-| import-in-mjs.mjs:1:8:1:24 | exported_from_mjs |
-| importcss.js:1:8:1:8 | A |
-| tst.html:5:10:5:10 | f |
-| unresolved.js:1:8:1:8 | f |
-test_getImportedName
-| b.js:1:8:1:8 | f | default |
-| d.js:1:10:1:21 | default as g | default |
-| d.js:1:24:1:29 | x as y | x |
-| f.ts:1:8:1:8 | g | default |
-| g.ts:1:9:1:11 | foo | foo |
-| import-in-mjs.mjs:1:8:1:24 | exported_from_mjs | default |
-| import-ts-with-js-extension.ts:1:10:1:12 | foo | foo |
-| importcss.js:1:8:1:8 | A | default |
-| tst.html:5:10:5:10 | f | default |
-| unresolved.js:1:8:1:8 | f | default |
+test_BulkReExportDeclarations
+| d.js:4:1:4:20 | export * from 'm/c'; |
 test_ExportDeclarations
 | a.js:1:1:3:1 | export  ... n 23;\\n} |
 | a.js:5:1:5:32 | export  ...  } = o; |
@@ -65,28 +13,45 @@ test_ExportDeclarations
 | f.ts:5:1:5:24 | export  ... oo() {} |
 | m/c.js:5:1:5:30 | export  ... '../b'; |
 | tst.html:7:3:7:22 | export const y = 42; |
-test_getAnImportedModule
-| library-tests/Modules/b.js | library-tests/Modules/a.js |
-| library-tests/Modules/d.js | library-tests/Modules/a.js |
-| library-tests/Modules/d.js | library-tests/Modules/b.js |
-| library-tests/Modules/es2015_require.js | library-tests/Modules/d.js |
-| library-tests/Modules/f.ts | library-tests/Modules/e.js |
-| library-tests/Modules/g.ts | library-tests/Modules/f.ts |
-| library-tests/Modules/import-ts-with-js-extension.ts | library-tests/Modules/f.ts |
-| library-tests/Modules/m/c.js | library-tests/Modules/b.js |
-test_getSourceNode
-| a.js:1:1:3:1 | export  ... n 23;\\n} | default | a.js:1:16:3:1 | functio ... n 23;\\n} |
-| a.js:5:1:5:32 | export  ...  } = o; | x | a.js:5:18:5:20 | f() |
-| b.js:5:1:5:18 | export { f as g }; | g | b.js:5:10:5:10 | f |
-| b.js:7:1:7:21 | export  ...  './a'; | f2 | a.js:1:16:3:1 | functio ... n 23;\\n} |
-| e.js:2:1:2:16 | export { x, y }; | x | e.js:2:10:2:10 | x |
-| e.js:2:1:2:16 | export { x, y }; | y | e.js:2:13:2:13 | y |
-| e.js:3:1:3:35 | export  ...  './a'; | g | a.js:1:16:3:1 | functio ... n 23;\\n} |
-| es2015_require.js:3:1:3:25 | export  ... ss C {} | default | es2015_require.js:3:16:3:25 | class C {} |
-| export-in-mjs.mjs:1:1:1:34 | export  ... s = 42; | exported_from_mjs | export-in-mjs.mjs:1:32:1:33 | 42 |
-| f.ts:5:1:5:24 | export  ... oo() {} | foo | f.ts:5:8:5:24 | function foo() {} |
-| m/c.js:5:1:5:30 | export  ... '../b'; | h | b.js:5:10:5:10 | f |
-| tst.html:7:3:7:22 | export const y = 42; | y | tst.html:7:20:7:21 | 42 |
+test_ExportDefaultDeclarations
+| a.js:1:1:3:1 | export  ... n 23;\\n} |
+| es2015_require.js:3:1:3:25 | export  ... ss C {} |
+test_ExportSpecifiers
+| b.js:5:10:5:15 | f as g | b.js:5:10:5:10 | f | b.js:5:15:5:15 | g |
+| e.js:2:10:2:10 | x | e.js:2:10:2:10 | x | e.js:2:10:2:10 | x |
+| e.js:2:13:2:13 | y | e.js:2:13:2:13 | y | e.js:2:13:2:13 | y |
+| e.js:3:10:3:21 | default as g | e.js:3:10:3:16 | default | e.js:3:21:3:21 | g |
+| m/c.js:5:10:5:15 | g as h | m/c.js:5:10:5:10 | g | m/c.js:5:15:5:15 | h |
+test_GlobalVariableRef
+| a.js:5:31:5:31 | o |
+| exports.js:3:9:3:15 | exports |
+| importmeta.js:1:15:1:17 | URL |
+| tst.html:6:3:6:7 | alert |
+test_ImportDefaultSpecifiers
+| b.js:1:8:1:8 | f |
+| f.ts:1:8:1:8 | g |
+| import-in-mjs.mjs:1:8:1:24 | exported_from_mjs |
+| importcss.js:1:8:1:8 | A |
+| tst.html:5:10:5:10 | f |
+| unresolved.js:1:8:1:8 | f |
+test_ImportMetaExpr
+| importmeta.js:1:33:1:43 | import.meta |
+test_ImportNamespaceSpecifier
+| exports.js:1:8:1:17 | * as dummy |
+| m/c.js:1:8:1:13 | * as b |
+test_ImportSpecifiers
+| b.js:1:8:1:8 | f | b.js:1:8:1:8 | f |
+| d.js:1:10:1:21 | default as g | d.js:1:21:1:21 | g |
+| d.js:1:24:1:29 | x as y | d.js:1:29:1:29 | y |
+| exports.js:1:8:1:17 | * as dummy | exports.js:1:13:1:17 | dummy |
+| f.ts:1:8:1:8 | g | f.ts:1:8:1:8 | g |
+| g.ts:1:9:1:11 | foo | g.ts:1:9:1:11 | foo |
+| import-in-mjs.mjs:1:8:1:24 | exported_from_mjs | import-in-mjs.mjs:1:8:1:24 | exported_from_mjs |
+| import-ts-with-js-extension.ts:1:10:1:12 | foo | import-ts-with-js-extension.ts:1:10:1:12 | foo |
+| importcss.js:1:8:1:8 | A | importcss.js:1:8:1:8 | A |
+| m/c.js:1:8:1:13 | * as b | m/c.js:1:13:1:13 | b |
+| tst.html:5:10:5:10 | f | tst.html:5:10:5:10 | f |
+| unresolved.js:1:8:1:8 | f | unresolved.js:1:8:1:8 | f |
 test_Imports
 | b.js:1:1:1:20 | import f from './a'; | b.js:1:15:1:19 | './a' | 1 |
 | d.js:1:1:1:43 | import  ...  './a'; | d.js:1:38:1:42 | './a' | 2 |
@@ -100,18 +65,6 @@ test_Imports
 | m/c.js:1:1:1:26 | import  ... '../b'; | m/c.js:1:20:1:25 | '../b' | 1 |
 | tst.html:5:3:5:20 | import f from 'a'; | tst.html:5:17:5:19 | 'a' | 1 |
 | unresolved.js:1:1:1:18 | import f from 'a'; | unresolved.js:1:15:1:17 | 'a' | 1 |
-test_NamedImportSpecifier
-| d.js:1:10:1:21 | default as g |
-| d.js:1:24:1:29 | x as y |
-| g.ts:1:9:1:11 | foo |
-| import-ts-with-js-extension.ts:1:10:1:12 | foo |
-test_GlobalVariableRef
-| a.js:5:31:5:31 | o |
-| exports.js:3:9:3:15 | exports |
-| importmeta.js:1:15:1:17 | URL |
-| tst.html:6:3:6:7 | alert |
-test_BulkReExportDeclarations
-| d.js:4:1:4:20 | export * from 'm/c'; |
 test_Module_exports
 | a.js:1:1:5:32 | <toplevel> | default | a.js:1:1:3:1 | export  ... n 23;\\n} |
 | a.js:1:1:5:32 | <toplevel> | x | a.js:5:1:5:32 | export  ...  } = o; |
@@ -126,15 +79,62 @@ test_Module_exports
 | f.ts:1:1:6:0 | <toplevel> | foo | f.ts:5:1:5:24 | export  ... oo() {} |
 | m/c.js:1:1:6:0 | <toplevel> | h | m/c.js:5:1:5:30 | export  ... '../b'; |
 | tst.html:4:23:8:0 | <toplevel> | y | tst.html:7:3:7:22 | export const y = 42; |
-test_ExportDefaultDeclarations
-| a.js:1:1:3:1 | export  ... n 23;\\n} |
-| es2015_require.js:3:1:3:25 | export  ... ss C {} |
-test_ExportSpecifiers
-| b.js:5:10:5:15 | f as g | b.js:5:10:5:10 | f | b.js:5:15:5:15 | g |
-| e.js:2:10:2:10 | x | e.js:2:10:2:10 | x | e.js:2:10:2:10 | x |
-| e.js:2:13:2:13 | y | e.js:2:13:2:13 | y | e.js:2:13:2:13 | y |
-| e.js:3:10:3:21 | default as g | e.js:3:10:3:16 | default | e.js:3:21:3:21 | g |
-| m/c.js:5:10:5:15 | g as h | m/c.js:5:10:5:10 | g | m/c.js:5:15:5:15 | h |
-test_ImportNamespaceSpecifier
-| exports.js:1:8:1:17 | * as dummy |
-| m/c.js:1:8:1:13 | * as b |
+test_NamedImportSpecifier
+| d.js:1:10:1:21 | default as g |
+| d.js:1:24:1:29 | x as y |
+| g.ts:1:9:1:11 | foo |
+| import-ts-with-js-extension.ts:1:10:1:12 | foo |
+test_OtherImports
+| es2015_require.js:1:11:1:24 | require('./d') | d.js:1:1:5:0 | <toplevel> |
+test_ReExportDeclarations
+| b.js:7:1:7:21 | export  ...  './a'; | b.js:7:16:7:20 | './a' |
+| d.js:4:1:4:20 | export * from 'm/c'; | d.js:4:15:4:19 | 'm/c' |
+| e.js:3:1:3:35 | export  ...  './a'; | e.js:3:30:3:34 | './a' |
+| m/c.js:5:1:5:30 | export  ... '../b'; | m/c.js:5:24:5:29 | '../b' |
+test_getAnImportedModule
+| library-tests/Modules/b.js | library-tests/Modules/a.js |
+| library-tests/Modules/d.js | library-tests/Modules/a.js |
+| library-tests/Modules/d.js | library-tests/Modules/b.js |
+| library-tests/Modules/es2015_require.js | library-tests/Modules/d.js |
+| library-tests/Modules/f.ts | library-tests/Modules/e.js |
+| library-tests/Modules/g.ts | library-tests/Modules/f.ts |
+| library-tests/Modules/import-ts-with-js-extension.ts | library-tests/Modules/f.ts |
+| library-tests/Modules/m/c.js | library-tests/Modules/b.js |
+test_getExportedName
+| b.js:5:10:5:15 | f as g | g |
+| b.js:7:8:7:9 | f2 | f2 |
+| e.js:2:10:2:10 | x | x |
+| e.js:2:13:2:13 | y | y |
+| e.js:3:10:3:21 | default as g | g |
+| m/c.js:5:10:5:15 | g as h | h |
+test_getImportedName
+| b.js:1:8:1:8 | f | default |
+| d.js:1:10:1:21 | default as g | default |
+| d.js:1:24:1:29 | x as y | x |
+| f.ts:1:8:1:8 | g | default |
+| g.ts:1:9:1:11 | foo | foo |
+| import-in-mjs.mjs:1:8:1:24 | exported_from_mjs | default |
+| import-ts-with-js-extension.ts:1:10:1:12 | foo | foo |
+| importcss.js:1:8:1:8 | A | default |
+| tst.html:5:10:5:10 | f | default |
+| unresolved.js:1:8:1:8 | f | default |
+test_getLocalName
+| b.js:5:10:5:15 | f as g | f |
+| b.js:7:8:7:9 | f2 | default |
+| e.js:2:10:2:10 | x | x |
+| e.js:2:13:2:13 | y | y |
+| e.js:3:10:3:21 | default as g | default |
+| m/c.js:5:10:5:15 | g as h | g |
+test_getSourceNode
+| a.js:1:1:3:1 | export  ... n 23;\\n} | default | a.js:1:16:3:1 | functio ... n 23;\\n} |
+| a.js:5:1:5:32 | export  ...  } = o; | x | a.js:5:18:5:20 | f() |
+| b.js:5:1:5:18 | export { f as g }; | g | b.js:5:10:5:10 | f |
+| b.js:7:1:7:21 | export  ...  './a'; | f2 | a.js:1:16:3:1 | functio ... n 23;\\n} |
+| e.js:2:1:2:16 | export { x, y }; | x | e.js:2:10:2:10 | x |
+| e.js:2:1:2:16 | export { x, y }; | y | e.js:2:13:2:13 | y |
+| e.js:3:1:3:35 | export  ...  './a'; | g | a.js:1:16:3:1 | functio ... n 23;\\n} |
+| es2015_require.js:3:1:3:25 | export  ... ss C {} | default | es2015_require.js:3:16:3:25 | class C {} |
+| export-in-mjs.mjs:1:1:1:34 | export  ... s = 42; | exported_from_mjs | export-in-mjs.mjs:1:32:1:33 | 42 |
+| f.ts:5:1:5:24 | export  ... oo() {} | foo | f.ts:5:8:5:24 | function foo() {} |
+| m/c.js:5:1:5:30 | export  ... '../b'; | h | b.js:5:10:5:10 | f |
+| tst.html:7:3:7:22 | export const y = 42; | y | tst.html:7:20:7:21 | 42 |

--- a/javascript/ql/test/library-tests/Modules/tests.expected
+++ b/javascript/ql/test/library-tests/Modules/tests.expected
@@ -12,6 +12,7 @@ test_ExportDeclarations
 | export-in-mjs.mjs:1:1:1:34 | export  ... s = 42; |
 | f.ts:5:1:5:24 | export  ... oo() {} |
 | m/c.js:5:1:5:30 | export  ... '../b'; |
+| reExportNamespace.js:1:1:1:26 | export  ...  "./a"; |
 | tst.html:7:3:7:22 | export const y = 42; |
 test_ExportDefaultDeclarations
 | a.js:1:1:3:1 | export  ... n 23;\\n} |
@@ -50,6 +51,7 @@ test_ImportSpecifiers
 | import-ts-with-js-extension.ts:1:10:1:12 | foo | import-ts-with-js-extension.ts:1:10:1:12 | foo |
 | importcss.js:1:8:1:8 | A | importcss.js:1:8:1:8 | A |
 | m/c.js:1:8:1:13 | * as b | m/c.js:1:13:1:13 | b |
+| reExportNamespaceClient.js:1:10:1:11 | ns | reExportNamespaceClient.js:1:10:1:11 | ns |
 | tst.html:5:10:5:10 | f | tst.html:5:10:5:10 | f |
 | unresolved.js:1:8:1:8 | f | unresolved.js:1:8:1:8 | f |
 test_Imports
@@ -63,6 +65,7 @@ test_Imports
 | import-ts-with-js-extension.ts:1:1:1:29 | import  ... /f.js"; | import-ts-with-js-extension.ts:1:21:1:28 | "./f.js" | 1 |
 | importcss.js:1:1:1:24 | import  ... a.css"; | importcss.js:1:15:1:23 | "./a.css" | 1 |
 | m/c.js:1:1:1:26 | import  ... '../b'; | m/c.js:1:20:1:25 | '../b' | 1 |
+| reExportNamespaceClient.js:1:1:1:41 | import  ... space"; | reExportNamespaceClient.js:1:20:1:40 | "./reEx ... espace" | 1 |
 | tst.html:5:3:5:20 | import f from 'a'; | tst.html:5:17:5:19 | 'a' | 1 |
 | unresolved.js:1:1:1:18 | import f from 'a'; | unresolved.js:1:15:1:17 | 'a' | 1 |
 test_Module_exports
@@ -84,6 +87,7 @@ test_NamedImportSpecifier
 | d.js:1:24:1:29 | x as y |
 | g.ts:1:9:1:11 | foo |
 | import-ts-with-js-extension.ts:1:10:1:12 | foo |
+| reExportNamespaceClient.js:1:10:1:11 | ns |
 test_OtherImports
 | es2015_require.js:1:11:1:24 | require('./d') | d.js:1:1:5:0 | <toplevel> |
 test_ReExportDeclarations
@@ -91,6 +95,7 @@ test_ReExportDeclarations
 | d.js:4:1:4:20 | export * from 'm/c'; | d.js:4:15:4:19 | 'm/c' |
 | e.js:3:1:3:35 | export  ...  './a'; | e.js:3:30:3:34 | './a' |
 | m/c.js:5:1:5:30 | export  ... '../b'; | m/c.js:5:24:5:29 | '../b' |
+| reExportNamespace.js:1:1:1:26 | export  ...  "./a"; | reExportNamespace.js:1:21:1:25 | "./a" |
 test_getAnImportedModule
 | library-tests/Modules/b.js | library-tests/Modules/a.js |
 | library-tests/Modules/d.js | library-tests/Modules/a.js |
@@ -100,6 +105,7 @@ test_getAnImportedModule
 | library-tests/Modules/g.ts | library-tests/Modules/f.ts |
 | library-tests/Modules/import-ts-with-js-extension.ts | library-tests/Modules/f.ts |
 | library-tests/Modules/m/c.js | library-tests/Modules/b.js |
+| library-tests/Modules/reExportNamespaceClient.js | library-tests/Modules/reExportNamespace.js |
 test_getExportedName
 | b.js:5:10:5:15 | f as g | g |
 | b.js:7:8:7:9 | f2 | f2 |
@@ -107,6 +113,7 @@ test_getExportedName
 | e.js:2:13:2:13 | y | y |
 | e.js:3:10:3:21 | default as g | g |
 | m/c.js:5:10:5:15 | g as h | h |
+| reExportNamespace.js:1:8:1:14 | * as ns | ns |
 test_getImportedName
 | b.js:1:8:1:8 | f | default |
 | d.js:1:10:1:21 | default as g | default |
@@ -116,6 +123,7 @@ test_getImportedName
 | import-in-mjs.mjs:1:8:1:24 | exported_from_mjs | default |
 | import-ts-with-js-extension.ts:1:10:1:12 | foo | foo |
 | importcss.js:1:8:1:8 | A | default |
+| reExportNamespaceClient.js:1:10:1:11 | ns | ns |
 | tst.html:5:10:5:10 | f | default |
 | unresolved.js:1:8:1:8 | f | default |
 test_getLocalName

--- a/javascript/ql/test/library-tests/Modules/tests.expected
+++ b/javascript/ql/test/library-tests/Modules/tests.expected
@@ -19,12 +19,12 @@ test_getLocalName
 | e.js:3:10:3:21 | default as g | default |
 | m/c.js:5:10:5:15 | g as h | g |
 test_getExportedName
-| b.js:5:10:5:15 | f as g | f |
-| b.js:7:8:7:9 | f2 | default |
+| b.js:5:10:5:15 | f as g | g |
+| b.js:7:8:7:9 | f2 | f2 |
 | e.js:2:10:2:10 | x | x |
 | e.js:2:13:2:13 | y | y |
-| e.js:3:10:3:21 | default as g | default |
-| m/c.js:5:10:5:15 | g as h | g |
+| e.js:3:10:3:21 | default as g | g |
+| m/c.js:5:10:5:15 | g as h | h |
 test_OtherImports
 | es2015_require.js:1:11:1:24 | require('./d') | d.js:1:1:5:0 | <toplevel> |
 test_ImportMetaExpr

--- a/javascript/ql/test/library-tests/Modules/tests.ql
+++ b/javascript/ql/test/library-tests/Modules/tests.ql
@@ -1,19 +1,58 @@
-import ImportSpecifiers
-import getLocalName
-import getExportedName
-import OtherImports
-import ImportMeta
-import ReExportDeclarations
-import ImportDefaultSpecifiers
-import getImportedName
-import ExportDeclarations
-import getAnImportedModule
-import getSourceNode
-import Imports
-import NamedImportSpecifier
-import GlobalVariableRef
-import BulkReExportDeclarations
-import Module_exports
-import ExportDefaultDeclarations
-import ExportSpecifiers
-import ImportNamespaceSpecifier
+import javascript
+
+query predicate test_BulkReExportDeclarations(BulkReExportDeclaration bred) { any() }
+
+query predicate test_ExportDeclarations(ExportDeclaration ed) { any() }
+
+query predicate test_ExportDefaultDeclarations(ExportDefaultDeclaration edd) { any() }
+
+query predicate test_ExportSpecifiers(ExportSpecifier es, Identifier res0, Identifier res1) {
+  res0 = es.getLocal() and res1 = es.getExported()
+}
+
+query predicate test_GlobalVariableRef(VarAccess access) {
+  access.getVariable() instanceof GlobalVariable
+}
+
+query predicate test_ImportDefaultSpecifiers(ImportDefaultSpecifier ids) { any() }
+
+query predicate test_ImportMetaExpr(ImportMetaExpr meta) { any() }
+
+query predicate test_ImportNamespaceSpecifier(ImportNamespaceSpecifier ins) { any() }
+
+query predicate test_ImportSpecifiers(ImportSpecifier is, VarDecl res) { res = is.getLocal() }
+
+query predicate test_Imports(ImportDeclaration id, PathExprInModule res0, int res1) {
+  res0 = id.getImportedPath() and res1 = count(id.getASpecifier())
+}
+
+query predicate test_Module_exports(Module m, string name, ASTNode export) {
+  m.exports(name, export)
+}
+
+query predicate test_NamedImportSpecifier(NamedImportSpecifier nis) { any() }
+
+query predicate test_OtherImports(Import imprt, Module res) {
+  not imprt instanceof ImportDeclaration and res = imprt.getImportedModule()
+}
+
+query predicate test_ReExportDeclarations(ReExportDeclaration red, ConstantString res) {
+  res = red.getImportedPath()
+}
+
+query predicate test_getAnImportedModule(string res0, string res1) {
+  exists(Module mod |
+    res0 = mod.getFile().getRelativePath() and
+    res1 = mod.getAnImportedModule().getFile().getRelativePath()
+  )
+}
+
+query predicate test_getExportedName(ExportSpecifier es, string res) { res = es.getExportedName() }
+
+query predicate test_getImportedName(ImportSpecifier is, string res) { res = is.getImportedName() }
+
+query predicate test_getLocalName(ExportSpecifier es, string res) { res = es.getLocalName() }
+
+query predicate test_getSourceNode(ExportDeclaration ed, string name, DataFlow::Node res) {
+  res = ed.getSourceNode(name)
+}


### PR DESCRIPTION
Builds out support for export declarations of the form:
```js
export * as ns from "x"
```

We already parse and extract these, but they were not mentioned in our documentation and not handled by the type inference.

The [proposal](https://github.com/tc39/proposal-export-ns-from) is at stage 4 and will be part of ES2020 (I think) and TypeScript 3.8.

Commit-by-commit review recommended.