### PR TITLE
Python: Improve tarslip sanitizer

### DIFF
--- a/python/ql/src/Security/CWE-022/TarSlip.ql
+++ b/python/ql/src/Security/CWE-022/TarSlip.ql
@@ -124,8 +124,16 @@ class TarFileInfoSanitizer extends Sanitizer {
     /** The test `if <path_sanitizing_test>:` clears taint on its `false` edge. */
     override predicate sanitizingEdge(TaintKind taint, PyEdgeRefinement test) {
         taint instanceof TarFileInfo and
-        path_sanitizing_test(test.getTest()) and
-        test.getSense() = false
+        clears_taint_on_false_edge(test.getTest(), test.getSense())
+    }
+
+    private predicate clears_taint_on_false_edge(ControlFlowNode test, boolean sense) {
+        path_sanitizing_test(test) and
+        sense = false
+        or
+        // handle `not` (also nested)
+        test.(UnaryExprNode).getNode().getOp() instanceof Not and
+        clears_taint_on_false_edge(test.(UnaryExprNode).getOperand(), sense.booleanNot())
     }
 }
 

--- a/python/ql/src/Security/CWE-022/TarSlip.ql
+++ b/python/ql/src/Security/CWE-022/TarSlip.ql
@@ -121,9 +121,11 @@ class ExtractMembersSink extends TaintSink {
 class TarFileInfoSanitizer extends Sanitizer {
     TarFileInfoSanitizer() { this = "TarInfo sanitizer" }
 
+    /** The test `if <path_sanitizing_test>:` clears taint on its `false` edge. */
     override predicate sanitizingEdge(TaintKind taint, PyEdgeRefinement test) {
+        taint instanceof TarFileInfo and
         path_sanitizing_test(test.getTest()) and
-        taint instanceof TarFileInfo
+        test.getSense() = false
     }
 }
 

--- a/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
+++ b/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
@@ -15,8 +15,22 @@ edges
 | tarslip.py:34:14:34:16 | tarfile.open | tarslip.py:34:1:34:17 | tarfile.entry |
 | tarslip.py:40:7:40:39 | tarfile.open | tarslip.py:41:24:41:26 | tarfile.open |
 | tarslip.py:40:7:40:39 | tarfile.open | tarslip.py:41:24:41:26 | tarfile.open |
+| tarslip.py:56:7:56:39 | tarfile.open | tarslip.py:57:14:57:16 | tarfile.open |
+| tarslip.py:56:7:56:39 | tarfile.open | tarslip.py:57:14:57:16 | tarfile.open |
+| tarslip.py:57:1:57:17 | tarfile.entry | tarslip.py:59:21:59:25 | tarfile.entry |
+| tarslip.py:57:1:57:17 | tarfile.entry | tarslip.py:59:21:59:25 | tarfile.entry |
+| tarslip.py:57:14:57:16 | tarfile.open | tarslip.py:57:1:57:17 | tarfile.entry |
+| tarslip.py:57:14:57:16 | tarfile.open | tarslip.py:57:1:57:17 | tarfile.entry |
+| tarslip.py:63:7:63:39 | tarfile.open | tarslip.py:64:14:64:16 | tarfile.open |
+| tarslip.py:63:7:63:39 | tarfile.open | tarslip.py:64:14:64:16 | tarfile.open |
+| tarslip.py:64:1:64:17 | tarfile.entry | tarslip.py:68:21:68:25 | tarfile.entry |
+| tarslip.py:64:1:64:17 | tarfile.entry | tarslip.py:68:21:68:25 | tarfile.entry |
+| tarslip.py:64:14:64:16 | tarfile.open | tarslip.py:64:1:64:17 | tarfile.entry |
+| tarslip.py:64:14:64:16 | tarfile.open | tarslip.py:64:1:64:17 | tarfile.entry |
 #select
 | tarslip.py:13:1:13:3 | tar | tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:13:1:13:3 | tarfile.open | Extraction of tarfile from $@ | tarslip.py:12:7:12:39 | Attribute() | a potentially untrusted source |
 | tarslip.py:18:17:18:21 | entry | tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:18:17:18:21 | tarfile.entry | Extraction of tarfile from $@ | tarslip.py:16:7:16:39 | Attribute() | a potentially untrusted source |
 | tarslip.py:37:17:37:21 | entry | tarslip.py:33:7:33:39 | tarfile.open | tarslip.py:37:17:37:21 | tarfile.entry | Extraction of tarfile from $@ | tarslip.py:33:7:33:39 | Attribute() | a potentially untrusted source |
 | tarslip.py:41:24:41:26 | tar | tarslip.py:40:7:40:39 | tarfile.open | tarslip.py:41:24:41:26 | tarfile.open | Extraction of tarfile from $@ | tarslip.py:40:7:40:39 | Attribute() | a potentially untrusted source |
+| tarslip.py:59:21:59:25 | entry | tarslip.py:56:7:56:39 | tarfile.open | tarslip.py:59:21:59:25 | tarfile.entry | Extraction of tarfile from $@ | tarslip.py:56:7:56:39 | Attribute() | a potentially untrusted source |
+| tarslip.py:68:21:68:25 | entry | tarslip.py:63:7:63:39 | tarfile.open | tarslip.py:68:21:68:25 | tarfile.entry | Extraction of tarfile from $@ | tarslip.py:63:7:63:39 | Attribute() | a potentially untrusted source |

--- a/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
+++ b/python/ql/test/query-tests/Security/CWE-022/TarSlip.expected
@@ -21,16 +21,9 @@ edges
 | tarslip.py:57:1:57:17 | tarfile.entry | tarslip.py:59:21:59:25 | tarfile.entry |
 | tarslip.py:57:14:57:16 | tarfile.open | tarslip.py:57:1:57:17 | tarfile.entry |
 | tarslip.py:57:14:57:16 | tarfile.open | tarslip.py:57:1:57:17 | tarfile.entry |
-| tarslip.py:63:7:63:39 | tarfile.open | tarslip.py:64:14:64:16 | tarfile.open |
-| tarslip.py:63:7:63:39 | tarfile.open | tarslip.py:64:14:64:16 | tarfile.open |
-| tarslip.py:64:1:64:17 | tarfile.entry | tarslip.py:68:21:68:25 | tarfile.entry |
-| tarslip.py:64:1:64:17 | tarfile.entry | tarslip.py:68:21:68:25 | tarfile.entry |
-| tarslip.py:64:14:64:16 | tarfile.open | tarslip.py:64:1:64:17 | tarfile.entry |
-| tarslip.py:64:14:64:16 | tarfile.open | tarslip.py:64:1:64:17 | tarfile.entry |
 #select
 | tarslip.py:13:1:13:3 | tar | tarslip.py:12:7:12:39 | tarfile.open | tarslip.py:13:1:13:3 | tarfile.open | Extraction of tarfile from $@ | tarslip.py:12:7:12:39 | Attribute() | a potentially untrusted source |
 | tarslip.py:18:17:18:21 | entry | tarslip.py:16:7:16:39 | tarfile.open | tarslip.py:18:17:18:21 | tarfile.entry | Extraction of tarfile from $@ | tarslip.py:16:7:16:39 | Attribute() | a potentially untrusted source |
 | tarslip.py:37:17:37:21 | entry | tarslip.py:33:7:33:39 | tarfile.open | tarslip.py:37:17:37:21 | tarfile.entry | Extraction of tarfile from $@ | tarslip.py:33:7:33:39 | Attribute() | a potentially untrusted source |
 | tarslip.py:41:24:41:26 | tar | tarslip.py:40:7:40:39 | tarfile.open | tarslip.py:41:24:41:26 | tarfile.open | Extraction of tarfile from $@ | tarslip.py:40:7:40:39 | Attribute() | a potentially untrusted source |
 | tarslip.py:59:21:59:25 | entry | tarslip.py:56:7:56:39 | tarfile.open | tarslip.py:59:21:59:25 | tarfile.entry | Extraction of tarfile from $@ | tarslip.py:56:7:56:39 | Attribute() | a potentially untrusted source |
-| tarslip.py:68:21:68:25 | entry | tarslip.py:63:7:63:39 | tarfile.open | tarslip.py:68:21:68:25 | tarfile.entry | Extraction of tarfile from $@ | tarslip.py:63:7:63:39 | Attribute() | a potentially untrusted source |

--- a/python/ql/test/query-tests/Security/CWE-022/tarslip.py
+++ b/python/ql/test/query-tests/Security/CWE-022/tarslip.py
@@ -65,4 +65,4 @@ for entry in tar:
     # using `if not (os.path.isabs(entry.name) or ".." in entry.name):`
     # would make the sanitizer work, but for the wrong reasons since out library is a bit broken.
     if not os.path.isabs(entry.name):
-        tar.extract(entry, "/tmp/unpack/") # TODO: FP
+        tar.extract(entry, "/tmp/unpack/")

--- a/python/ql/test/query-tests/Security/CWE-022/tarslip.py
+++ b/python/ql/test/query-tests/Security/CWE-022/tarslip.py
@@ -50,3 +50,19 @@ def safemembers(members):
 
 tar = tarfile.open(unsafe_filename_tar)
 tar.extractall(members=safemembers(tar))
+
+
+# Wrong sanitizer (is missing not)
+tar = tarfile.open(unsafe_filename_tar)
+for entry in tar:
+    if os.path.isabs(entry.name) or ".." in entry.name:
+        tar.extract(entry, "/tmp/unpack/") # TODO: FN
+
+
+# OK Sanitized using not
+tar = tarfile.open(unsafe_filename_tar)
+for entry in tar:
+    # using `if not (os.path.isabs(entry.name) or ".." in entry.name):`
+    # would make the sanitizer work, but for the wrong reasons since out library is a bit broken.
+    if not os.path.isabs(entry.name):
+        tar.extract(entry, "/tmp/unpack/")

--- a/python/ql/test/query-tests/Security/CWE-022/tarslip.py
+++ b/python/ql/test/query-tests/Security/CWE-022/tarslip.py
@@ -62,7 +62,21 @@ for entry in tar:
 # OK Sanitized using not
 tar = tarfile.open(unsafe_filename_tar)
 for entry in tar:
-    # using `if not (os.path.isabs(entry.name) or ".." in entry.name):`
-    # would make the sanitizer work, but for the wrong reasons since out library is a bit broken.
+    if not (os.path.isabs(entry.name) or ".." in entry.name):
+        tar.extract(entry, "/tmp/unpack/")
+
+# The following two variants are included by purpose, since by default there is a
+# difference in handling `not x` and `not (x or False)` when overriding
+# Sanitizer.sanitizingEdge. We want to ensure we handle both consistently.
+
+# Not reported, although vulnerable to '..'
+tar = tarfile.open(unsafe_filename_tar)
+for entry in tar:
+    if not (os.path.isabs(entry.name) or False):
+        tar.extract(entry, "/tmp/unpack/")
+
+# Not reported, although vulnerable to '..'
+tar = tarfile.open(unsafe_filename_tar)
+for entry in tar:
     if not os.path.isabs(entry.name):
         tar.extract(entry, "/tmp/unpack/")

--- a/python/ql/test/query-tests/Security/CWE-022/tarslip.py
+++ b/python/ql/test/query-tests/Security/CWE-022/tarslip.py
@@ -56,7 +56,7 @@ tar.extractall(members=safemembers(tar))
 tar = tarfile.open(unsafe_filename_tar)
 for entry in tar:
     if os.path.isabs(entry.name) or ".." in entry.name:
-        tar.extract(entry, "/tmp/unpack/") # TODO: FN
+        tar.extract(entry, "/tmp/unpack/")
 
 
 # OK Sanitized using not
@@ -65,4 +65,4 @@ for entry in tar:
     # using `if not (os.path.isabs(entry.name) or ".." in entry.name):`
     # would make the sanitizer work, but for the wrong reasons since out library is a bit broken.
     if not os.path.isabs(entry.name):
-        tar.extract(entry, "/tmp/unpack/")
+        tar.extract(entry, "/tmp/unpack/") # TODO: FP


### PR DESCRIPTION
Since the old sanitizer would clear taint on any edge for a test that involves `path`. According to our test-code, this should make the query alert on more thing (correctly), but we should probably check if it has too many FPs before shipping it :shipit: 