### PR TITLE
Add guidelines for experimental CodeQL queries and libraries

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,8 @@ Follow the steps below to help other users understand what your query does, and 
    Query help files explain the purpose of your query to other users. Write your query help in a `.qhelp` file and save it in the same directory as your new query. 
    For more information on writing query help, see the [Query help style guide](https://github.com/Semmle/ql/blob/master/docs/query-help-style-guide.md).
 
+In addition to contributions to our standard queries and libraries, we also welcome contributions of a more experimental nature, which do not need to fulfill all the requirements listed above. See the guidelines for [experimental queries and libraries](docs/experimental.md) for details.
+
 ## Using your personal data
 
 If you contribute to this project, we will record your name and email

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,10 @@ Follow the steps below to help other users understand what your query does, and 
    Query help files explain the purpose of your query to other users. Write your query help in a `.qhelp` file and save it in the same directory as your new query. 
    For more information on writing query help, see the [Query help style guide](https://github.com/Semmle/ql/blob/master/docs/query-help-style-guide.md).
 
+7. **Maintain backwards compatibility**
+
+The standard CodeQL libraries must evolve in a backwards compatible manner. If any backwards incompatible changes need to be made, the existing API must first be marked as deprecated. This is done by adding a `deprecated` annotation along with a QLDoc reference to the replacement API. Only after at least one full release cycle has elapsed may the old API be removed.
+
 In addition to contributions to our standard queries and libraries, we also welcome contributions of a more experimental nature, which do not need to fulfill all the requirements listed above. See the guidelines for [experimental queries and libraries](docs/experimental.md) for details.
 
 ## Using your personal data

--- a/cpp/ql/src/experimental/README.md
+++ b/cpp/ql/src/experimental/README.md
@@ -1,0 +1,1 @@
+This directory contains [experimental](../../../../docs/experimental.md) CodeQL queries and libraries.

--- a/cpp/ql/test/experimental/README.md
+++ b/cpp/ql/test/experimental/README.md
@@ -1,0 +1,1 @@
+This directory contains tests for [experimental](../../../../docs/experimental.md) CodeQL queries and libraries.

--- a/csharp/ql/src/experimental/README.md
+++ b/csharp/ql/src/experimental/README.md
@@ -1,0 +1,1 @@
+This directory contains [experimental](../../../../docs/experimental.md) CodeQL queries and libraries.

--- a/csharp/ql/test/experimental/README.md
+++ b/csharp/ql/test/experimental/README.md
@@ -1,0 +1,1 @@
+This directory contains tests for [experimental](../../../../docs/experimental.md) CodeQL queries and libraries.

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -25,7 +25,7 @@ Experimental queries and libraries may not be actively maintained as the standar
 
 4. **Compilation**
 
-    - Compilation of the query and any associated libraries and tests must be resilient to future development of the standard libraries. This means that the functionality cannot use internal APIs, cannot depend on the output of `getAQlClass` and cannot make use of regexp matching on `toString`.
+    - Compilation of the query and any associated libraries and tests must be resilient to future development of the standard libraries. This means that the functionality cannot use internal APIs, cannot depend on the output of `getAQlClass`, and cannot make use of regexp matching on `toString`.
     - The query and any associated libraries and tests must not cause any compiler warnings to be emitted (such as use of deprecated functionality or missing `override` annotations).
 
 5. **Results**
@@ -39,4 +39,3 @@ Experimental queries and libraries may not be actively maintained as the standar
 ## Non-requirements
 
 Other criteria typically required for our standard queries and libraries are not required for experimental queries and libraries. In particular, fully disciplined query [metadata](docs/query-metadata-style-guide.md), query [help](docs/query-help-style-guide.md), tests, a low false positive rate and performance tuning are not required (but nonetheless recommended).
-

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -2,6 +2,8 @@
 
 In addition to our standard CodeQL queries and libraries, this repository may also contain queries and libraries of a more experimental nature. Experimental queries and libraries can be improved incrementally and may eventually reach a sufficient maturity to be included in our standard libraries and queries.
 
+Experimental queries and libraries may not be actively maintained as the standard libraries evolve, may be changed in backwards-incompatible ways or may be removed entirely in the future without deprecation warnings.
+
 ## Requirements
 
 1. **Directory structure**
@@ -23,7 +25,7 @@ In addition to our standard CodeQL queries and libraries, this repository may al
 
 4. **Compilation**
 
-    - Compilation of the query and any associated libraries and tests must be resilient to future development of the standard libraries. This means that the functionality cannot depend on the output of `getAQlClass` and it cannot use internal APIs.
+    - Compilation of the query and any associated libraries and tests must be resilient to future development of the standard libraries. This means that the functionality cannot use internal APIs, cannot depend on the output of `getAQlClass` and cannot make use of regexp matching on `toString`.
     - The query and any associated libraries and tests must not cause any compiler warnings to be emitted (such as use of deprecated functionality or missing `override` annotations).
 
 5. **Results**
@@ -37,6 +39,4 @@ In addition to our standard CodeQL queries and libraries, this repository may al
 ## Non-requirements
 
 Other criteria typically required for our standard queries and libraries are not required for experimental queries and libraries. In particular, fully disciplined query [metadata](docs/query-metadata-style-guide.md), query [help](docs/query-help-style-guide.md), tests, a low false positive rate and performance tuning are not required (but nonetheless recommended).
-
-Experimental queries and libraries may not be actively maintained as the standard libraries evolve and may be removed in the future.
 

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -1,0 +1,42 @@
+# Experimental CodeQL queries and libraries
+
+In addition to our standard CodeQL queries and libraries, this repository may also contain queries and libraries of a more experimental nature. Experimental queries and libraries can be improved incrementally and may eventually reach a sufficient maturity to be included in our standard libraries and queries.
+
+## Requirements
+
+1. **Directory structure**
+
+    - Experimental queries and libraries are stored in the `experimental` subdirectory within each language-specific directory in the [CodeQL repository](https://github.com/Semmle/ql). For example, experimental Java queries and libraries are stored in `ql/java/ql/src/experimental` and any corresponding tests in `ql/java/ql/test/experimental`.
+    - The structure of an `experimental` subdirectory mirrors the structure of standard queries and libraries (or tests) in the parent directory.
+
+2. **Query metadata**
+
+    - The query `@id` must not clash with any other queries in the repository.
+    - The query must have a `@name` and `@description` to explain its purpose.
+    - The query must have a `@kind` and `@problem.severity` as required by CodeQL tools.
+
+    For details, see the [guide on query metadata](https://github.com/Semmle/ql/blob/master/docs/query-metadata-style-guide.md).
+
+3. **Formatting**
+
+    - The queries and libraries must be [autoformatted](https://help.semmle.com/codeql/codeql-for-vscode/reference/editor.html#autoformatting).
+
+4. **Compilation**
+
+    - Compilation of the query and any associated libraries and tests must be resilient to future development of the standard libraries. This means that the functionality cannot depend on the output of `getAQlClass` and it cannot use internal APIs.
+    - The query and any associated libraries and tests must not cause any compiler warnings to be emitted (such as use of deprecated functionality or missing `override` annotations).
+
+5. **Results**
+
+    - The query must have at least one true positive result on some revision of a real project.
+
+6. **Contributor License Agreement**
+
+    - The contributor can satisfy the [CLA](CONTRIBUTING.md#contributor-license-agreement).
+
+## Non-requirements
+
+Other criteria typically required for our standard queries and libraries are not required for experimental queries and libraries. In particular, fully disciplined query [metadata](docs/query-metadata-style-guide.md), query [help](docs/query-help-style-guide.md), tests, a low false positive rate and performance tuning are not required (but nonetheless recommended).
+
+Experimental queries and libraries may not be actively maintained as the standard libraries evolve and may be removed in the future.
+

--- a/docs/experimental.md
+++ b/docs/experimental.md
@@ -2,7 +2,7 @@
 
 In addition to our standard CodeQL queries and libraries, this repository may also contain queries and libraries of a more experimental nature. Experimental queries and libraries can be improved incrementally and may eventually reach a sufficient maturity to be included in our standard libraries and queries.
 
-Experimental queries and libraries may not be actively maintained as the standard libraries evolve, may be changed in backwards-incompatible ways or may be removed entirely in the future without deprecation warnings.
+Experimental queries and libraries may not be actively maintained as the standard libraries evolve. They may also be changed in backwards-incompatible ways or may be removed entirely in the future without deprecation warnings.
 
 ## Requirements
 

--- a/java/ql/src/experimental/README.md
+++ b/java/ql/src/experimental/README.md
@@ -1,0 +1,1 @@
+This directory contains [experimental](../../../../docs/experimental.md) CodeQL queries and libraries.

--- a/java/ql/test/experimental/README.md
+++ b/java/ql/test/experimental/README.md
@@ -1,0 +1,1 @@
+This directory contains tests for [experimental](../../../../docs/experimental.md) CodeQL queries and libraries.

--- a/javascript/ql/src/experimental/README.md
+++ b/javascript/ql/src/experimental/README.md
@@ -1,0 +1,1 @@
+This directory contains [experimental](../../../../docs/experimental.md) CodeQL queries and libraries.

--- a/javascript/ql/test/experimental/README.md
+++ b/javascript/ql/test/experimental/README.md
@@ -1,0 +1,1 @@
+This directory contains tests for [experimental](../../../../docs/experimental.md) CodeQL queries and libraries.

--- a/python/ql/src/experimental/README.md
+++ b/python/ql/src/experimental/README.md
@@ -1,0 +1,1 @@
+This directory contains [experimental](../../../../docs/experimental.md) CodeQL queries and libraries.

--- a/python/ql/test/experimental/README.md
+++ b/python/ql/test/experimental/README.md
@@ -1,0 +1,1 @@
+This directory contains tests for [experimental](../../../../docs/experimental.md) CodeQL queries and libraries.


### PR DESCRIPTION
This improves our workflow by allowing us to merge queries and libraries that may not satisfy all the requirements for our standard queries and libraries but may nonetheless be useful.

For instance, we do not want to display queries with a high false positive rate on LGTM, but security researchers may still find such queries useful for finding vulnerabilities. Queries that have not yet been tuned for performance on large projects may nonetheless be usable on smaller projects.

The new workflow allows us to improve queries and libraries in a more incremental manner, until they have reached a sufficient maturity to be moved into our standard set of queries and libraries, without requiring all of the work to be done in a single pull request.

Each language now has an `experimental` subdirectory in both the `src` and `test` directories. This directory structure enforces that the use of experimental libraries requires import directives of the form `import experimental.*`, clearly identifying such libraries as code that may not be ready for production use. The directory structure under `experimental` is meant to mirror the structure for standard queries and libraries, such that moving from one set to the other involves minimal work (typically only changing `import experimental.X` directives to `import X` or vice versa).