### PR TITLE
C++: add more extensive test for desugaring of range-based-for loops

### DIFF
--- a/cpp/ql/test/library-tests/range_based_for/range_based_for.expected
+++ b/cpp/ql/test/library-tests/range_based_for/range_based_for.expected
@@ -1,0 +1,32 @@
+bodies
+| test.cpp:8:3:10:3 | for(...:...) ... | test.cpp:8:28:10:3 | { ... } |
+| test.cpp:28:3:30:3 | for(...:...) ... | test.cpp:28:28:30:3 | { ... } |
+| test.cpp:44:3:46:3 | for(...:...) ... | test.cpp:44:27:46:3 | { ... } |
+variables
+| test.cpp:8:3:10:3 | for(...:...) ... | test.cpp:8:13:8:17 | value | file://:0:0:0:0 | short |
+| test.cpp:28:3:30:3 | for(...:...) ... | test.cpp:28:12:28:16 | value | file://:0:0:0:0 | int |
+| test.cpp:44:3:46:3 | for(...:...) ... | test.cpp:44:13:44:17 | value | file://:0:0:0:0 | long |
+ranges
+| test.cpp:8:3:10:3 | for(...:...) ... | test.cpp:8:21:8:25 | array | file://:0:0:0:0 | short[100] |
+| test.cpp:28:3:30:3 | for(...:...) ... | test.cpp:28:20:28:25 | vector | test.cpp:16:8:16:13 | Vector<int> |
+| test.cpp:44:3:46:3 | for(...:...) ... | test.cpp:44:21:44:24 | list | file://:0:0:0:0 | const List<long> & |
+rangeVariables
+| test.cpp:8:3:10:3 | for(...:...) ... | test.cpp:8:3:8:3 | (__range) | file://:0:0:0:0 | short(&)[100] |
+| test.cpp:28:3:30:3 | for(...:...) ... | test.cpp:28:3:28:3 | (__range) | file://:0:0:0:0 | Vector<int> & |
+| test.cpp:44:3:46:3 | for(...:...) ... | test.cpp:44:3:44:3 | (__range) | file://:0:0:0:0 | const List<long> & |
+conditions
+| test.cpp:8:3:10:3 | for(...:...) ... | file://:0:0:0:0 | ... != ... | file://:0:0:0:0 | (__begin) | file://:0:0:0:0 | (__end) |
+| test.cpp:28:3:30:3 | for(...:...) ... | test.cpp:28:20:28:20 | call to operator!= | file://:0:0:0:0 | (__begin) | file://:0:0:0:0 | (__end) |
+| test.cpp:44:3:46:3 | for(...:...) ... | file://:0:0:0:0 | ... != ... | file://:0:0:0:0 | (__begin) | file://:0:0:0:0 | (__end) |
+beginVariables
+| test.cpp:8:3:10:3 | for(...:...) ... | test.cpp:8:3:8:3 | (__begin) | file://:0:0:0:0 | short * |
+| test.cpp:28:3:30:3 | for(...:...) ... | test.cpp:28:3:28:3 | (__begin) | test.cpp:17:10:17:17 | Iterator |
+| test.cpp:44:3:46:3 | for(...:...) ... | test.cpp:44:3:44:3 | (__begin) | file://:0:0:0:0 | long * |
+endVariables
+| test.cpp:8:3:10:3 | for(...:...) ... | test.cpp:8:3:8:3 | (__end) | file://:0:0:0:0 | short * |
+| test.cpp:28:3:30:3 | for(...:...) ... | test.cpp:28:3:28:3 | (__end) | test.cpp:17:10:17:17 | Iterator |
+| test.cpp:44:3:46:3 | for(...:...) ... | test.cpp:44:3:44:3 | (__end) | file://:0:0:0:0 | long * |
+updates
+| test.cpp:8:3:10:3 | for(...:...) ... | file://:0:0:0:0 | ++ ... | file://:0:0:0:0 | (__begin) |
+| test.cpp:28:3:30:3 | for(...:...) ... | test.cpp:28:20:28:20 | call to operator++ | file://:0:0:0:0 | (__begin) |
+| test.cpp:44:3:46:3 | for(...:...) ... | file://:0:0:0:0 | ++ ... | file://:0:0:0:0 | (__begin) |

