### PR TITLE
C#: Fix compilation of ValueNumberingInternal

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/internal/ValueNumberingInternal.qll
@@ -45,6 +45,11 @@ newtype TValueNumber =
   ) {
     inheritanceConversionValueNumber(_, irFunc, opcode, baseClass, derivedClass, operand)
   } or
+  TLoadTotalOverlapValueNumber(
+    IRFunction irFunc, IRType type, TValueNumber memOperand, TValueNumber operand
+  ) {
+    none()
+  } or
   TUniqueValueNumber(IRFunction irFunc, Instruction instr) { uniqueValueNumber(instr, irFunc) }
 
 /**
@@ -191,6 +196,12 @@ private predicate uniqueValueNumber(Instruction instr, IRFunction irFunc) {
   not instr.getResultIRType() instanceof IRVoidType and
   not numberableInstruction(instr)
 }
+
+/**
+ * Gets the value number assigned to the exact definition of `op`, if any.
+ * Returns at most one result.
+ */
+TValueNumber tvalueNumberOfOperand(Operand op) { result = tvalueNumber(op.getDef()) }
 
 /**
  * Gets the value number assigned to `instr`, if any. Returns at most one result.


### PR DESCRIPTION
Fixes the compilation of C# qldocs, for example `build target/packs/pack-csharp-qldoc.zip` on the internal repository.

I'm not quite sure what `TLoadTotalOverlapValueNumber` means for C# so I left it `none()`. Since C# doesn't have `union`, this is probably correct.