### PR TITLE
C#: Improve DB consistency

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CIL.Driver/Program.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL.Driver/Program.cs
@@ -21,13 +21,13 @@ namespace Semmle.Extraction.CIL.Driver
             Console.WriteLine("    path       A directory/dll/exe to analyze");
         }
 
-        static void ExtractAssembly(Layout layout, string assemblyPath, ILogger logger, bool nocache, bool extractPdbs, TrapWriter.CompressionMode trapCompression)
+        static void ExtractAssembly(Layout layout, string assemblyPath, ILogger logger, CommonOptions options)
         {
             string trapFile;
             bool extracted;
             var sw = new Stopwatch();
             sw.Start();
-            Entities.Assembly.ExtractCIL(layout, assemblyPath, logger, nocache, extractPdbs, trapCompression, out trapFile, out extracted);
+            Entities.Assembly.ExtractCIL(layout, assemblyPath, logger, options, out trapFile, out extracted);
             sw.Stop();
             logger.Log(Severity.Info, "  {0} ({1})", assemblyPath, sw.Elapsed);
         }
@@ -46,7 +46,7 @@ namespace Semmle.Extraction.CIL.Driver
 
             var actions = options.
                 AssembliesToExtract.Select(asm => asm.filename).
-                Select<string, Action>(filename => () => ExtractAssembly(layout, filename, logger, options.NoCache, options.PDB, options.TrapCompression)).
+                Select<string, Action>(filename => () => ExtractAssembly(layout, filename, logger, options)).
                 ToArray();
 
             foreach (var missingRef in options.MissingReferences)

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Assembly.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Assembly.cs
@@ -108,9 +108,9 @@ namespace Semmle.Extraction.CIL.Entities
             }
         }
 
