### PR TITLE
Python: ObjectAPI to ValueAPI: HashedButNoHash

### DIFF
--- a/python/ql/src/Expressions/HashedButNoHash.ql
+++ b/python/ql/src/Expressions/HashedButNoHash.ql
@@ -69,7 +69,7 @@ predicate is_unhashable(ControlFlowNode f, ClassValue cls, ControlFlowNode origi
 predicate typeerror_is_caught(ControlFlowNode f) {
     exists (Try try |
         try.getBody().contains(f.getNode()) and
-        try.getAHandler().getType().pointsTo(ClassValue::typeErrorType()))
+        try.getAHandler().getType().pointsTo(ClassValue::typeError()))
 }
 
 from ControlFlowNode f, ClassValue c, ControlFlowNode origin

--- a/python/ql/src/Expressions/HashedButNoHash.ql
+++ b/python/ql/src/Expressions/HashedButNoHash.ql
@@ -69,7 +69,7 @@ predicate is_unhashable(ControlFlowNode f, ClassValue cls, ControlFlowNode origi
 predicate typeerror_is_caught(ControlFlowNode f) {
     exists (Try try |
         try.getBody().contains(f.getNode()) and
-        try.getAHandler().getType().refersTo(theTypeErrorType()))
+        try.getAHandler().getType().pointsTo(ClassValue::typeErrorType()))
 }
 
 from ControlFlowNode f, ClassValue c, ControlFlowNode origin

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -743,6 +743,11 @@ module ClassValue {
     ClassValue nonetype() {
         result = TBuiltinClassObject(Builtin::special("NoneType"))
     }
+    
+    /** Get the `ClassValue` for the `TypeError` class */
+    ClassValue typeErrorType() {
+        result = TBuiltinClassObject(Builtin::special("TypeError"))
+    }
 
     /** Get the `ClassValue` for the `NameError` class. */
     ClassValue nameError() {

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -745,7 +745,7 @@ module ClassValue {
     }
     
     /** Get the `ClassValue` for the `TypeError` class */
-    ClassValue typeErrorType() {
+    ClassValue typeError() {
         result = TBuiltinClassObject(Builtin::special("TypeError"))
     }
 


### PR DESCRIPTION
This PR is part of the effort to modernize the Expressions queries, moving away from the use of `refersTo` and associated APIs, and towards `pointsTo` and its associated APIs.