### PR TITLE
C#: Add runtime identifiers to project files

### DIFF
--- a/csharp/autobuilder/Semmle.Autobuild.Tests/Semmle.Autobuild.Tests.csproj
+++ b/csharp/autobuilder/Semmle.Autobuild.Tests/Semmle.Autobuild.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/autobuilder/Semmle.Autobuild/Semmle.Autobuild.csproj
+++ b/csharp/autobuilder/Semmle.Autobuild/Semmle.Autobuild.csproj
@@ -8,6 +8,7 @@
     <OutputType>Exe</OutputType>
     <StartupObject />
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/extractor/Semmle.Extraction.CIL.Driver/Semmle.Extraction.CIL.Driver.csproj
+++ b/csharp/extractor/Semmle.Extraction.CIL.Driver/Semmle.Extraction.CIL.Driver.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>Semmle.Extraction.CIL.Driver</AssemblyName>
     <RootNamespace>Semmle.Extraction.CIL.Driver</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/extractor/Semmle.Extraction.CIL/Semmle.Extraction.CIL.csproj
+++ b/csharp/extractor/Semmle.Extraction.CIL/Semmle.Extraction.CIL.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Semmle.Extraction.CIL</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/csharp/extractor/Semmle.Extraction.CSharp.Driver/Semmle.Extraction.CSharp.Driver.csproj
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Driver/Semmle.Extraction.CSharp.Driver.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>Semmle.Extraction.CSharp.Driver</AssemblyName>
     <RootNamespace>Semmle.Extraction.CSharp.Driver</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Semmle.Extraction.CSharp.Standalone.csproj
+++ b/csharp/extractor/Semmle.Extraction.CSharp.Standalone/Semmle.Extraction.CSharp.Standalone.csproj
@@ -9,6 +9,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/extractor/Semmle.Extraction.CSharp/Semmle.Extraction.CSharp.csproj
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Semmle.Extraction.CSharp.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Semmle.Extraction.CSharp</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/extractor/Semmle.Extraction.Tests/Semmle.Extraction.Tests.csproj
+++ b/csharp/extractor/Semmle.Extraction.Tests/Semmle.Extraction.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/extractor/Semmle.Extraction/Semmle.Extraction.csproj
+++ b/csharp/extractor/Semmle.Extraction/Semmle.Extraction.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Semmle.Extraction</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <CodeAnalysisRuleSet>Semmle.Extraction.ruleset</CodeAnalysisRuleSet>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/csharp/extractor/Semmle.Util.Tests/Semmle.Util.Tests.csproj
+++ b/csharp/extractor/Semmle.Util.Tests/Semmle.Util.Tests.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/extractor/Semmle.Util/Semmle.Util.csproj
+++ b/csharp/extractor/Semmle.Util/Semmle.Util.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>Semmle.Util</AssemblyName>
     <RootNamespace>Semmle.Util</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This helps me build locally on Windows, when I try to build using Visual Studio.