-        static void ExtractCIL(Extraction.Context cx, string assemblyPath, bool extractPdbs)
+        static void ExtractCIL(Extraction.Context cx, string assemblyPath, CommonOptions options)
         {
-            using (var cilContext = new Context(cx, assemblyPath, extractPdbs))
+            using (var cilContext = new Context(cx, assemblyPath))
             {
                 cilContext.Populate(new Assembly(cilContext));
                 cilContext.cx.PopulateAll();
@@ -128,21 +128,21 @@ namespace Semmle.Extraction.CIL.Entities
         /// <param name="extractPdbs">Whether to extract PDBs.</param>
         /// <param name="trapFile">The path of the trap file.</param>
         /// <param name="extracted">Whether the file was extracted (false=cached).</param>
-        public static void ExtractCIL(Layout layout, string assemblyPath, ILogger logger, bool nocache, bool extractPdbs, TrapWriter.CompressionMode trapCompression, out string trapFile, out bool extracted)
+        public static void ExtractCIL(Layout layout, string assemblyPath, ILogger logger, CommonOptions options, out string trapFile, out bool extracted)
         {
             trapFile = "";
             extracted = false;
             try
             {
-                var extractor = new Extractor(false, assemblyPath, logger);
+                var extractor = new Extractor(false, assemblyPath, logger, options);
                 var project = layout.LookupProjectOrDefault(assemblyPath);
-                using (var trapWriter = project.CreateTrapWriter(logger, assemblyPath + ".cil", true, trapCompression))
+                using (var trapWriter = project.CreateTrapWriter(logger, assemblyPath + ".cil", true, options.TrapCompression))
                 {
                     trapFile = trapWriter.TrapFile;
-                    if (nocache || !System.IO.File.Exists(trapFile))
+                    if (!options.Cache || !System.IO.File.Exists(trapFile))
                     {
                         var cx = extractor.CreateContext(null, trapWriter, null);
-                        ExtractCIL(cx, assemblyPath, extractPdbs);
+                        ExtractCIL(cx, assemblyPath, options);
                         extracted = true;
                     }
                 }

--- a/csharp/extractor/Semmle.Extraction.CIL/Entities/Type.cs
+++ b/csharp/extractor/Semmle.Extraction.CIL/Entities/Type.cs
@@ -651,6 +651,9 @@ namespace Semmle.Extraction.CIL.Entities
 
         public override void WriteAssemblyPrefix(TextWriter trapFile)
         {
+            if (!cx.PrefixAssemblyId)
+                return;
+
             switch (tr.ResolutionScope.Kind)
             {
                 case HandleKind.TypeReference:

--- a/csharp/extractor/Semmle.Extraction.CSharp/Analyser.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Analyser.cs
@@ -64,7 +64,7 @@ namespace Semmle.Extraction.CSharp
             layout = new Layout();
             this.options = options;
             this.compilation = compilation;
-            extractor = new Extraction.Extractor(false, GetOutputName(compilation, commandLineArguments), Logger);
+            extractor = new Extraction.Extractor(false, GetOutputName(compilation, commandLineArguments), Logger, options);
             LogDiagnostics();
 
             SetReferencePaths();
@@ -114,7 +114,7 @@ namespace Semmle.Extraction.CSharp
         {
             compilation = compilationIn;
             layout = new Layout();
-            extractor = new Extraction.Extractor(true, null, Logger);
+            extractor = new Extraction.Extractor(true, null, Logger, options);
             this.options = options;
             LogExtractorInfo(Extraction.Extractor.Version);
             SetReferencePaths();
@@ -312,7 +312,7 @@ namespace Semmle.Extraction.CSharp
             stopwatch.Start();
             string trapFile;
             bool extracted;
-            CIL.Entities.Assembly.ExtractCIL(layout, r.FilePath, Logger, !options.Cache, options.PDB, options.TrapCompression, out trapFile, out extracted);
+            CIL.Entities.Assembly.ExtractCIL(layout, r.FilePath, Logger, options, out trapFile, out extracted);
             stopwatch.Stop();
             ReportProgress(r.FilePath, trapFile, stopwatch.Elapsed, extracted ? AnalysisAction.Extracted : AnalysisAction.UpToDate);
         }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Symbol.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Symbol.cs
@@ -123,7 +123,8 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public virtual bool IsSourceDeclaration => symbol.IsSourceDeclaration();
 
-        public override bool NeedsPopulation => Context.Defines(symbol);
+        public override bool NeedsPopulation =>
+            Context.Defines(symbol) || (symbol.ContainingType!=null && symbol.ContainingType.IsTupleType);
 
         public Extraction.Entities.Location Location => Context.Create(ReportingLocation);
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
@@ -213,7 +213,7 @@ namespace Semmle.Extraction.CSharp
 
         static void BuildNamedTypeId(this INamedTypeSymbol named, Context cx, TextWriter trapFile, Action<Context, TextWriter, ITypeSymbol> subTermAction)
         {
-            bool prefixAssembly = true;
+            bool prefixAssembly = cx.Extractor.Options.PrefixIdsWithAssemblies;
             if (cx.Extractor.Standalone) prefixAssembly = false;
             if (named.ContainingAssembly is null) prefixAssembly = false;
 

--- a/csharp/extractor/Semmle.Extraction/Extractor.cs
+++ b/csharp/extractor/Semmle.Extraction/Extractor.cs
@@ -87,6 +87,11 @@ namespace Semmle.Extraction
         /// <param name="scope">The extraction scope (what to include in this trap file).</param>
         /// <returns></returns>
         Context CreateContext(Compilation c, TrapWriter trapWriter, IExtractionScope scope);
+
+        /// <summary>
+        /// The options from the command line.
+        /// </summary>
+        CommonOptions Options { get; }
     }
 
     /// <summary>
@@ -99,21 +104,21 @@ namespace Semmle.Extraction
         /// </summary>
         public static readonly int DefaultNumberOfThreads = Environment.ProcessorCount;
 
-        public bool Standalone
-        {
-            get; private set;
-        }
+        public bool Standalone { get; }
+
+        public CommonOptions Options { get; }
 
         /// <summary>
         /// Creates a new extractor instance for one compilation unit.
         /// </summary>
         /// <param name="standalone">If the extraction is standalone.</param>
         /// <param name="outputPath">The name of the output DLL/EXE, or null if not specified (standalone extraction).</param>
-        public Extractor(bool standalone, string outputPath, ILogger logger)
+        public Extractor(bool standalone, string outputPath, ILogger logger, CommonOptions options)
         {
             Standalone = standalone;
             OutputPath = outputPath;
             Logger = logger;
+            Options = options;
         }
 
         // Limit the number of error messages in the log file

--- a/csharp/extractor/Semmle.Extraction/Options.cs
+++ b/csharp/extractor/Semmle.Extraction/Options.cs
@@ -49,6 +49,11 @@ namespace Semmle.Extraction
         /// </summary>
         public TrapWriter.CompressionMode TrapCompression = TrapWriter.CompressionMode.Gzip;
 
+        /// <summary>
+        /// Whether to prefix identifiers in trap files with the assembly id.
+        /// </summary>
+        public bool PrefixIdsWithAssemblies = false;
+
         public virtual bool handleOption(string key, string value)
         {
             switch (key)
@@ -92,6 +97,9 @@ namespace Semmle.Extraction
                     return true;
                 case "brotli":
                     TrapCompression = value ? TrapWriter.CompressionMode.Brotli : TrapWriter.CompressionMode.Gzip;
+                    return true;
+                case "assemblyprefix":
+                    PrefixIdsWithAssemblies = value;
                     return true;
                 default:
                     return false;

--- a/csharp/ql/src/semmle/code/cil/ConsistencyChecks.qll
+++ b/csharp/ql/src/semmle/code/cil/ConsistencyChecks.qll
@@ -423,10 +423,14 @@ class MethodViolation extends ConsistencyViolation, DeclarationCheck {
  */
 class InconsistentMethodLocation extends MethodViolation {
   InconsistentMethodLocation() {
-    this.getMethod().getLocation() != this.getMethod().getSourceDeclaration().getLocation()
+    not this.getMethod().getLocation() = this.getMethod().getSourceDeclaration().getLocation()
   }
 
-  override string getMessage() { result = "Inconsistent constructed method location" }
+  override string getMessage() {
+    result =
+      "Inconsistent constructed method location" + this.getMethod().getLocation() +
+        this.getMethod().getSourceDeclaration().getLocation()
+  }
 }
 
 /**

--- a/csharp/ql/test/library-tests/cil/consistency/Handles.expected
+++ b/csharp/ql/test/library-tests/cil/consistency/Handles.expected
@@ -1,4 +1,3 @@
-tooManyMatchingHandles
 missingCil
 csharpLocationViolation
 matchingObjectMethods

--- a/csharp/ql/test/library-tests/cil/consistency/Handles.ql
+++ b/csharp/ql/test/library-tests/cil/consistency/Handles.ql
@@ -10,10 +10,6 @@ class MetadataEntity extends DotNet::NamedElement, @metadata_entity {
   Assembly getAssembly() { metadata_handle(this, result, _) }
 }
 
-query predicate tooManyMatchingHandles(MetadataEntity e) {
-  strictcount(MetadataEntity e2 | e.matchesHandle(e2)) > 2
-}
-
 query predicate missingCil(Element e) {
   (
     e instanceof Callable


### PR DESCRIPTION
- Make prefixing assembly IDs to trap IDs configurable
- Disable prefixing assembly to IDs by default