### PR TITLE
QL docs: update supported C/C++ language versions

### DIFF
--- a/docs/language/support/versions-compilers.csv
+++ b/docs/language/support/versions-compilers.csv
@@ -1,7 +1,7 @@
 Language,Variants,Compilers,Extensions
-C/C++,"C89, C99, C11, C18, C++98, C++03, C++11, C++14, C++17","Clang (and clang-cl [1]_) extensions (up to Clang 8.0),
+C/C++,"C89, C99, C11, C18, C++98, C++03, C++11, C++14, C++17","Clang (and clang-cl [1]_) extensions (up to Clang 9.0),
 
-GNU extensions (up to GCC 8.3), 
+GNU extensions (up to GCC 9.2),
 
 Microsoft extensions (up to VS 2019),
 

--- a/docs/language/support/versions-compilers.csv
+++ b/docs/language/support/versions-compilers.csv
@@ -5,7 +5,7 @@ GNU extensions (up to GCC 9.2),
 
 Microsoft extensions (up to VS 2019),
 
-Arm Compiler 5.0 [2]_","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++``, ``.hxx``, ``.c``, ``.cc``, ``.h``"
+Arm Compiler 5 [2]_","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++``, ``.hxx``, ``.c``, ``.cc``, ``.h``"
 C#,C# up to 8.0. with .NET up to 4.8 [3]_,"Microsoft Visual Studio up to 2019, 
 
 .NET Core up to 3.0","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"

--- a/docs/language/support/versions-compilers.csv
+++ b/docs/language/support/versions-compilers.csv
@@ -1,5 +1,5 @@
 Language,Variants,Compilers,Extensions
-C/C++,"C89, C99, C11, C++98, C++03, C++11, C++14, C++17","Clang (and clang-cl [1]_) extensions (up to Clang 8.0),
+C/C++,"C89, C99, C11, C18, C++98, C++03, C++11, C++14, C++17","Clang (and clang-cl [1]_) extensions (up to Clang 8.0),
 
 GNU extensions (up to GCC 8.3), 
 


### PR DESCRIPTION
Updates our supported language list for C/C++.

@felicitymay: I have not included C++20 as support for that is very preliminary at the moment.

@igfoo: I have updated the clang/gcc versions we support to match those that I can see in EDG 6.

I have also updated the Arm Compiler 5 label to just "Arm Compiler 5", as we tested on 5.06, and not the original 5.00.