### PR TITLE
Python: ObjectAPI to ValueAPI: Foresight Additions

### DIFF
--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -679,6 +679,13 @@ module ClassValue {
         result = TBuiltinClassObject(Builtin::special("list"))
     }
     
+    /** The builtin class '(x)range' */
+    ClassValue rangeType() {
+        result = TBuiltinClassObject(Builtin::special("xrange"))
+        or
+        major_version() = 3 and result = TBuiltinClassObject(Builtin::special("range"))
+    }
+    
     /** Get the `ClassValue` for the `dict` class. */
     ClassValue dict() {
         result = TBuiltinClassObject(Builtin::special("dict"))

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -681,7 +681,7 @@ module ClassValue {
     
     /** Get the `ClassValue` for `xrange` (Python 2), or `range` (only Python 3) */
     ClassValue rangeType() {
-        result = TBuiltinClassObject(Builtin::special("xrange"))
+        major_version() = 2 and result = TBuiltinClassObject(Builtin::special("xrange"))
         or
         major_version() = 3 and result = TBuiltinClassObject(Builtin::special("range"))
     }

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -679,13 +679,6 @@ module ClassValue {
         result = TBuiltinClassObject(Builtin::special("list"))
     }
     
-    /** Get the `ClassValue` for the `(x)range` class. */
-    ClassValue rangeType() {
-        result = Builtin::special("xrange")
-        or
-        major_version() = 3 and result = Builtin::special("range")
-    }
-    
     /** Get the `ClassValue` for the `dict` class. */
     ClassValue dict() {
         result = TBuiltinClassObject(Builtin::special("dict"))
@@ -739,13 +732,6 @@ module ClassValue {
            result = bytes()
         else
            result = unicode()
-    }
-    
-    /** Get the `ClassValue` for the builtin properties. */
-    ClassValue builtinPropertyType() {
-        /* This is CPython specific */ 
-        result.isC() and
-        result.getName() = "getset_descriptor"
     }
     
     /** Get the `ClassValue` for the `property` class. */

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -679,7 +679,7 @@ module ClassValue {
         result = TBuiltinClassObject(Builtin::special("list"))
     }
     
-    /** The builtin class '(x)range' */
+    /** Get the `ClassValue` for `xrange` (Python 2), or `range` (only Python 3) */
     ClassValue rangeType() {
         result = TBuiltinClassObject(Builtin::special("xrange"))
         or

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -668,40 +668,57 @@ module ClassValue {
     ClassValue bool() {
         result = TBuiltinClassObject(Builtin::special("bool"))
     }
-
+    
+    /** Get the `ClassValue` for the `tuple` class. */
+    ClassValue tupleType() {
+        result = TBuiltinClassObject(Builtin::special("tuple"))
+    }
+    
+    /** Get the `ClassValue` for the `list` class. */
+    ClassValue listType() {
+        result = TBuiltinClassObject(Builtin::special("list"))
+    }
+    
+    /** Get the `ClassValue` for the `(x)range` class. */
+    ClassValue rangeType() {
+        result = Builtin::special("xrange")
+        or
+        major_version() = 3 and result = Builtin::special("range")
+    }
+    
     /** Get the `ClassValue` for the `dict` class. */
     ClassValue dict() {
         result = TBuiltinClassObject(Builtin::special("dict"))
     }
-
-    /** Get the `ClassValue` for the class of Python functions. */
-    ClassValue function() {
-        result = TBuiltinClassObject(Builtin::special("FunctionType"))
+    
+    /** Get the `ClassValue` for the `set` class. */
+    ClassValue setType() {
+        result = TBuiltinClassObject(Builtin::special("set"))
     }
-
-    /** Get the `ClassValue` for the `type` class. */
-    ClassValue type() {
-        result = TType()
-    }
-
-    /** Get the `ClassValue` for the class of builtin functions. */
-    ClassValue builtinFunction() {
-        result = Value::named("len").getClass()
+    
+    /** Get the `ClassValue` for the `object` class. */
+    ClassValue objectType() {
+        result = TBuiltinClassObject(Builtin::special("object"))
     }
 
     /** Get the `ClassValue` for the `int` class. */
     ClassValue int_() {
         result = TBuiltinClassObject(Builtin::special("int"))
     }
+    
+    /** Get the `ClassValue` for the `long` class. */
+    ClassValue longType() {
+        result = TBuiltinClassObject(Builtin::special("long"))
+    }
 
     /** Get the `ClassValue` for the `float` class. */
     ClassValue float_() {
         result = TBuiltinClassObject(Builtin::special("float"))
     }
-
-    /** Get the `ClassValue` for the `list` class. */
-    ClassValue list() {
-        result = TBuiltinClassObject(Builtin::special("list"))
+    
+    /** Get the `ClassValue` for the `complex` class. */
+    ClassValue complexType() {
+        result = TBuiltinClassObject(Builtin::special("complex"))
     }
 
     /** Get the `ClassValue` for the `bytes` class (also called `str` in Python 2). */
@@ -723,7 +740,54 @@ module ClassValue {
         else
            result = unicode()
     }
+    
+    /** Get the `ClassValue` for the builtin properties. */
+    ClassValue builtinPropertyType() {
+        /* This is CPython specific */ 
+        result.isC() and
+        result.getName() = "getset_descriptor"
+    }
+    
+    /** Get the `ClassValue` for the `property` class. */
+    ClassValue propertyType() {
+        result = TBuiltinClassObject(Builtin::special("property"))
+    }
+    
+    /** Get the `ClassValue` for the class of Python functions. */
+    ClassValue function() {
+        result = TBuiltinClassObject(Builtin::special("FunctionType"))
+    }
 
+    /** Get the `ClassValue` for the class of builtin functions. */
+    ClassValue builtinFunction() {
+        result = Value::named("len").getClass()
+    }
+    
+    /** Get the `ClassValue` for the `generatorType` class. */
+    ClassValue generatorType() {
+        result = TBuiltinClassObject(Builtin::special("generator"))
+    }
+    
+    /** Get the `ClassValue` for the `type` class. */
+    ClassValue type() {
+        result = TType()
+    }
+    
+    /** Get the `ClassValue` for `ClassType`. */
+    ClassValue classType() {
+        result = TBuiltinClassObject(Builtin::special("ClassType"))
+    }
+    
+    /** Get the `ClassValue` for `InstanceType`. */
+    ClassValue instanceType() {
+        result = TBuiltinClassObject(Builtin::special("InstanceType"))
+    }
+    
+    /** Get the `ClassValue` for `super`. */
+    ClassValue superType() {
+        result = TBuiltinClassObject(Builtin::special("super"))
+    }
+    
     /** Get the `ClassValue` for the `classmethod` class. */
     ClassValue classmethod() {
         result = TBuiltinClassObject(Builtin::special("ClassMethod"))
@@ -733,20 +797,76 @@ module ClassValue {
     ClassValue staticmethod() {
         result = TBuiltinClassObject(Builtin::special("StaticMethod"))
     }
+    
+    /** Get the `ClassValue` for the `MethodType` class. */
+    pragma [noinline]
+    ClassValue boundMethodType() {
+        result = TBuiltinClassObject(Builtin::special("MethodType"))
+    }
+    
+    /** Get the `ClassValue` for the `MethodDescriptorType` class. */
+    ClassValue methodDescriptorType() {
+        result = TBuiltinClassObject(Builtin::special("MethodDescriptorType"))
+    }
+    
+    /** Get the `ClassValue` for the `GetSetDescriptorType` class. */
+    ClassValue getSetDescriptorType() {
+        result = TBuiltinClassObject(Builtin::special("GetSetDescriptorType"))
+    }
+    
+    /** Get the `ClassValue` for the `StopIteration` class. */
+    ClassValue stopIterationType() {
+        result = TBuiltinClassObject(Builtin::special("StopIteration"))
+    }
 
     /** Get the `ClassValue` for the class of modules. */
     ClassValue module_() {
         result = TBuiltinClassObject(Builtin::special("ModuleType"))
     }
 
+    /** Get the `ClassValue` for the `Exception` class. */
+    ClassValue exceptionType() {
+        result = TBuiltinClassObject(Builtin::special("Exception"))
+    }
+    
+    /** Get the `ClassValue` for the `BaseException` class. */
+    ClassValue baseExceptionType() {
+        result = TBuiltinClassObject(Builtin::special("BaseException"))
+    }
+    
     /** Get the `ClassValue` for the `NoneType` class. */
     ClassValue nonetype() {
         result = TBuiltinClassObject(Builtin::special("NoneType"))
+    }
+    
+    /** Get the `ClassValue` for the `TypeError` class */
+    ClassValue typeErrorType() {
+        result = TBuiltinClassObject(Builtin::special("TypeError"))
     }
 
     /** Get the `ClassValue` for the `NameError` class. */
     ClassValue nameError() {
         result = TBuiltinClassObject(Builtin::builtin("NameError"))
+    }
+    
+    /** Get the `ClassValue` for the `AttributeError` class. */
+    ClassValue attributeErrorType() {
+        result = TBuiltinClassObject(Builtin::builtin("AttributeError"))
+    }
+    
+    /** Get the `ClassValue` for the `KeyError` class. */
+    ClassValue keyErrorType() {
+        result = TBuiltinClassObject(Builtin::builtin("KeyError"))
+    }
+    
+    /** Get the `ClassValue` for the `IOError` class. */
+    ClassValue ioErrorType() {
+        result = TBuiltinClassObject(Builtin::builtin("IOError"))
+    }
+    
+    /** Get the `ClassValue` for the `NotImplementedError` class. */
+    ClassValue notImplementedError() {
+        result = TBuiltinClassObject(Builtin::builtin("NotImplementedError"))
     }
 
 }

--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -670,17 +670,17 @@ module ClassValue {
     }
     
     /** Get the `ClassValue` for the `tuple` class. */
-    ClassValue tupleType() {
+    ClassValue tuple() {
         result = TBuiltinClassObject(Builtin::special("tuple"))
     }
     
     /** Get the `ClassValue` for the `list` class. */
-    ClassValue listType() {
+    ClassValue list() {
         result = TBuiltinClassObject(Builtin::special("list"))
     }
     
     /** Get the `ClassValue` for `xrange` (Python 2), or `range` (only Python 3) */
-    ClassValue rangeType() {
+    ClassValue range() {
         major_version() = 2 and result = TBuiltinClassObject(Builtin::special("xrange"))
         or
         major_version() = 3 and result = TBuiltinClassObject(Builtin::special("range"))
@@ -692,12 +692,12 @@ module ClassValue {
     }
     
     /** Get the `ClassValue` for the `set` class. */
-    ClassValue setType() {
+    ClassValue set() {
         result = TBuiltinClassObject(Builtin::special("set"))
     }
     
     /** Get the `ClassValue` for the `object` class. */
-    ClassValue objectType() {
+    ClassValue object() {
         result = TBuiltinClassObject(Builtin::special("object"))
     }
 
@@ -707,7 +707,7 @@ module ClassValue {
     }
     
     /** Get the `ClassValue` for the `long` class. */
-    ClassValue longType() {
+    ClassValue long() {
         result = TBuiltinClassObject(Builtin::special("long"))
     }
 
@@ -717,7 +717,7 @@ module ClassValue {
     }
     
     /** Get the `ClassValue` for the `complex` class. */
-    ClassValue complexType() {
+    ClassValue complex() {
         result = TBuiltinClassObject(Builtin::special("complex"))
     }
 
@@ -742,12 +742,12 @@ module ClassValue {
     }
     
     /** Get the `ClassValue` for the `property` class. */
-    ClassValue propertyType() {
+    ClassValue property() {
         result = TBuiltinClassObject(Builtin::special("property"))
     }
     
     /** Get the `ClassValue` for the class of Python functions. */
-    ClassValue function() {
+    ClassValue functionType() {
         result = TBuiltinClassObject(Builtin::special("FunctionType"))
     }
 
@@ -757,7 +757,7 @@ module ClassValue {
     }
     
     /** Get the `ClassValue` for the `generatorType` class. */
-    ClassValue generatorType() {
+    ClassValue generator() {
         result = TBuiltinClassObject(Builtin::special("generator"))
     }
     
@@ -777,7 +777,7 @@ module ClassValue {
     }
     
     /** Get the `ClassValue` for `super`. */
-    ClassValue superType() {
+    ClassValue super_() {
         result = TBuiltinClassObject(Builtin::special("super"))
     }
     
@@ -793,7 +793,7 @@ module ClassValue {
     
     /** Get the `ClassValue` for the `MethodType` class. */
     pragma [noinline]
-    ClassValue boundMethodType() {
+    ClassValue methodType() {
         result = TBuiltinClassObject(Builtin::special("MethodType"))
     }
     
@@ -808,7 +808,7 @@ module ClassValue {
     }
     
     /** Get the `ClassValue` for the `StopIteration` class. */
-    ClassValue stopIterationType() {
+    ClassValue stopIteration() {
         result = TBuiltinClassObject(Builtin::special("StopIteration"))
     }
 
@@ -818,12 +818,12 @@ module ClassValue {
     }
 
     /** Get the `ClassValue` for the `Exception` class. */
-    ClassValue exceptionType() {
+    ClassValue exception() {
         result = TBuiltinClassObject(Builtin::special("Exception"))
     }
     
     /** Get the `ClassValue` for the `BaseException` class. */
-    ClassValue baseExceptionType() {
+    ClassValue baseException() {
         result = TBuiltinClassObject(Builtin::special("BaseException"))
     }
     
@@ -833,7 +833,7 @@ module ClassValue {
     }
     
     /** Get the `ClassValue` for the `TypeError` class */
-    ClassValue typeErrorType() {
+    ClassValue typeError() {
         result = TBuiltinClassObject(Builtin::special("TypeError"))
     }
 
@@ -843,17 +843,17 @@ module ClassValue {
     }
     
     /** Get the `ClassValue` for the `AttributeError` class. */
-    ClassValue attributeErrorType() {
+    ClassValue attributeError() {
         result = TBuiltinClassObject(Builtin::builtin("AttributeError"))
     }
     
     /** Get the `ClassValue` for the `KeyError` class. */
-    ClassValue keyErrorType() {
+    ClassValue keyError() {
         result = TBuiltinClassObject(Builtin::builtin("KeyError"))
     }
     
     /** Get the `ClassValue` for the `IOError` class. */
-    ClassValue ioErrorType() {
+    ClassValue ioError() {
         result = TBuiltinClassObject(Builtin::builtin("IOError"))
     }
     


### PR DESCRIPTION
This PR is part of the effort to modernize the Expressions queries, moving away from the use of `refersTo` and associated APIs, and towards `pointsTo` and its associated APIs.

### Foresight Additions

There are some additions that are in-progress for foresight purposes. The old `refersTo` code makes extensive use of predicates like `theIntType()` which modernizes to `ClassValue::int_()`. Not all of the `the...Type()` predicates have been translated, presumably because they're being moved over on an as-needed basis. It seems useful to just move everything over since most of it is formulaic.