### PR TITLE
Java/C++: Minor dataflow cleanup.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowDispatch.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowDispatch.qll
@@ -1,7 +1,5 @@
 private import cpp
 
-Function viableImpl(Call call) { result = viableCallable(call) }
-
 /**
  * Gets a function that might be called by `call`.
  */

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -132,16 +132,6 @@ OutNode getAnOutNode(DataFlowCall call, ReturnKind kind) {
  */
 predicate jumpStep(Node n1, Node n2) { none() }
 
-/**
- * Holds if `call` passes an implicit or explicit qualifier, i.e., a
- * `this` parameter.
- */
-predicate callHasQualifier(Call call) {
-  call.hasQualifier()
-  or
-  call.getTarget() instanceof Destructor
-}
-
 private newtype TContent =
   TFieldContent(Field f) or
   TCollectionContent() or

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
@@ -3,8 +3,6 @@ private import semmle.code.cpp.ir.IR
 private import semmle.code.cpp.ir.dataflow.DataFlow
 private import semmle.code.cpp.ir.dataflow.internal.DataFlowPrivate
 
-Function viableImpl(CallInstruction call) { result = viableCallable(call) }
-
 /**
  * Gets a function that might be called by `call`.
  */

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -67,16 +67,6 @@ OutNode getAnOutNode(DataFlowCall call, ReturnKind kind) {
  */
 predicate jumpStep(Node n1, Node n2) { none() }
 
-/**
- * Holds if `call` passes an implicit or explicit qualifier, i.e., a
- * `this` parameter.
- */
-predicate callHasQualifier(Call call) {
-  call.hasQualifier()
-  or
-  call.getTarget() instanceof Destructor
-}
-
 private newtype TContent =
   TFieldContent(Field f) or
   TCollectionContent() or

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -120,7 +120,7 @@ predicate jumpStep(Node node1, Node node2) {
  * Holds if `fa` is an access to an instance field that occurs as the
  * destination of an assignment of the value `src`.
  */
-predicate instanceFieldAssign(Expr src, FieldAccess fa) {
+private predicate instanceFieldAssign(Expr src, FieldAccess fa) {
   exists(AssignExpr a |
     a.getSource() = src and
     a.getDest() = fa and


### PR DESCRIPTION
A bit of cleanup in the internal interface implementations:
* All virtual dispatch is specified by `viableCallable`, and `viableImpl` is no longer used by the shared implementation, so this alias can be deleted in C++.
* The predicate `callHasQualifier` is, I believe, an even older leftover from something the shared implementation also no longer references.

Since these are internal implementation files that are privately imported by data flow, we don't need to deprecate these predicates before deleting them.

@hvitved I believe you asked for the deletion of `viableImpl` at some point, so you should now be free to refactor the C# side if you want to get rid of the name there.