### PR TITLE
C++: Align definition of anonymous union with the C/C++ standard

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Union.qll
+++ b/cpp/ql/src/semmle/code/cpp/Union.qll
@@ -20,7 +20,7 @@ class Union extends Struct {
   override predicate isDeeplyConstBelow() { any() } // No subparts
 
   /** Holds if this type is anonymous. */
-  final predicate isAnonymous() { getName().matches("(unnamed%") }
+  final predicate isAnonymous() { getName() = "union <unnamed>" }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/Union.qll
+++ b/cpp/ql/src/semmle/code/cpp/Union.qll
@@ -71,6 +71,15 @@ class NestedUnion extends Union {
   predicate isPublic() { this.hasSpecifier("public") }
 }
 
+/**
+ * A C/C++ anonymous union. For example:
+ * ```
+ * union {
+ *   int i;
+ *   float f;
+ * };
+ * ```
+ */
 class AnonymousUnion extends Union {
   AnonymousUnion() { this.isAnonymous() }
 }

--- a/cpp/ql/src/semmle/code/cpp/Union.qll
+++ b/cpp/ql/src/semmle/code/cpp/Union.qll
@@ -20,7 +20,10 @@ class Union extends Struct {
   override predicate isDeeplyConstBelow() { any() } // No subparts
 
   /** Holds if this type is anonymous. */
-  final predicate isAnonymous() { getName() = "union <unnamed>" }
+  final predicate isAnonymous() {
+    getName() = "union <unnamed>" and
+    exists(Variable v | v.getType() = this and v.getName() = "(null)")
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/Union.qll
+++ b/cpp/ql/src/semmle/code/cpp/Union.qll
@@ -18,6 +18,9 @@ class Union extends Struct {
   override string explain() { result = "union " + this.getName() }
 
   override predicate isDeeplyConstBelow() { any() } // No subparts
+
+  /** Holds if this type is anonymous. */
+  final predicate isAnonymous() { getName().matches("(unnamed%") }
 }
 
 /**
@@ -63,4 +66,8 @@ class NestedUnion extends Union {
 
   /** Holds if this member is public. */
   predicate isPublic() { this.hasSpecifier("public") }
+}
+
+class AnonymousUnion extends Union {
+  AnonymousUnion() { this.isAnonymous() }
 }

--- a/cpp/ql/src/semmle/code/cpp/UserType.qll
+++ b/cpp/ql/src/semmle/code/cpp/UserType.qll
@@ -30,9 +30,6 @@ class UserType extends Type, Declaration, NameQualifyingElement, AccessHolder, @
 
   override predicate hasName(string name) { usertypes(underlyingElement(this), name, _) }
 
-  /** Holds if this type is anonymous. */
-  predicate isAnonymous() { getName().matches("(unnamed%") }
-
   override predicate hasSpecifier(string s) { Type.super.hasSpecifier(s) }
 
   override Specifier getASpecifier() { result = Type.super.getASpecifier() }

--- a/cpp/ql/test/library-tests/unions/Unions1.expected
+++ b/cpp/ql/test/library-tests/unions/Unions1.expected
@@ -4,3 +4,5 @@
 | unions.cpp:27:9:27:20 | MyLocalUnion | LocalUnion, Struct, Union |  | operator= |
 | unions.cpp:33:7:33:13 | MyClass |  |  | operator= |
 | unions.cpp:36:9:36:21 | MyNestedUnion | NestedUnion, Struct, Union |  | operator= |
+| unions.cpp:43:9:43:9 | union <unnamed> | LocalUnion, Struct, Union |  | operator= |
+| unions.cpp:48:9:48:9 | union <unnamed> | LocalUnion, Struct, Union |  | operator= |

--- a/cpp/ql/test/library-tests/unions/Unions1.expected
+++ b/cpp/ql/test/library-tests/unions/Unions1.expected
@@ -5,4 +5,4 @@
 | unions.cpp:33:7:33:13 | MyClass |  |  | operator= |
 | unions.cpp:36:9:36:21 | MyNestedUnion | NestedUnion, Struct, Union |  | operator= |
 | unions.cpp:43:9:43:9 | union <unnamed> | AnonymousUnion, LocalUnion, Struct, Union |  | operator= |
-| unions.cpp:48:9:48:9 | union <unnamed> | AnonymousUnion, LocalUnion, Struct, Union |  | operator= |
+| unions.cpp:48:9:48:9 | union <unnamed> | LocalUnion, Struct, Union |  | operator= |

--- a/cpp/ql/test/library-tests/unions/Unions1.expected
+++ b/cpp/ql/test/library-tests/unions/Unions1.expected
@@ -4,5 +4,5 @@
 | unions.cpp:27:9:27:20 | MyLocalUnion | LocalUnion, Struct, Union |  | operator= |
 | unions.cpp:33:7:33:13 | MyClass |  |  | operator= |
 | unions.cpp:36:9:36:21 | MyNestedUnion | NestedUnion, Struct, Union |  | operator= |
-| unions.cpp:43:9:43:9 | union <unnamed> | LocalUnion, Struct, Union |  | operator= |
-| unions.cpp:48:9:48:9 | union <unnamed> | LocalUnion, Struct, Union |  | operator= |
+| unions.cpp:43:9:43:9 | union <unnamed> | AnonymousUnion, LocalUnion, Struct, Union |  | operator= |
+| unions.cpp:48:9:48:9 | union <unnamed> | AnonymousUnion, LocalUnion, Struct, Union |  | operator= |

--- a/cpp/ql/test/library-tests/unions/Unions1.ql
+++ b/cpp/ql/test/library-tests/unions/Unions1.ql
@@ -12,6 +12,9 @@ string describe(Class c) {
   or
   c instanceof NestedUnion and
   result = "NestedUnion"
+  or
+  c instanceof AnonymousUnion and
+  result = "AnonymousUnion"
 }
 
 from Class c

--- a/cpp/ql/test/library-tests/unions/unions.cpp
+++ b/cpp/ql/test/library-tests/unions/unions.cpp
@@ -48,5 +48,5 @@ void test_anonymous_union() {
   union {
     int u3;
     char* u4;
-  } local_union;
+  } not_an_anonymous_union;
 }

--- a/cpp/ql/test/library-tests/unions/unions.cpp
+++ b/cpp/ql/test/library-tests/unions/unions.cpp
@@ -38,3 +38,15 @@ public:
     float f;
   };
 };
+
+void test_anonymous_union() {
+  union {
+    int u1;
+    char* u2;
+  };
+
+  union {
+    int u3;
+    char* u4;
+  } local_union;
+}


### PR DESCRIPTION
Stumbled upon this while working on something else. This PR does three things:

1. Move `isAnonymous` from `UserType` to `Union`.
2. Fix the implementation of `isAnonymous` to match the behaviour of the extractor.
3. Align the implementation of `isAnonymous` with the definition of anonymous unions in the C++14 standard.

The motivation for the first change is that the C++14 standard only mentions anonymity when talking about unions.

The motivation for the third change is that the following is not considered an anonymous union in the C++14 standard:
```
union {
  int i;
  float f;
} u;
```