### PR TITLE
C++: Add TLoadTotalOverlapValueNumber to getKind predicate

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/internal/ASTValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/ASTValueNumbering.qll
@@ -97,6 +97,8 @@ class GVN extends TValueNumber {
     or
     this instanceof TInheritanceConversionValueNumber and result = "InheritanceConversion"
     or
+    this instanceof TLoadTotalOverlapValueNumber and result = "LoadTotalOverlap"
+    or
     this instanceof TUniqueValueNumber and result = "Unique"
   }
 


### PR DESCRIPTION
The `getKind` predicate in the AST value numbering wrapper was missing a case for `TLoadTotalOverlapValueNumber`.