### PR TITLE
C++: Manual magic for `isInCycle`

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
@@ -103,6 +103,19 @@ private module Cached {
   }
 
   /**
+   * Gets a non-phi instruction that defines an operand of `instr` but only if
+   * both `instr` and the result have neighbor on the other side of the edge
+   * between them. This is a necessary condition for being in a cycle, and it
+   * removes about two thirds of the tuples that would otherwise be in this
+   * predicate.
+   */
+  private Instruction getNonPhiOperandDefOfIntermediate(Instruction instr) {
+    result = getNonPhiOperandDef(instr) and
+    exists(getNonPhiOperandDef(result)) and
+    instr = getNonPhiOperandDef(_)
+  }
+
+  /**
    * Holds if `instr` is part of a cycle in the operand graph that doesn't go
    * through a phi instruction and therefore should be impossible.
    *
@@ -115,7 +128,7 @@ private module Cached {
   cached
   predicate isInCycle(Instruction instr) {
     instr instanceof Instruction and
-    getNonPhiOperandDef+(instr) = instr
+    getNonPhiOperandDefOfIntermediate+(instr) = instr
   }
 
   cached


### PR DESCRIPTION
The `isInCycle` predicate would take a long time on Wireshark with 6GB RAM, sometimes OOMing in the fastTC HOP. Analyzing wireshark with 6GB is important because that's the standard configuration on our Jenkins workers. With this commit, I can analyze Wireshark with 6GB on my laptop.

The `getNonPhiOperandDef` predicate on Wireshark is 34M tuples, while `getDefIfHasNeighbors` is 11M tuples, and the TC of `getDefIfHasNeighbors` is 23M tuples (487 MB).