### PR TITLE
C#: Handle implicitly-typed stackallocs

### DIFF
--- a/change-notes/1.24/analysis-csharp.md
+++ b/change-notes/1.24/analysis-csharp.md
@@ -27,7 +27,8 @@ The following changes in version 1.24 affect C# analysis in all applications.
 ## Changes to code extraction
 
 * Tuple expressions, for example `(int,bool)` in `default((int,bool))` are now extracted correctly.
-* Expression nullability flow state is extracted. 
+* Expression nullability flow state is extracted.
+* Implicitly typed `stackalloc` expressions are now extracted correctly.
 
 ## Changes to libraries
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ArrayCreation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ArrayCreation.cs
@@ -101,11 +101,7 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
 
         protected override void PopulateExpression(TextWriter trapFile)
         {
-            if (Syntax.Initializer != null)
-            {
-                ArrayInitializer.Create(new ExpressionNodeInfo(cx, Syntax.Initializer, this, -1));
-            }
-
+            ArrayInitializer.Create(new ExpressionNodeInfo(cx, Syntax.Initializer, this, -1));
             trapFile.implicitly_typed_array_creation(this);
         }
     }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ArrayCreation.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/ArrayCreation.cs
@@ -93,6 +93,23 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
         public static Expression Create(ExpressionNodeInfo info) => new StackAllocArrayCreation(info).TryPopulate();
     }
 
+    class ImplicitStackAllocArrayCreation : ArrayCreation<ImplicitStackAllocArrayCreationExpressionSyntax>
+    {
+        ImplicitStackAllocArrayCreation(ExpressionNodeInfo info) : base(info.SetKind(ExprKind.ARRAY_CREATION)) { }
+
+        public static Expression Create(ExpressionNodeInfo info) => new ImplicitStackAllocArrayCreation(info).TryPopulate();
+
+        protected override void PopulateExpression(TextWriter trapFile)
+        {
+            if (Syntax.Initializer != null)
+            {
+                ArrayInitializer.Create(new ExpressionNodeInfo(cx, Syntax.Initializer, this, -1));
+            }
+
+            trapFile.implicitly_typed_array_creation(this);
+        }
+    }
+
     class ImplicitArrayCreation : ArrayCreation<ImplicitArrayCreationExpressionSyntax>
     {
         ImplicitArrayCreation(ExpressionNodeInfo info) : base(info.SetKind(ExprKind.ARRAY_CREATION)) { }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Factory.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Expressions/Factory.cs
@@ -207,6 +207,9 @@ namespace Semmle.Extraction.CSharp.Entities.Expressions
                     case SyntaxKind.StackAllocArrayCreationExpression:
                         return StackAllocArrayCreation.Create(info);
 
+                    case SyntaxKind.ImplicitStackAllocArrayCreationExpression:
+                        return ImplicitStackAllocArrayCreation.Create(info);
+
                     case SyntaxKind.ArgListExpression:
                         return ArgList.Create(info);
 

--- a/csharp/ql/test/library-tests/csharp7.3/ArrayCreations.expected
+++ b/csharp/ql/test/library-tests/csharp7.3/ArrayCreations.expected
@@ -3,4 +3,4 @@
 | csharp73.cs:11:20:11:37 | array creation of type Char[] | 0 | csharp73.cs:11:20:11:37 | 1 |
 | csharp73.cs:12:20:12:38 | array creation of type Char* | 0 | csharp73.cs:12:36:12:37 | 10 |
 | csharp73.cs:13:20:13:31 | array creation of type Char[] | 0 | csharp73.cs:13:29:13:30 | 10 |
-| csharp73.cs:21:23:21:33 | array creation of type Int32[] | 0 | csharp73.cs:21:31:21:32 | 10 |
+| csharp73.cs:22:23:22:33 | array creation of type Int32[] | 0 | csharp73.cs:22:31:22:32 | 10 |

--- a/csharp/ql/test/library-tests/csharp7.3/ArrayElements.expected
+++ b/csharp/ql/test/library-tests/csharp7.3/ArrayElements.expected
@@ -2,3 +2,6 @@
 | csharp73.cs:9:20:9:49 | array creation of type Char* | 1 | csharp73.cs:9:45:9:47 | y |
 | csharp73.cs:10:20:10:45 | array creation of type Char* | 0 | csharp73.cs:10:41:10:43 | x |
 | csharp73.cs:11:20:11:37 | array creation of type Char[] | 0 | csharp73.cs:11:33:11:35 | x |
+| csharp73.cs:14:20:14:43 | array creation of type Int32* | 0 | csharp73.cs:14:35:14:35 | 1 |
+| csharp73.cs:14:20:14:43 | array creation of type Int32* | 1 | csharp73.cs:14:38:14:38 | 2 |
+| csharp73.cs:14:20:14:43 | array creation of type Int32* | 2 | csharp73.cs:14:41:14:41 | 3 |

--- a/csharp/ql/test/library-tests/csharp7.3/csharp73.cs
+++ b/csharp/ql/test/library-tests/csharp7.3/csharp73.cs
@@ -11,6 +11,7 @@ class StackAllocs
         var arr3 = new char[] { 'x' };
         var arr4 = stackalloc char[10];
         var arr5 = new char[10];
+        var arr6 = stackalloc[] { 1, 2, 3 };
     }
 }
 


### PR DESCRIPTION
e.g.
```
var x = stackalloc[] { 1, 2, 3 };
```
This would previously throw an exception in the extractor because the expression type was not handled.

Note: conflicts with https://github.com/Semmle/ql/pull/2766