### PR TITLE
Python: Highlight py/use-of-input is for Python 2

### DIFF
--- a/python/ql/src/Expressions/UseofInput.qhelp
+++ b/python/ql/src/Expressions/UseofInput.qhelp
@@ -3,20 +3,20 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>A call to the input() function, <code>input(prompt)</code> is equivalent to <code>eval(raw_input(prompt))</code>. Evaluating user input without any checking can be a serious security flaw.</p>
+<p>In Python 2, a call to the input() function, <code>input(prompt)</code> is equivalent to <code>eval(raw_input(prompt))</code>. Evaluating user input without any checking can be a serious security flaw.</p>
 
 </overview>
 <recommendation>
 
-<p> Get user input with <code>raw_input(prompt)</code> and then validate that input before evaluating. If the expected input is a number or
+<p>Get user input with <code>raw_input(prompt)</code> and then validate that input before evaluating. If the expected input is a number or
 string, then <code>ast.literal_eval()</code> can always be used safely.</p>
 
 
 </recommendation>
 <references>
 
-  <li>Python Standard Library: <a href="http://docs.python.org/library/functions.html#input">input</a>,
-  <a href="http://docs.python.org/library/ast.html#ast.literal_eval">ast.literal_eval</a>.</li>
+  <li>Python Standard Library: <a href="http://docs.python.org/2/library/functions.html#input">input</a>,
+  <a href="http://docs.python.org/2/library/ast.html#ast.literal_eval">ast.literal_eval</a>.</li>
   <li>Wikipedia: <a href="http://en.wikipedia.org/wiki/Data_validation">Data validation</a>.</li>
 
 </references>

--- a/python/ql/src/Expressions/UseofInput.qhelp
+++ b/python/ql/src/Expressions/UseofInput.qhelp
@@ -3,7 +3,7 @@
   "qhelp.dtd">
 <qhelp>
 <overview>
-<p>In Python 2, a call to the input() function, <code>input(prompt)</code> is equivalent to <code>eval(raw_input(prompt))</code>. Evaluating user input without any checking can be a serious security flaw.</p>
+<p>In Python 2, a call to the <code>input()</code> function, <code>input(prompt)</code> is equivalent to <code>eval(raw_input(prompt))</code>. Evaluating user input without any checking can be a serious security flaw.</p>
 
 </overview>
 <recommendation>

--- a/python/ql/src/Expressions/UseofInput.ql
+++ b/python/ql/src/Expressions/UseofInput.ql
@@ -1,6 +1,6 @@
 /**
- * @name 'input' function used
- * @description The built-in function 'input' is used which can allow arbitrary code to be run.
+ * @name 'input' function used in Python 2
+ * @description The built-in function 'input' is used which, in Python 2, can allow arbitrary code to be run.
  * @kind problem
  * @tags security
  *       correctness
@@ -18,4 +18,4 @@ where
     call.getFunction() = func and
     func.pointsTo(context, Value::named("input"), _) and
     not func.pointsTo(context, Value::named("raw_input"), _)
-select call, "The unsafe built-in function 'input' is used."
+select call, "The unsafe built-in function 'input' is used in Python 2."

--- a/python/ql/test/2/query-tests/Expressions/UseofInput.expected
+++ b/python/ql/test/2/query-tests/Expressions/UseofInput.expected
@@ -1,1 +1,1 @@
-| expressions_test.py:6:12:6:18 | ControlFlowNode for input() | The unsafe built-in function 'input' is used. |
+| expressions_test.py:6:12:6:18 | ControlFlowNode for input() | The unsafe built-in function 'input' is used in Python 2. |


### PR DESCRIPTION
I also want to put into question the part of the documentation that says

> (...) `ast.literal_eval()` can always be used safely

When https://docs.python.org/2/library/ast.html#ast.literal_eval says:

> **Warning:** It is possible to crash the Python interpreter with a sufficiently large/complex string due to stack depth limitations in Python’s AST compiler.