### PR TITLE
JavaScript: Add model of `http2` compatibility API.

### DIFF
--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -26,6 +26,7 @@
   - [for-own](https://www.npmjs.com/package/for-own)
   - [send](https://www.npmjs.com/package/send)
   - [chrome-remote-interface](https://www.npmjs.com/package/chrome-remote-interface)
+  - [http2](https://nodejs.org/api/http2.html)
 
 ## New queries
 

--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -12,21 +12,21 @@
 * The analysis of sanitizer guards has improved, leading to fewer false-positive results from the security queries.
 
 * Support for the following frameworks and libraries has been improved:
-  - [react](https://www.npmjs.com/package/react)
-  - [typeahead.js](https://www.npmjs.com/package/typeahead.js)
-  - [Handlebars](https://www.npmjs.com/package/handlebars)
   - [Electron](https://electronjs.org/)
+  - [Handlebars](https://www.npmjs.com/package/handlebars)
+  - [Koa](https://www.npmjs.com/package/koa)
   - [Node.js](https://nodejs.org/)
   - [Socket.IO](https://socket.io/)
-  - [ws](https://github.com/websockets/ws)
   - [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API)
-  - [Koa](https://www.npmjs.com/package/koa)
-  - [lazy-cache](https://www.npmjs.com/package/lazy-cache)
+  - [chrome-remote-interface](https://www.npmjs.com/package/chrome-remote-interface)
   - [for-in](https://www.npmjs.com/package/for-in)
   - [for-own](https://www.npmjs.com/package/for-own)
-  - [send](https://www.npmjs.com/package/send)
-  - [chrome-remote-interface](https://www.npmjs.com/package/chrome-remote-interface)
   - [http2](https://nodejs.org/api/http2.html)
+  - [lazy-cache](https://www.npmjs.com/package/lazy-cache)
+  - [react](https://www.npmjs.com/package/react)
+  - [send](https://www.npmjs.com/package/send)
+  - [typeahead.js](https://www.npmjs.com/package/typeahead.js)
+  - [ws](https://github.com/websockets/ws)
 
 ## New queries
 

--- a/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/HTTP.qll
@@ -119,8 +119,11 @@ module HTTP {
   }
 
   /**
+   * DEPRECATED: Use `http` or `https` directly as appropriate.
+   *
    * Gets the string `http` or `https`.
    */
+  deprecated
   string httpOrHttps() { result = "http" or result = "https" }
 
   /**

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/createServer.js
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/createServer.js
@@ -1,3 +1,4 @@
 var https = require('https');
 https.createServer(function (req, res) {});
 https.createServer(o, function (req, res) {});
+require('http2').createServer((req, res) => {});

--- a/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
+++ b/javascript/ql/test/library-tests/frameworks/NodeJSLib/tests.expected
@@ -1,6 +1,7 @@
 test_isCreateServer
 | createServer.js:2:1:2:42 | https.c ... es) {}) |
 | createServer.js:3:1:3:45 | https.c ... es) {}) |
+| createServer.js:4:1:4:47 | require ...  => {}) |
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) |
 | src/http.js:57:1:57:31 | http.cr ... dler()) |
@@ -51,6 +52,7 @@ test_HeaderDefinition
 test_RouteSetup_getServer
 | createServer.js:2:1:2:42 | https.c ... es) {}) | createServer.js:2:1:2:42 | https.c ... es) {}) |
 | createServer.js:3:1:3:45 | https.c ... es) {}) | createServer.js:3:1:3:45 | https.c ... es) {}) |
+| createServer.js:4:1:4:47 | require ...  => {}) | createServer.js:4:1:4:47 | require ...  => {}) |
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) | src/http.js:12:1:16:2 | http.cr ... r");\\n}) |
 | src/http.js:57:1:57:31 | http.cr ... dler()) | src/http.js:57:1:57:31 | http.cr ... dler()) |
@@ -72,6 +74,7 @@ test_HeaderDefinition_getAHeaderName
 test_ServerDefinition
 | createServer.js:2:1:2:42 | https.c ... es) {}) |
 | createServer.js:3:1:3:45 | https.c ... es) {}) |
+| createServer.js:4:1:4:47 | require ...  => {}) |
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) |
 | src/http.js:57:1:57:31 | http.cr ... dler()) |
@@ -103,6 +106,7 @@ test_RouteHandler_getAResponseExpr
 test_ServerDefinition_getARouteHandler
 | createServer.js:2:1:2:42 | https.c ... es) {}) | createServer.js:2:20:2:41 | functio ... res) {} |
 | createServer.js:3:1:3:45 | https.c ... es) {}) | createServer.js:3:23:3:44 | functio ... res) {} |
+| createServer.js:4:1:4:47 | require ...  => {}) | createServer.js:4:31:4:46 | (req, res) => {} |
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:57:1:57:31 | http.cr ... dler()) | src/http.js:55:12:55:30 | function(req,res){} |
@@ -120,6 +124,7 @@ test_ResponseSendArgument
 test_RouteSetup_getARouteHandler
 | createServer.js:2:1:2:42 | https.c ... es) {}) | createServer.js:2:20:2:41 | functio ... res) {} |
 | createServer.js:3:1:3:45 | https.c ... es) {}) | createServer.js:3:23:3:44 | functio ... res) {} |
+| createServer.js:4:1:4:47 | require ...  => {}) | createServer.js:4:31:4:46 | (req, res) => {} |
 | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) | src/http.js:4:32:10:1 | functio ... .foo;\\n} |
 | src/http.js:12:1:16:2 | http.cr ... r");\\n}) | src/http.js:12:19:16:1 | functio ... ar");\\n} |
 | src/http.js:57:1:57:31 | http.cr ... dler()) | src/http.js:55:12:55:30 | function(req,res){} |
@@ -147,6 +152,7 @@ test_RemoteFlowSources
 test_RouteHandler
 | createServer.js:2:20:2:41 | functio ... res) {} | createServer.js:2:1:2:42 | https.c ... es) {}) |
 | createServer.js:3:23:3:44 | functio ... res) {} | createServer.js:3:1:3:45 | https.c ... es) {}) |
+| createServer.js:4:31:4:46 | (req, res) => {} | createServer.js:4:1:4:47 | require ...  => {}) |
 | src/http.js:4:32:10:1 | functio ... .foo;\\n} | src/http.js:4:14:10:2 | http.cr ... foo;\\n}) |
 | src/http.js:12:19:16:1 | functio ... ar");\\n} | src/http.js:12:1:16:2 | http.cr ... r");\\n}) |
 | src/http.js:55:12:55:30 | function(req,res){} | src/http.js:57:1:57:31 | http.cr ... dler()) |


### PR DESCRIPTION
Also deprecated the `httpOrHttps` predicate, which was now only used in one place and seemed a little pointless anyway.

[Evaluation](https://git.semmle.com/max/dist-compare-reports/blob/master/js/http2/report.md) shows four new results on react. These true (though probably not exploitable) positives were the original motivation for this PR. Performance could look happier, but considering the very minor changes in this PR I'm inclined to attribute this to an acute case of the wobbles; let me know if you disagree, I'd be happy to rerun selected projects.