### PR TITLE
Don't chain to ./codeql in .codeqlmanifest.json

### DIFF
--- a/.codeqlmanifest.json
+++ b/.codeqlmanifest.json
@@ -2,5 +2,4 @@
                "*/ql/test/qlpack.yml",
                "*/upgrades/qlpack.yml",
                "misc/legacy-support/*/qlpack.yml",
-               "misc/suite-helpers/qlpack.yml",
-               "codeql/.codeqlmanifest.json" ] }
+               "misc/suite-helpers/qlpack.yml" ] }


### PR DESCRIPTION
This entry in `.codeqlmanifest.json` was intended to allow unpacking the CodeQL CLI as a subdirectory of `ql`, and things would Just Work.

However, it is not necessary anymore because recent releases of the CLI will search their own directory as a fallback _independently_ of the parent directory.

On the contrary, removing this link will make internal testing easier because you then run a test build of the CLI with `--search-path` pointing to the `ql` checkout without inadvertently making extractors in a _different_ build that is unpacked there visible.