### PR TITLE
C++: Modify the argvlocal tests

### DIFF
--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.c
@@ -151,12 +151,14 @@ int main(int argc, char **argv) {
 	printWrapper(i8);
 
 	// BAD: i9 value comes from argv
+
 	char *i9;
 	memcpy(1 ? i9++ : 0, argv[1], 1);
 	printf(i9);
 	printWrapper(i9);
 
 	// BAD: i91 value comes from argv
+
 	char *i91;
 	memcpy(0 ? 0 : (char *)((int) i91 * 2), argv[1], 1);
 	printf(i91);

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.c
@@ -146,21 +146,21 @@ int main(int argc, char **argv) {
 
 	// BAD: i8 value comes from argv
 	char *i8;
-	*(&i8 + 1) = argv[1];
+	*(&i8) = argv[1];
 	printf(i8);
 	printWrapper(i8);
 
 	// BAD: i9 value comes from argv
-
-	char *i9;
-	memcpy(1 ? i9++ : 0, argv[1], 1);
+	char i9buf[32];
+	char *i9 = i9buf;
+	memcpy(1 ? ++i9 : 0, argv[1], 1);
 	printf(i9);
 	printWrapper(i9);
 
 	// BAD: i91 value comes from argv
-
-	char *i91;
-	memcpy(0 ? 0 : (char *)((int) i91 * 2), argv[1], 1);
+	char i91buf[64];
+	char *i91 = &i91buf[0];
+	memcpy(0 ? 0 : i91, argv[1] + 1, 1);
 	printf(i91);
 	printWrapper(i91);
 

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
@@ -18,5 +18,11 @@
 | argvLocal.c:136:15:136:18 | -- ... | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format) | argvLocal.c:115:13:115:16 | argv | argv |
 | argvLocal.c:144:9:144:10 | i7 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format) | argvLocal.c:100:7:100:10 | argv | argv |
 | argvLocal.c:145:15:145:16 | i7 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format) | argvLocal.c:100:7:100:10 | argv | argv |
+| argvLocal.c:150:9:150:10 | i8 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format) | argvLocal.c:149:11:149:14 | argv | argv |
+| argvLocal.c:151:15:151:16 | i8 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format) | argvLocal.c:149:11:149:14 | argv | argv |
+| argvLocal.c:157:9:157:10 | i9 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format) | argvLocal.c:156:23:156:26 | argv | argv |
+| argvLocal.c:158:15:158:16 | i9 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format) | argvLocal.c:156:23:156:26 | argv | argv |
+| argvLocal.c:164:9:164:11 | i91 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format) | argvLocal.c:163:22:163:25 | argv | argv |
+| argvLocal.c:165:15:165:17 | i91 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format) | argvLocal.c:163:22:163:25 | argv | argv |
 | argvLocal.c:169:18:169:20 | i10 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format) | argvLocal.c:168:18:168:21 | argv | argv |
 | argvLocal.c:170:24:170:26 | i10 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format) | argvLocal.c:168:18:168:21 | argv | argv |

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-134/semmle/argv/argvLocal.expected
@@ -18,5 +18,5 @@
 | argvLocal.c:136:15:136:18 | -- ... | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format) | argvLocal.c:115:13:115:16 | argv | argv |
 | argvLocal.c:144:9:144:10 | i7 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format) | argvLocal.c:100:7:100:10 | argv | argv |
 | argvLocal.c:145:15:145:16 | i7 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format) | argvLocal.c:100:7:100:10 | argv | argv |
-| argvLocal.c:167:18:167:20 | i10 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format) | argvLocal.c:166:18:166:21 | argv | argv |
-| argvLocal.c:168:24:168:26 | i10 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format) | argvLocal.c:166:18:166:21 | argv | argv |
+| argvLocal.c:169:18:169:20 | i10 | The value of this argument may come from $@ and is being used as a formatting argument to printf(format) | argvLocal.c:168:18:168:21 | argv | argv |
+| argvLocal.c:170:24:170:26 | i10 | The value of this argument may come from $@ and is being used as a formatting argument to printWrapper(correct), which calls printf(format) | argvLocal.c:168:18:168:21 | argv | argv |


### PR DESCRIPTION
Following the discussion on https://jira.semmle.com/browse/CPP-491, I'm inclined to agree that some of the argvlocal test cases contain undefined behaviour and are not good test cases.  I also don't see any connection between these specific test cases and our requirements for covering CWE-134 or the associated SAMATE tests - thus, I propose replacing these tests with something superficially similar but well behaved, that will contribute to our testing rather than distracting from it.