### PR TITLE
JS: Recognize class members in more cases

### DIFF
--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -13,6 +13,8 @@
 
 * The analysis of sanitizer guards has improved, leading to fewer false-positive results from the security queries.
 
+* Calls can now be resolved to class members in more cases, leading to more results from the security queries.
+
 * Support for the following frameworks and libraries has been improved:
   - [Electron](https://electronjs.org/)
   - [Handlebars](https://www.npmjs.com/package/handlebars)

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -1036,6 +1036,9 @@ module ClassNode {
         kind = MemberKind::of(method) and
         result = method.getBody().flow()
       )
+      or
+      kind = MemberKind::method() and
+      result = getConstructor().getReceiver().getAPropertySource(name)
     }
 
     override FunctionNode getAnInstanceMember(MemberKind kind) {
@@ -1045,6 +1048,9 @@ module ClassNode {
         kind = MemberKind::of(method) and
         result = method.getBody().flow()
       )
+      or
+      kind = MemberKind::method() and
+      result = getConstructor().getReceiver().getAPropertySource()
     }
 
     override FunctionNode getStaticMethod(string name) {
@@ -1063,6 +1069,8 @@ module ClassNode {
         method.isStatic() and
         result = method.getBody().flow()
       )
+      or
+      result = getAPropertySource()
     }
 
     override DataFlow::Node getASuperClassNode() { result = astNode.getSuperClass().flow() }

--- a/javascript/ql/test/library-tests/ClassNode/InstanceMember.expected
+++ b/javascript/ql/test/library-tests/ClassNode/InstanceMember.expected
@@ -1,6 +1,8 @@
+| fields.ts:2:16:2:32 | (x: string) => {} | Foo.m | method |
 | namespace.js:5:32:5:44 | function() {} | Baz.method | method |
 | tst2.js:6:9:9:3 | () {\\n   ... .x;\\n  } | C.method | method |
 | tst2.js:11:13:13:3 | () {\\n   ... .x;\\n  } | C.getter | getter |
+| tst2.js:18:14:18:22 | (x) => {} | D.f | method |
 | tst.js:4:17:4:21 | () {} | A.instanceMethod | method |
 | tst.js:7:6:7:10 | () {} | A.bar | method |
 | tst.js:9:10:9:14 | () {} | A.baz | getter |

--- a/javascript/ql/test/library-tests/ClassNode/InstanceMethod.expected
+++ b/javascript/ql/test/library-tests/ClassNode/InstanceMethod.expected
@@ -1,5 +1,7 @@
+| fields.ts:2:16:2:32 | (x: string) => {} | Foo.m |
 | namespace.js:5:32:5:44 | function() {} | Baz.method |
 | tst2.js:6:9:9:3 | () {\\n   ... .x;\\n  } | C.method |
+| tst2.js:18:14:18:22 | (x) => {} | D.f |
 | tst.js:4:17:4:21 | () {} | A.instanceMethod |
 | tst.js:7:6:7:10 | () {} | A.bar |
 | tst.js:17:19:17:31 | function() {} | B.foo |

--- a/javascript/ql/test/library-tests/ClassNode/fields.ts
+++ b/javascript/ql/test/library-tests/ClassNode/fields.ts
@@ -1,0 +1,3 @@
+class Foo {
+    public m = (x: string) => {};
+}

--- a/javascript/ql/test/library-tests/ClassNode/getAReceiverNode.expected
+++ b/javascript/ql/test/library-tests/ClassNode/getAReceiverNode.expected
@@ -1,8 +1,10 @@
+| fields.ts:1:1:3:1 | class F ... > {};\\n} | fields.ts:1:11:1:10 | this |
 | namespace.js:3:15:3:31 | function Baz() {} | namespace.js:3:15:3:14 | this |
 | namespace.js:3:15:3:31 | function Baz() {} | namespace.js:5:32:5:31 | this |
 | tst2.js:1:1:14:1 | class C ... ;\\n  }\\n} | tst2.js:2:14:2:13 | this |
 | tst2.js:1:1:14:1 | class C ... ;\\n  }\\n} | tst2.js:6:9:6:8 | this |
 | tst2.js:1:1:14:1 | class C ... ;\\n  }\\n} | tst2.js:11:13:11:12 | this |
+| tst2.js:16:1:20:1 | class D ... ;\\n  }\\n} | tst2.js:17:14:17:13 | this |
 | tst.js:3:1:10:1 | class A ... () {}\\n} | tst.js:3:9:3:8 | this |
 | tst.js:3:1:10:1 | class A ... () {}\\n} | tst.js:4:17:4:16 | this |
 | tst.js:3:1:10:1 | class A ... () {}\\n} | tst.js:7:6:7:5 | this |

--- a/javascript/ql/test/library-tests/ClassNode/tst2.js
+++ b/javascript/ql/test/library-tests/ClassNode/tst2.js
@@ -12,3 +12,9 @@ class C {
     return this.x;
   }
 }
+
+class D {
+  constructor() {
+    this.f = (x) => {};
+  }
+}


### PR DESCRIPTION
We did not recognize instance methods in ES6 classes when these were installed through fields or in the constructor.

[Evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/js/field-methods_1582218569419) is uneventful.