### PR TITLE
C++: fix cartesian product in FunctionWithWrapper

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/security/FunctionWithWrappers.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/FunctionWithWrappers.qll
@@ -98,6 +98,22 @@ abstract class FunctionWithWrappers extends Function {
    * Whether 'func' is a (possibly nested) wrapper function that feeds a parameter at the given index
    * through to an interesting parameter of 'this' function.
    *
+   * The 'cause' gives the name of 'this' interesting function and its relevant parameter
+   * at the end of the call chain.
+   *
+   * If there is more than one possible 'cause', a unique one is picked (by lexicographic order).
+   */
+  pragma[nomagic]
+  private string wrapperFunctionAnyDepthUnique(Function func, int paramIndex) {
+    result =
+      min(string targetCause | this.wrapperFunctionAnyDepth(func, paramIndex, targetCause)) +
+        ", which ends up calling " + toCause(func, paramIndex)
+  }
+
+  /**
+   * Whether 'func' is a (possibly nested) wrapper function that feeds a parameter at the given index
+   * through to an interesting parameter of 'this' function.
+   *
    * If there exists a call chain with depth at most 4, the 'cause' reports the smallest call chain.
    * Otherwise, the 'cause' merely reports the name of 'this' interesting function and its relevant
    * parameter at the end of the call chain.
@@ -114,13 +130,7 @@ abstract class FunctionWithWrappers extends Function {
       )
     or
     not this.wrapperFunctionLimitedDepth(func, paramIndex, _, _) and
-    cause =
-      min(string targetCause, string possibleCause |
-        this.wrapperFunctionAnyDepth(func, paramIndex, targetCause) and
-        possibleCause = toCause(func, paramIndex) + ", which ends up calling " + targetCause
-      |
-        possibleCause
-      )
+    cause = wrapperFunctionAnyDepthUnique(func, paramIndex)
   }
 
   /**

--- a/cpp/ql/src/semmle/code/cpp/security/FunctionWithWrappers.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/FunctionWithWrappers.qll
@@ -106,8 +106,8 @@ abstract class FunctionWithWrappers extends Function {
   pragma[nomagic]
   private string wrapperFunctionAnyDepthUnique(Function func, int paramIndex) {
     result =
-      min(string targetCause | this.wrapperFunctionAnyDepth(func, paramIndex, targetCause)) +
-        ", which ends up calling " + toCause(func, paramIndex)
+      toCause(func, paramIndex) + ", which ends up calling " +
+        min(string targetCause | this.wrapperFunctionAnyDepth(func, paramIndex, targetCause))
   }
 
   /**


### PR DESCRIPTION
before:
```
[2020-02-10 11:21:30] (1294s) Tuple counts for FunctionWithWrappers::FunctionWithWrappers::wrapperFunction_dispred#ffbf#shared#1:
                      185259    ~1%     {3} r1 = JOIN project#Call::Call::getArgument_dispred#fff AS L WITH Function::Function::getParameter_dispred#fff_102#join_rhs AS R ON FIRST 1 OUTPUT R.<2>, L.<0>, R.<1>
                      185262    ~0%     {3} r2 = JOIN r1 WITH Declaration::Declaration::getName_dispred#ff AS R ON FIRST 1 OUTPUT r1.<2>, r1.<1>, R.<1>
                      184274    ~4%     {3} r3 = JOIN r2 WITH Declaration::Declaration::getQualifiedName_dispred#ff AS R ON FIRST 1 OUTPUT r2.<0>, r2.<1>, (R.<1> ++ "(" ++ r2.<2> ++ ")")
                      716       ~0%     {2} r4 = SCAN project#Call::Call::getArgument_dispred#fff AS I OUTPUT I.<0>, toString(I.<0>)
                      168371696 ~0%     {4} r5 = JOIN r4 WITH Declaration::Declaration::getQualifiedName_dispred#ff AS R CARTESIAN PRODUCT OUTPUT r4.<0>, r4.<1>, R.<0>, R.<1>
                      168187425 ~0%     {4} r6 = r5 AND NOT FunctionWithWrappers::FunctionWithWrappers::wrapperFunction_dispred#ffbf#antijoin_rhs AS R(r5.<0>, r5.<1>, r5.<2>, r5.<3>)
                      168187425 ~4%     {3} r7 = SCAN r6 OUTPUT r6.<2>, r6.<0>, (r6.<3> ++ "(arg " ++ r6.<1> ++ ")")
                      168371699 ~4%     {3} r8 = r3 \/ r7
                                        return r8
```

After:
```
[2020-02-10 13:00:08] (19s) Tuple counts for FunctionWithWrappers::FunctionWithWrappers::wrapperFunctionAnyDepthUnique#ffff:
                      193    ~1%     {5} r1 = JOIN FunctionWithWrappers::FunctionWithWrappers::wrapperFunctionAnyDepthUnique#ffff#shared#1 AS L WITH Declaration::Declaration::getName_dispred#ff AS R ON FIRST 1 OUTPUT L.<2>, L.<1>, L.<3>, L.<4>, R.<1>
                      193    ~1%     {4} r2 = JOIN r1 WITH Declaration::Declaration::getQualifiedName_dispred#ff AS R ON FIRST 1 OUTPUT r1.<1>, r1.<0>, r1.<2>, (r1.<3> ++ ", which ends up calling " ++ (R.<1> ++ "(" ++ r1.<4> ++ ")"))
                      5      ~0%     {4} r3 = FunctionWithWrappers::FunctionWithWrappers::wrapperFunctionAnyDepthUnique#ffff#shared AS L AND NOT FunctionWithWrappers::FunctionWithWrappers::wrapperFunctionAnyDepthUnique#ffff#antijoin_rhs AS R(L.<0>, L.<1>, L.<2>, L.<3>)
                      5      ~0%     {5} r4 = SCAN r3 OUTPUT r3.<1>, r3.<0>, r3.<2>, r3.<3>, toString(r3.<2>)
                      5      ~0%     {4} r5 = JOIN r4 WITH Declaration::Declaration::getQualifiedName_dispred#ff AS R ON FIRST 1 OUTPUT r4.<1>, r4.<0>, r4.<2>, (r4.<3> ++ ", which ends up calling " ++ (R.<1> ++ "(arg " ++ r4.<4> ++ ")"))
                      198    ~1%     {4} r6 = r2 \/ r5
                                     return r6
```

```
[2020-02-10 13:00:08] (19s) Tuple counts for FunctionWithWrappers::FunctionWithWrappers::wrapperFunction_dispred#ffbf:
                      198 ~0%     {4} r1 = AGGREGATE FunctionWithWrappers::FunctionWithWrappers::wrapperFunction_dispred#ffbf#min_range AS R, FunctionWithWrappers::FunctionWithWrappers::wrapperFunction_dispred#ffbf#min_term AS T ON {T.<5>} WITH MIN<0 ASC> OUTPUT {T.<0>,T.<1>,T.<2>,agg.<0>}
                      198 ~2%     {4} r2 = SCAN r1 OUTPUT r1.<2>, r1.<0>, r1.<1>, r1.<3>
                      198 ~0%     {4} r3 = JOIN r2 WITH project#Call::Call::getArgument_dispred#fff AS R ON FIRST 1 OUTPUT r2.<1>, r2.<2>, R.<0>, r2.<3>
                      198 ~4%     {4} r4 = SCAN FunctionWithWrappers::FunctionWithWrappers::wrapperFunctionAnyDepthUnique#ffff AS I OUTPUT I.<2>, I.<0>, I.<1>, I.<3>
                      198 ~4%     {4} r5 = JOIN r4 WITH project#Call::Call::getArgument_dispred#fff AS R ON FIRST 1 OUTPUT R.<0>, r4.<1>, r4.<2>, r4.<3>
                      0   ~0%     {4} r6 = r5 AND NOT project#FunctionWithWrappers::FunctionWithWrappers::wrapperFunctionLimitedDepth#ffbff#2 AS R(r5.<1>, r5.<2>, r5.<0>)
                      0   ~0%     {4} r7 = SCAN r6 OUTPUT r6.<1>, r6.<2>, r6.<0>, r6.<3>
                      198 ~0%     {4} r8 = r3 \/ r7
                                  return r8
```