### PR TITLE
JS: add HTMLSanitizerCall as a sanitizer for XSS

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -51,6 +51,16 @@ module Shared {
       )
     }
   }
+
+  /**
+   * A call that sanitizes HTML in a string, viewed as a sanitizer for 
+   * XSS vulnerabilities. 
+   */ 
+  class XssEscapingHTMLSanitizerCall extends Sanitizer {
+    XssEscapingHTMLSanitizerCall() {
+      this instanceof HtmlSanitizerCall
+    }
+  }
 }
 
 /** Provides classes and predicates for the DOM-based XSS query. */
@@ -287,6 +297,8 @@ module DomBasedXss {
   private class MetacharEscapeSanitizer extends Sanitizer, Shared::MetacharEscapeSanitizer { }
 
   private class UriEncodingSanitizer extends Sanitizer, Shared::UriEncodingSanitizer { }
+
+  private class XssEscapingHTMLSanitizerCall extends Sanitizer, Shared::XssEscapingHTMLSanitizerCall { }
 }
 
 /** Provides classes and predicates for the reflected XSS query. */
@@ -332,6 +344,8 @@ module ReflectedXss {
   private class MetacharEscapeSanitizer extends Sanitizer, Shared::MetacharEscapeSanitizer { }
 
   private class UriEncodingSanitizer extends Sanitizer, Shared::UriEncodingSanitizer { }
+
+  private class XssEscapingHTMLSanitizerCall extends Sanitizer, Shared::XssEscapingHTMLSanitizerCall { }
 }
 
 /** Provides classes and predicates for the stored XSS query. */
@@ -360,4 +374,6 @@ module StoredXss {
   private class MetacharEscapeSanitizer extends Sanitizer, Shared::MetacharEscapeSanitizer { }
 
   private class UriEncodingSanitizer extends Sanitizer, Shared::UriEncodingSanitizer { }
+
+  private class XssEscapingHTMLSanitizerCall extends Sanitizer, Shared::XssEscapingHTMLSanitizerCall { }
 }

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -333,6 +333,12 @@ nodes
 | tst.js:319:35:319:42 | location |
 | tst.js:319:35:319:42 | location |
 | tst.js:319:35:319:42 | location |
+| tst.js:335:7:335:39 | target |
+| tst.js:335:16:335:32 | document.location |
+| tst.js:335:16:335:32 | document.location |
+| tst.js:335:16:335:39 | documen ... .search |
+| tst.js:341:18:341:23 | target |
+| tst.js:341:18:341:23 | target |
 | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:38 | document.location |
 | typeahead.js:20:22:20:38 | document.location |
@@ -642,6 +648,11 @@ edges
 | tst.js:313:10:313:10 | e | tst.js:314:20:314:20 | e |
 | tst.js:313:10:313:10 | e | tst.js:314:20:314:20 | e |
 | tst.js:319:35:319:42 | location | tst.js:319:35:319:42 | location |
+| tst.js:335:7:335:39 | target | tst.js:341:18:341:23 | target |
+| tst.js:335:7:335:39 | target | tst.js:341:18:341:23 | target |
+| tst.js:335:16:335:32 | document.location | tst.js:335:16:335:39 | documen ... .search |
+| tst.js:335:16:335:32 | document.location | tst.js:335:16:335:39 | documen ... .search |
+| tst.js:335:16:335:39 | documen ... .search | tst.js:335:7:335:39 | target |
 | typeahead.js:20:13:20:45 | target | typeahead.js:21:12:21:17 | target |
 | typeahead.js:20:22:20:38 | document.location | typeahead.js:20:22:20:45 | documen ... .search |
 | typeahead.js:20:22:20:38 | document.location | typeahead.js:20:22:20:45 | documen ... .search |
