### PR TITLE
Remove link to blog

### DIFF
--- a/docs/language/global-sphinx-files/_templates/layout.html
+++ b/docs/language/global-sphinx-files/_templates/layout.html
@@ -66,7 +66,6 @@
                     <a href="https://help.semmle.com/QL/ql-tools.html" target="_blank">Tools</a>
                     <a href="https://help.semmle.com/QL/ql-explore-queries.html" target="_blank">Queries</a>
                     <a href="https://help.semmle.com/QL/ql-reference-topics.html" target="_blank">Reference</a>
-                    <a href="https://blog.semmle.com" target="_blank">Blog</a>
                     <a href="https://help.semmle.com" target="_blank">help.semmle.com</a>
                 </div>
                 <div class="small-bar">


### PR DESCRIPTION
Whilst looking at @felicitymay's [PR](https://git.semmle.com/Semmle/code/pull/36198) to update the help.semmle.com footer, I remembered that we still link to the Semmle blog from certain Sphinx projects like [Learning CodeQL](https://help.semmle.com/QL/learn-ql/) too.

Not that it really matters, but the Sphinx stuff is likely to be around for a while before we migrate, so it's probably worth updating. (Non-urgent of course. I've used `rc/1.23` to match the other PR, but we don't need to republish this immediately.) 

@jf205 - could you review please? 