### PR TITLE
C++: IR DataFlowUtil::modelFlow join order fix

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -392,11 +392,11 @@ private predicate modelFlow(Instruction iFrom, Instruction iTo) {
 }
 
 /**
-  * Holds if the result is a side effect for instruction `call` on argument
-  * index `argument`. This helper predicate makes it easy to join on both of
-  * these columns at once, avoiding pathological join orders in case the
-  * argument index should get joined first.
-  */
+ * Holds if the result is a side effect for instruction `call` on argument
+ * index `argument`. This helper predicate makes it easy to join on both of
+ * these columns at once, avoiding pathological join orders in case the
+ * argument index should get joined first.
+ */
 pragma[noinline]
 SideEffectInstruction getSideEffectFor(CallInstruction call, int argument) {
   call = result.getPrimaryInstruction() and


### PR DESCRIPTION
We had these tuple counts on ElektraInitiative/libelektra (note that the `modelFlow` predicate got inlined into `simpleInstructionLocalFlowStep`):

    (652s) Tuple counts for DataFlowUtil::simpleInstructionLocalFlowStep#ff:
    ...
    19701      ~1%      {4} r27 = JOIN r26 WITH Instruction::SideEffectInstruction::getPrimaryInstruction_dispred#3#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r26.<2>, r26.<1>, r26.<0>
    7908       ~0%      {3} r28 = JOIN r27 WITH SSAConstruction::Cached::getInstructionIndex#ff@staged_ext AS R ON FIRST 2 OUTPUT r27.<0>, r27.<2>, r27.<3>
    4023       ~0%      {3} r29 = JOIN r28 WITH Instruction::WriteSideEffectInstruction#class#ff AS R ON FIRST 1 OUTPUT r28.<1>, r28.<2>, r28.<0>
    ...
    1060807009 ~3%      {3} r34 = JOIN r33 WITH SSAConstruction::Cached::getInstructionIndex#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, r33.<1>, r33.<2>
    15670      ~5%      {2} r35 = JOIN r34 WITH Instruction::SideEffectInstruction::getPrimaryInstruction_dispred#3#ff AS R ON FIRST 2 OUTPUT r34.<0>, r34.<2>
    7973       ~0%      {2} r36 = JOIN r35 WITH Instruction::ReadSideEffectInstruction::getSideEffectOperand_dispred#ff AS R ON FIRST 1 OUTPUT R.<1>, r35.<1>
    ...

In this predicate there are two cases (`WriteSideEffectInstruction` and `ReadSideEffectInstruction`) where we need to join on both the call and the argument index of a side effect. It works well enough for the first case, `WriteSideEffectInstruction`, where the call is joined on before the index, but it explodes in the second case, `ReadSideEffectInstruction`, where the index is joined first. To fix the second case, and to guard against future optimizer accidents in the first case, this commit changes both of those cases to use a new helper predicate that makes it possible to join on both columns at once. The resulting tuple counts are:

    (3s) Tuple counts for DataFlowUtil::simpleInstructionLocalFlowStep#ff:
    ...
    7908    ~0%      {3} r27 = JOIN r26 WITH DataFlowUtil::getSideEffectFor#fff AS R ON FIRST 2 OUTPUT R.<2>, r26.<2>, r26.<0>
    4023    ~0%      {3} r28 = JOIN r27 WITH Instruction::WriteSideEffectInstruction#class#ff AS R ON FIRST 1 OUTPUT r27.<1>, r27.<2>, r27.<0>
    ...
    15670   ~5%      {2} r33 = JOIN r32 WITH DataFlowUtil::getSideEffectFor#fff AS R ON FIRST 2 OUTPUT R.<2>, r32.<2>
    7973    ~0%      {2} r34 = JOIN r33 WITH Instruction::ReadSideEffectInstruction::getSideEffectOperand_dispred#ff AS R ON FIRST 1 OUTPUT R.<1>, r33.<1>
    ...

The bulge is now limited to a factor of two, and that's just because I didn't write separate versions of `getSideEffectFor` for `ReadSideEffectInstruction` and `WriteSideEffectInstruction`.