### PR TITLE
C++/C#/Java: Bad join order in pathStep

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -2083,14 +2083,18 @@ private class PathNodeSink extends PathNode, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf |
+  exists(
+    LocalCallContext localCC, AccessPath ap0, Node midnode, Configuration conf,
+    DataFlowCallable call
+  |
     midnode = mid.getNode() and
     conf = mid.getConfiguration() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
-    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    call = midnode.getEnclosingCallable() and
     ap0 = mid.getAp()
   |
+    localCC = getLocalCallContext(cc, call) and
     localFlowBigStep(midnode, node, true, conf, localCC) and
     ap = ap0
     or


### PR DESCRIPTION
Fixes a bad join order caused by joining with `CallContext::relevantFor` before `Node::getFunction`.

Before:
```
Tuple counts for DataFlowImplLocal::pathStep#fffff#cur_delta:
                      133      ~0%        {6} r1 = SCAN DataFlowImplLocal::PathNodeMid#class#ffffff#prev_delta AS I OUTPUT I.<2>, I.<0>, I.<1>, I.<3>, I.<4>, I.<5>
                      81894284 ~3%        {7} r2 = JOIN r1 WITH DataFlowImplCommon::ImplCommon::CallContext::relevantFor_dispred#ff AS R ON FIRST 1 OUTPUT r1.<2>, R.<1>, r1.<1>, r1.<0>, r1.<3>, r1.<4>, r1.<5>
                      133      ~3%        {7} r3 = JOIN r2 WITH DataFlowUtil::Node::getFunction_dispred#ff AS R ON FIRST 2 OUTPUT r2.<0>, true, r2.<6>, r2.<2>, r2.<3>, r2.<4>, r2.<5>
                      0        ~0%        {5} r4 = JOIN r3 WITH DataFlowImplLocal::localFlowBigStep#fffff_0231#join_rhs AS R ON FIRST 3 OUTPUT r3.<3>, r3.<4>, r3.<5>, r3.<6>, R.<3>
```

After:
```
Tuple counts for DataFlowImplLocal::pathStep#fffff#cur_delta:
                      7056    ~1%       {6} r1 = SCAN DataFlowImplLocal::PathNodeMid#class#ffffff#prev_delta AS I OUTPUT I.<1>, I.<0>, I.<2>, I.<3>, I.<4>, I.<5>
                      7056    ~1%       {7} r2 = JOIN r1 WITH DataFlowUtil::Node::getFunction_dispred#ff AS R ON FIRST 1 OUTPUT r1.<2>, R.<1>, r1.<1>, r1.<0>, r1.<3>, r1.<4>, r1.<5>
                      7056    ~0%       {7} r3 = JOIN r2 WITH DataFlowImplCommon::ImplCommon::getLocalCallContext#cpe#12#ff AS R ON FIRST 2 OUTPUT r2.<3>, r2.<1>, r2.<2>, r2.<0>, r2.<4>, r2.<5>, r2.<6>
                      7056    ~1%       {7} r4 = JOIN r3 WITH DataFlowUtil::Node::getFunction_dispred#ff AS R ON FIRST 2 OUTPUT r3.<0>, true, r3.<6>, r3.<2>, r3.<3>, r3.<4>, r3.<5>
                      2       ~0%       {5} r5 = JOIN r4 WITH DataFlowImplLocal::localFlowBigStep#fffff_0231#join_rhs AS R ON FIRST 3 OUTPUT r4.<3>, r4.<4>, r4.<5>, r4.<6>, R.<3>
                      7056    ~0%       {7} r6 = JOIN r1 WITH DataFlowUtil::Node::getFunction_dispred#ff AS R ON FIRST 1 OUTPUT r1.<4>, r1.<1>, r1.<0>, r1.<2>, r1.<3>, r1.<5>, R.<1>
                      7056    ~0%       {6} r7 = JOIN r6 WITH DataFlowImplLocal::TNil#ff_1#join_rhs AS R ON FIRST 1 OUTPUT r6.<2>, r6.<6>, r6.<1>, r6.<3>, r6.<4>, r6.<5>
                      7056    ~0%       {6} r8 = JOIN r7 WITH DataFlowUtil::Node::getFunction_dispred#ff AS R ON FIRST 2 OUTPUT r7.<0>, false, r7.<5>, r7.<2>, r7.<3>, r7.<4>
                      0       ~0%       {4} r9 = JOIN r8 WITH DataFlowImplLocal::localFlowBigStep#fffff_0231#join_rhs AS R ON FIRST 3 OUTPUT R.<3>, r8.<3>, r8.<4>, r8.<5>
```

With these changes I can analyse `CGAL/cgal-swig-bindings` and `scribusproject/scribus` locally without timeouts.