### PR TITLE
JS: add model for chrome-remote-interface as a ClientRequest

### DIFF
--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -25,6 +25,7 @@
   - [for-in](https://www.npmjs.com/package/for-in)
   - [for-own](https://www.npmjs.com/package/for-own)
   - [send](https://www.npmjs.com/package/send)
+  - [chrome-remote-interface](https://www.npmjs.com/package/chrome-remote-interface)
 
 ## New queries
 

--- a/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/ClientRequests.qll
@@ -551,7 +551,7 @@ module ClientRequest {
   }
 
   /**
-   * Gets a reference to a instance of `chrome-remote-interface`.
+   * Gets a reference to an instance of `chrome-remote-interface`.
    *
    * An instantiation of `chrome-remote-interface` either accepts a callback or returns a promise. 
    * 

--- a/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-918/RequestForgery.expected
@@ -37,6 +37,16 @@ nodes
 | tst.js:45:13:45:56 | 'http:/ ... tainted |
 | tst.js:45:13:45:56 | 'http:/ ... tainted |
 | tst.js:45:50:45:56 | tainted |
+| tst.js:58:9:58:52 | tainted |
+| tst.js:58:19:58:42 | url.par ... , true) |
+| tst.js:58:19:58:48 | url.par ... ).query |
+| tst.js:58:19:58:52 | url.par ... ery.url |
+| tst.js:58:29:58:35 | req.url |
+| tst.js:58:29:58:35 | req.url |
+| tst.js:61:29:61:35 | tainted |
+| tst.js:61:29:61:35 | tainted |
+| tst.js:64:30:64:36 | tainted |
+| tst.js:64:30:64:36 | tainted |
 edges
 | tst.js:14:9:14:52 | tainted | tst.js:18:13:18:19 | tainted |
 | tst.js:14:9:14:52 | tainted | tst.js:18:13:18:19 | tainted |
@@ -75,6 +85,15 @@ edges
 | tst.js:43:46:43:52 | tainted | tst.js:43:13:43:54 | `http:/ ... inted}` |
 | tst.js:45:50:45:56 | tainted | tst.js:45:13:45:56 | 'http:/ ... tainted |
 | tst.js:45:50:45:56 | tainted | tst.js:45:13:45:56 | 'http:/ ... tainted |
+| tst.js:58:9:58:52 | tainted | tst.js:61:29:61:35 | tainted |
+| tst.js:58:9:58:52 | tainted | tst.js:61:29:61:35 | tainted |
+| tst.js:58:9:58:52 | tainted | tst.js:64:30:64:36 | tainted |
+| tst.js:58:9:58:52 | tainted | tst.js:64:30:64:36 | tainted |
+| tst.js:58:19:58:42 | url.par ... , true) | tst.js:58:19:58:48 | url.par ... ).query |
+| tst.js:58:19:58:48 | url.par ... ).query | tst.js:58:19:58:52 | url.par ... ery.url |
+| tst.js:58:19:58:52 | url.par ... ery.url | tst.js:58:9:58:52 | tainted |
+| tst.js:58:29:58:35 | req.url | tst.js:58:19:58:42 | url.par ... , true) |
+| tst.js:58:29:58:35 | req.url | tst.js:58:19:58:42 | url.par ... , true) |
 #select
 | tst.js:18:5:18:20 | request(tainted) | tst.js:14:29:14:35 | req.url | tst.js:18:13:18:19 | tainted | The $@ of this request depends on $@. | tst.js:18:13:18:19 | tainted | URL | tst.js:14:29:14:35 | req.url | a user-provided value |
 | tst.js:20:5:20:24 | request.get(tainted) | tst.js:14:29:14:35 | req.url | tst.js:20:17:20:23 | tainted | The $@ of this request depends on $@. | tst.js:20:17:20:23 | tainted | URL | tst.js:14:29:14:35 | req.url | a user-provided value |
@@ -88,3 +107,5 @@ edges
 | tst.js:41:5:41:52 | request ... nted}`) | tst.js:14:29:14:35 | req.url | tst.js:41:13:41:51 | `http:/ ... inted}` | The $@ of this request depends on $@. | tst.js:41:13:41:51 | `http:/ ... inted}` | URL | tst.js:14:29:14:35 | req.url | a user-provided value |
 | tst.js:43:5:43:55 | request ... nted}`) | tst.js:14:29:14:35 | req.url | tst.js:43:13:43:54 | `http:/ ... inted}` | The $@ of this request depends on $@. | tst.js:43:13:43:54 | `http:/ ... inted}` | URL | tst.js:14:29:14:35 | req.url | a user-provided value |
 | tst.js:45:5:45:57 | request ... ainted) | tst.js:14:29:14:35 | req.url | tst.js:45:13:45:56 | 'http:/ ... tainted | The $@ of this request depends on $@. | tst.js:45:13:45:56 | 'http:/ ... tainted | URL | tst.js:14:29:14:35 | req.url | a user-provided value |
+| tst.js:61:2:61:37 | client. ... inted}) | tst.js:58:29:58:35 | req.url | tst.js:61:29:61:35 | tainted | The $@ of this request depends on $@. | tst.js:61:29:61:35 | tainted | URL | tst.js:58:29:58:35 | req.url | a user-provided value |
+| tst.js:64:3:64:38 | client. ... inted}) | tst.js:58:29:58:35 | req.url | tst.js:64:30:64:36 | tainted | The $@ of this request depends on $@. | tst.js:64:30:64:36 | tainted | URL | tst.js:58:29:58:35 | req.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-918/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-918/tst.js
@@ -52,3 +52,15 @@ var server = http.createServer(function(req, res) {
 
     request(`${base}${tainted}`); // OK - assumed safe
 })
+
+var CDP = require("chrome-remote-interface");
+var server = http.createServer(async function(req, res) {
+    var tainted = url.parse(req.url, true).query.url;
+
+    var client = await CDP(options);
+	client.Page.navigate({url: tainted}); // NOT OK.
+	
+	CDP(options, (client) => {
+		client.Page.navigate({url: tainted}); // NOT OK.	
+	});
+})


### PR DESCRIPTION
[`chrome-remote-interface`](https://www.npmjs.com/package/chrome-remote-interface) is a [somewhat often used](https://github.com/cyrus-and/chrome-remote-interface/network/dependents) library for remote controlling browsers. 

In CVE-2017-18355 the library was used to request a user controlled URL, and the contents of the URL was returned to the user. This allowed an arbitrary file read (by starting the URL with `file://`). 

To support the CVE we only need to add a sink. 

There are two options for which query the sink belongs to: `js/path-injection` or `js/request-forgery`. 

I've chosen to model the sink as a `ClientRequest`, as the sink sends a network request to an arbitrary URL, and the query is therefore `js/request-forgery`. 

Here are some example projects that use the sink: https://lgtm.com/query/5288831567363067439/