### PR TITLE
C++: Change import order for stable cache checksum

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -3,9 +3,12 @@
  */
 
 private import cpp
+// The `ValueNumbering` library has to be imported right after `cpp` to ensure
+// that the cached IR gets the same checksum here as it does in queries that use
+// `ValueNumbering` without `DataFlow`.
+private import semmle.code.cpp.ir.ValueNumbering
 private import semmle.code.cpp.ir.IR
 private import semmle.code.cpp.controlflow.IRGuards
-private import semmle.code.cpp.ir.ValueNumbering
 private import semmle.code.cpp.models.interfaces.DataFlow
 
 private newtype TIRDataFlowNode =


### PR DESCRIPTION
Without this fix, running the full LGTM suite would get the IR evaluated twice. That's because we have multiple IPA types and constructors with the same name (like `TInstruction` and `MkIRFunction`), and the QL compiler chooses how to disambiguate those names differently depending on import order.

I've tested that the IR is only evaluated once now by running the whole suite on a tiny project (jbj/magicrescue) and looking at the output of

    perl -ne 'print if /^RESULTS IN:/ .. /^\[/ and not /^\[/' runSnapshotQueries-debug.log | sort |uniq -c |sort -n |less