--- a/cpp/ql/test/library-tests/range_based_for/range_based_for.ql
+++ b/cpp/ql/test/library-tests/range_based_for/range_based_for.ql
@@ -1,0 +1,52 @@
+import cpp
+
+query predicate bodies(RangeBasedForStmt rbf, Stmt body) { body = rbf.getStmt() }
+
+query predicate variables(RangeBasedForStmt rbf, LocalVariable v, Type t) {
+  v = rbf.getVariable() and
+  t = v.getType()
+}
+
+query predicate ranges(RangeBasedForStmt rbf, Expr range, Type t) {
+  range = rbf.getRange() and
+  t = range.getType()
+}
+
+query predicate rangeVariables(RangeBasedForStmt rbf, LocalVariable rangeVar, Type t) {
+  rangeVar = rbf.getRangeVariable() and
+  t = rangeVar.getType()
+}
+
+query predicate conditions(RangeBasedForStmt rbf, Expr condition, Expr left, Expr right) {
+  condition = rbf.getCondition() and
+  (
+    condition instanceof BinaryOperation and
+    left = condition.(BinaryOperation).getLeftOperand() and
+    right = condition.(BinaryOperation).getRightOperand()
+    or
+    condition instanceof FunctionCall and
+    left = condition.(FunctionCall).getQualifier() and
+    right = condition.(FunctionCall).getArgument(0)
+  )
+}
+
+query predicate beginVariables(RangeBasedForStmt rbf, LocalVariable beginVar, Type t) {
+  beginVar = rbf.getBeginVariable() and
+  t = beginVar.getType()
+}
+
+query predicate endVariables(RangeBasedForStmt rbf, LocalVariable endVar, Type t) {
+  endVar = rbf.getEndVariable() and
+  t = endVar.getType()
+}
+
+query predicate updates(RangeBasedForStmt rbf, Expr update, Expr operand) {
+  update = rbf.getUpdate() and
+  (
+    update instanceof UnaryOperation and
+    operand = update.(UnaryOperation).getOperand()
+    or
+    update instanceof FunctionCall and
+    operand = update.(FunctionCall).getQualifier()
+  )
+}

--- a/cpp/ql/test/library-tests/range_based_for/test.cpp
+++ b/cpp/ql/test/library-tests/range_based_for/test.cpp
@@ -1,0 +1,47 @@
+
+void print_short(short);
+void print_int(int);
+void print_long(long);
+
+short array[100];
+void loop_over_c_array() {
+  for (auto value : array) {
+    print_short(value);
+  }
+}
+
+// A class that can be used with range-based-for, because it has the member
+// functions `begin` and `end`.
+template<typename T>
+struct Vector {
+  struct Iterator {
+    const T& operator*() const;
+    bool operator!=(const Iterator &rhs) const;
+    Iterator operator++();
+  };
+  Iterator begin();
+  Iterator end();
+};
+
+Vector<int> vector;
+void loop_over_vector_object() {
+  for (int value : vector) {
+    print_int(value);
+  }
+}
+
+// A class that can be used with range-based-for, because there are `begin` and
+// `end` functions that take a `List` as their argument.
+template<typename T>
+struct List {};
+
+template<typename T>
+T* begin(const List<T> &list);
+template<typename T>
+T* end(const List<T> &list);
+
+void loop_over_list_object(const List<long> &list) {
+  for (auto value : list) {
+    print_long(value);
+  }
+}


### PR DESCRIPTION
I was looking at a slight refactoring of range-based-for loops in the extractor, and noticed our existing tests for them look a little light, so this should give us more thorough coverage that the extractor and QL library agree on how we represent the various desugarings.