### PR TITLE
Fix a few typos in the QL grammar

### DIFF
--- a/docs/language/ql-spec/language.rst
+++ b/docs/language/ql-spec/language.rst
@@ -1804,7 +1804,7 @@ The complete grammar for QL is as follows:
 
 ::
 
-   ql ::= moduleBody ;
+   ql ::= moduleBody
 
    module ::= annotation* "module" modulename "{" moduleBody "}"
 

--- a/docs/language/ql-spec/language.rst
+++ b/docs/language/ql-spec/language.rst
@@ -502,7 +502,7 @@ Identifiers are used in following syntactic constructs:
    simpleId      ::= lowerId | upperId
    modulename    ::= simpleId
    classname     ::= upperId
-   dbasetype     ::= atlowerId
+   dbasetype     ::= atLowerId
    predicateRef  ::= (moduleId "::")? literalId
    predicateName ::= lowerId
    varname       ::= simpleId
@@ -1976,11 +1976,11 @@ The complete grammar for QL is as follows:
 
    simpleId ::= lowerId | upperId
 
-   modulename :: = simpleId
+   modulename ::= simpleId
 
    classname ::= upperId
 
-   dbasetype ::= atlowerId
+   dbasetype ::= atLowerId
 
    predicateRef ::= (moduleId "::")? literalId
 


### PR DESCRIPTION
Typos:
* `atlowerId` -> `atLowerId`
* `:: =` -> `::=`

There is also a trailing `;` in the start symbol definition (`ql`). I don't know what it is supposed to mean. Should it be removed? 
