### PR TITLE
C++: Fix a test that should be working on the AST dataflow.

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/security-taint/tainted.expected
+++ b/cpp/ql/test/library-tests/dataflow/security-taint/tainted.expected
@@ -15,27 +15,39 @@
 | test.cpp:38:23:38:28 | call to getenv | test.cpp:38:23:38:28 | call to getenv |  |
 | test.cpp:38:23:38:28 | call to getenv | test.cpp:38:23:38:40 | (const char *)... |  |
 | test.cpp:38:23:38:28 | call to getenv | test.cpp:40:14:40:19 | envStr |  |
-| test.cpp:49:23:49:28 | call to getenv | test.cpp:8:24:8:25 | s1 |  |
+| test.cpp:49:23:49:28 | call to getenv | test.cpp:8:24:8:25 | s1 | envStrGlobal |
 | test.cpp:49:23:49:28 | call to getenv | test.cpp:45:13:45:24 | envStrGlobal |  |
+| test.cpp:49:23:49:28 | call to getenv | test.cpp:45:13:45:24 | envStrGlobal | envStrGlobal |
 | test.cpp:49:23:49:28 | call to getenv | test.cpp:49:14:49:19 | envStr |  |
 | test.cpp:49:23:49:28 | call to getenv | test.cpp:49:23:49:28 | call to getenv |  |
 | test.cpp:49:23:49:28 | call to getenv | test.cpp:49:23:49:40 | (const char *)... |  |
+| test.cpp:49:23:49:28 | call to getenv | test.cpp:50:15:50:24 | envStr_ptr |  |
+| test.cpp:49:23:49:28 | call to getenv | test.cpp:50:15:50:24 | envStr_ptr | envStrGlobal |
+| test.cpp:49:23:49:28 | call to getenv | test.cpp:50:28:50:40 | & ... | envStrGlobal |
+| test.cpp:49:23:49:28 | call to getenv | test.cpp:50:29:50:40 | envStrGlobal | envStrGlobal |
+| test.cpp:49:23:49:28 | call to getenv | test.cpp:52:2:52:12 | * ... |  |
+| test.cpp:49:23:49:28 | call to getenv | test.cpp:52:3:52:12 | envStr_ptr |  |
 | test.cpp:49:23:49:28 | call to getenv | test.cpp:52:16:52:21 | envStr |  |
-| test.cpp:49:23:49:28 | call to getenv | test.cpp:54:6:54:35 | ! ... |  |
-| test.cpp:49:23:49:28 | call to getenv | test.cpp:54:7:54:12 | call to strcmp |  |
-| test.cpp:49:23:49:28 | call to getenv | test.cpp:54:7:54:35 | (bool)... |  |
-| test.cpp:49:23:49:28 | call to getenv | test.cpp:54:14:54:25 | envStrGlobal |  |
+| test.cpp:49:23:49:28 | call to getenv | test.cpp:54:6:54:35 | ! ... | envStrGlobal |
+| test.cpp:49:23:49:28 | call to getenv | test.cpp:54:7:54:12 | call to strcmp | envStrGlobal |
+| test.cpp:49:23:49:28 | call to getenv | test.cpp:54:7:54:35 | (bool)... | envStrGlobal |
+| test.cpp:49:23:49:28 | call to getenv | test.cpp:54:14:54:25 | envStrGlobal | envStrGlobal |
 | test.cpp:60:29:60:34 | call to getenv | test.cpp:10:27:10:27 | s |  |
 | test.cpp:60:29:60:34 | call to getenv | test.cpp:60:18:60:25 | userName |  |
 | test.cpp:60:29:60:34 | call to getenv | test.cpp:60:29:60:34 | call to getenv |  |
 | test.cpp:60:29:60:34 | call to getenv | test.cpp:60:29:60:47 | (const char *)... |  |
 | test.cpp:60:29:60:34 | call to getenv | test.cpp:64:25:64:32 | userName |  |
+| test.cpp:68:28:68:33 | call to getenv | test.cpp:11:20:11:21 | s1 |  |
 | test.cpp:68:28:68:33 | call to getenv | test.cpp:11:36:11:37 | s2 |  |
+| test.cpp:68:28:68:33 | call to getenv | test.cpp:67:7:67:13 | copying |  |
 | test.cpp:68:28:68:33 | call to getenv | test.cpp:68:17:68:24 | userName |  |
 | test.cpp:68:28:68:33 | call to getenv | test.cpp:68:28:68:33 | call to getenv |  |
 | test.cpp:68:28:68:33 | call to getenv | test.cpp:68:28:68:46 | (const char *)... |  |
+| test.cpp:68:28:68:33 | call to getenv | test.cpp:69:10:69:13 | copy |  |
 | test.cpp:68:28:68:33 | call to getenv | test.cpp:70:5:70:10 | call to strcpy |  |
+| test.cpp:68:28:68:33 | call to getenv | test.cpp:70:12:70:15 | copy |  |
 | test.cpp:68:28:68:33 | call to getenv | test.cpp:70:18:70:25 | userName |  |
+| test.cpp:68:28:68:33 | call to getenv | test.cpp:71:12:71:15 | copy |  |
 | test.cpp:75:20:75:25 | call to getenv | test.cpp:15:22:15:25 | nptr |  |
 | test.cpp:75:20:75:25 | call to getenv | test.cpp:75:15:75:18 | call to atoi |  |
 | test.cpp:75:20:75:25 | call to getenv | test.cpp:75:20:75:25 | call to getenv |  |

--- a/cpp/ql/test/library-tests/dataflow/security-taint/tainted.ql
+++ b/cpp/ql/test/library-tests/dataflow/security-taint/tainted.ql
@@ -1,4 +1,4 @@
-import semmle.code.cpp.security.TaintTracking
+import semmle.code.cpp.security.TaintTrackingImpl
 
 from Expr source, Element tainted, string globalVar
 where


### PR DESCRIPTION
Following https://github.com/Semmle/ql/pull/2851 there were some AST tests that now test the IR instead (because that's the new default) when they shouldn't.  https://github.com/Semmle/ql/pull/2861 fixed the diff tests.  This fixed an explicit AST taint test in `library-tests\dataflow\security-taint` (the same directory contains an IR taint test and a diff between the two).