### PR TITLE
JS: Do not flag void operands MissingAwait

### DIFF
--- a/javascript/ql/src/Expressions/MissingAwait.ql
+++ b/javascript/ql/src/Expressions/MissingAwait.ql
@@ -43,7 +43,10 @@ predicate isBadPromiseContext(Expr expr) {
   or
   expr = any(LogicalBinaryExpr e).getLeftOperand()
   or
-  expr = any(UnaryExpr e).getOperand()
+  exists(UnaryExpr e |
+    expr = e.getOperand() and
+    not e instanceof VoidExpr
+  )
   or
   expr = any(UpdateExpr e).getOperand()
   or

--- a/javascript/ql/test/query-tests/Expressions/MissingAwait/tst.js
+++ b/javascript/ql/test/query-tests/Expressions/MissingAwait/tst.js
@@ -61,3 +61,7 @@ function useThingPossiblySync(b) {
 
     return thing + "bar"; // NOT OK - but we don't flag it
 }
+
+function useThingInVoid() {
+    void getThing(); // OK
+}


### PR DESCRIPTION
Fixes the FP in https://github.com/Semmle/ql/issues/2865