### PR TITLE
Python: Remove `--optimize: true` from options files

### DIFF
--- a/python/ql/test/2/library-tests/six/options
+++ b/python/ql/test/2/library-tests/six/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --lang=2 --max-import-depth=4
-optimize: true

--- a/python/ql/test/3/library-tests/PointsTo/typehints/options
+++ b/python/ql/test/3/library-tests/PointsTo/typehints/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --lang=3 -p ../../lib/ --max-import-depth=3
-optimize: true

--- a/python/ql/test/3/library-tests/six/options
+++ b/python/ql/test/3/library-tests/six/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --lang=3 --max-import-depth=4
-optimize: true

--- a/python/ql/test/library-tests/PointsTo/guarded/options
+++ b/python/ql/test/library-tests/PointsTo/guarded/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --max-import-depth=3
-optimize: true

--- a/python/ql/test/library-tests/PointsTo/new/options
+++ b/python/ql/test/library-tests/PointsTo/new/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --max-import-depth=4
-optimize: true

--- a/python/ql/test/library-tests/PointsTo/returns/options
+++ b/python/ql/test/library-tests/PointsTo/returns/options
@@ -1,1 +1,0 @@
-optimize: true

--- a/python/ql/test/library-tests/modules/duplicate_name/options
+++ b/python/ql/test/library-tests/modules/duplicate_name/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: -R .
-optimize: true

--- a/python/ql/test/library-tests/regex/options
+++ b/python/ql/test/library-tests/regex/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --max-import-depth=3
-optimize: true

--- a/python/ql/test/library-tests/web/bottle/options
+++ b/python/ql/test/library-tests/web/bottle/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --max-import-depth=3 -p ../../../query-tests/Security/lib/
-optimize: true

--- a/python/ql/test/library-tests/web/cherrypy/options
+++ b/python/ql/test/library-tests/web/cherrypy/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --max-import-depth=3 -p ../../../query-tests/Security/lib/
-optimize: true

--- a/python/ql/test/library-tests/web/django/options
+++ b/python/ql/test/library-tests/web/django/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --lang=3 --max-import-depth=3 -p ../../../query-tests/Security/lib/
-optimize: true

--- a/python/ql/test/library-tests/web/falcon/options
+++ b/python/ql/test/library-tests/web/falcon/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --max-import-depth=3 -p ../../../query-tests/Security/lib/
-optimize: true

--- a/python/ql/test/library-tests/web/flask/options
+++ b/python/ql/test/library-tests/web/flask/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --max-import-depth=3 -p ../../../query-tests/Security/lib/
-optimize: true

--- a/python/ql/test/library-tests/web/pyramid/options
+++ b/python/ql/test/library-tests/web/pyramid/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --max-import-depth=2 -p ../../../query-tests/Security/lib/
-optimize: true

--- a/python/ql/test/library-tests/web/tornado/options
+++ b/python/ql/test/library-tests/web/tornado/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --max-import-depth=2 -p ../../../query-tests/Security/lib/
-optimize: true

--- a/python/ql/test/library-tests/web/turbogears/options
+++ b/python/ql/test/library-tests/web/turbogears/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --max-import-depth=3 -p ../../../query-tests/Security/lib/
-optimize: true

--- a/python/ql/test/library-tests/web/twisted/options
+++ b/python/ql/test/library-tests/web/twisted/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --max-import-depth=1 -p ../../../query-tests/Security/lib/
-optimize: true

--- a/python/ql/test/query-tests/Security/CWE-022/options
+++ b/python/ql/test/query-tests/Security/CWE-022/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: -p ../lib/ --max-import-depth=3
-optimize: true

--- a/python/ql/test/query-tests/Security/CWE-078/options
+++ b/python/ql/test/query-tests/Security/CWE-078/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: -p ../lib/ --max-import-depth=3
-optimize: true

--- a/python/ql/test/query-tests/Security/CWE-094/options
+++ b/python/ql/test/query-tests/Security/CWE-094/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: -p ../lib/ --max-import-depth=3
-optimize: true

--- a/python/ql/test/query-tests/Security/CWE-326/options
+++ b/python/ql/test/query-tests/Security/CWE-326/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: -p ../lib/ --max-import-depth=3
-optimize: true

--- a/python/ql/test/query-tests/Security/CWE-327/options
+++ b/python/ql/test/query-tests/Security/CWE-327/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: -p ../lib/ --max-import-depth=3
-optimize: true

--- a/python/ql/test/query-tests/Security/CWE-377/options
+++ b/python/ql/test/query-tests/Security/CWE-377/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: -p ../lib/ --max-import-depth=3
-optimize: true

--- a/python/ql/test/query-tests/Security/CWE-502/options
+++ b/python/ql/test/query-tests/Security/CWE-502/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --max-import-depth=2 -p ../lib
-optimize: true

--- a/python/ql/test/query-tests/Security/CWE-732/options
+++ b/python/ql/test/query-tests/Security/CWE-732/options
@@ -1,2 +1,1 @@
 semmle-extractor-options: --max-import-depth=2 -p ../lib
-optimize: true

--- a/python/ql/test/query-tests/Security/options
+++ b/python/ql/test/query-tests/Security/options
@@ -1,1 +1,0 @@
-optimize: true


### PR DESCRIPTION
Tests will be run with optimizations on by default (when the internal PR is merged at least :smile:)