@@ -741,6 +752,7 @@ edges
 | tst.js:306:20:306:20 | e | tst.js:304:9:304:16 | location | tst.js:306:20:306:20 | e | Cross-site scripting vulnerability due to $@. | tst.js:304:9:304:16 | location | user-provided value |
 | tst.js:314:20:314:20 | e | tst.js:311:10:311:17 | location | tst.js:314:20:314:20 | e | Cross-site scripting vulnerability due to $@. | tst.js:311:10:311:17 | location | user-provided value |
 | tst.js:319:35:319:42 | location | tst.js:319:35:319:42 | location | tst.js:319:35:319:42 | location | Cross-site scripting vulnerability due to $@. | tst.js:319:35:319:42 | location | user-provided value |
+| tst.js:341:18:341:23 | target | tst.js:335:16:335:32 | document.location | tst.js:341:18:341:23 | target | Cross-site scripting vulnerability due to $@. | tst.js:335:16:335:32 | document.location | user-provided value |
 | typeahead.js:25:18:25:20 | val | typeahead.js:20:22:20:38 | document.location | typeahead.js:25:18:25:20 | val | Cross-site scripting vulnerability due to $@. | typeahead.js:20:22:20:38 | document.location | user-provided value |
 | v-html.vue:2:8:2:23 | v-html=tainted | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted | Cross-site scripting vulnerability due to $@. | v-html.vue:6:42:6:58 | document.location | user-provided value |
 | winjs.js:3:43:3:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:3:43:3:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssWithAdditionalSources.expected
@@ -333,6 +333,12 @@ nodes
 | tst.js:319:35:319:42 | location |
 | tst.js:319:35:319:42 | location |
 | tst.js:319:35:319:42 | location |
+| tst.js:335:7:335:39 | target |
+| tst.js:335:16:335:32 | document.location |
+| tst.js:335:16:335:32 | document.location |
+| tst.js:335:16:335:39 | documen ... .search |
+| tst.js:341:18:341:23 | target |
+| tst.js:341:18:341:23 | target |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:10:16:10:18 | loc |
@@ -646,6 +652,11 @@ edges
 | tst.js:313:10:313:10 | e | tst.js:314:20:314:20 | e |
 | tst.js:313:10:313:10 | e | tst.js:314:20:314:20 | e |
 | tst.js:319:35:319:42 | location | tst.js:319:35:319:42 | location |
+| tst.js:335:7:335:39 | target | tst.js:341:18:341:23 | target |
+| tst.js:335:7:335:39 | target | tst.js:341:18:341:23 | target |
+| tst.js:335:16:335:32 | document.location | tst.js:335:16:335:39 | documen ... .search |
+| tst.js:335:16:335:32 | document.location | tst.js:335:16:335:39 | documen ... .search |
+| tst.js:335:16:335:39 | documen ... .search | tst.js:335:7:335:39 | target |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |

--- a/javascript/ql/test/query-tests/Security/CWE-079/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/tst.js
@@ -325,3 +325,18 @@ function test2() {
   // OK
   $('myId').html(target.length)
 }
+
+// Bad escape function, but that is not what we are checking for.
+function escapeHtml(x) {
+	return x.substr(0, 10);
+}
+
+function test() {
+  var target = document.location.search
+
+  // OK
+  $('myId').html(escapeHtml(target));
+
+  // NOT OK
+  $('myId').html(target);
+}


### PR DESCRIPTION
Add the existing `HtmlSanitizerCall` as a sanitizer for the 3 XSS queries. 

This gives us a TN for the fix of CVE-2019-10771. 

This means that we no longer flag the below example: 

```JavaScript
// Bad escape function, but that is not what we are checking for.
function escapeHtml(x) {
   return x.substr(0, 10);
}

function test() {
  var tainted = document.location.search

  // OK
  $('#myId').html(escapeHtml(tainted));
}
```

I've marked as WIP as I'm not sure yet if it is a good approach. 

I would have liked to say that an evaluation is on the way, but we're running out of Azure workers.