### PR TITLE
Python: ObjectAPI to ValueAPI: CallArgs and Others

### DIFF
--- a/python/ql/src/Classes/WrongNameForArgumentInClassInstantiation.ql
+++ b/python/ql/src/Classes/WrongNameForArgumentInClassInstantiation.ql
@@ -20,7 +20,7 @@ import Expressions.CallArgs
 
 from Call call, ClassObject cls, string name, FunctionObject init
 where
-    illegally_named_parameter(call, cls, name)
+    illegally_named_parameter_objectapi(call, cls, name)
     and init = get_function_or_initializer_objectapi(cls)
 select
     call, "Keyword argument '" + name + "' is not a supported parameter name of $@.", init, init.getQualifiedName()

--- a/python/ql/src/Classes/WrongNameForArgumentInClassInstantiation.ql
+++ b/python/ql/src/Classes/WrongNameForArgumentInClassInstantiation.ql
@@ -21,7 +21,7 @@ import Expressions.CallArgs
 from Call call, ClassObject cls, string name, FunctionObject init
 where
     illegally_named_parameter(call, cls, name)
-    and init = get_function_or_initializer(cls)
+    and init = get_function_or_initializer_objectapi(cls)
 select
     call, "Keyword argument '" + name + "' is not a supported parameter name of $@.", init, init.getQualifiedName()
 

--- a/python/ql/src/Classes/WrongNumberArgumentsInClassInstantiation.ql
+++ b/python/ql/src/Classes/WrongNumberArgumentsInClassInstantiation.ql
@@ -18,7 +18,7 @@ import Expressions.CallArgs
 from Call call, ClassObject cls, string too, string should, int limit, FunctionObject init
 where
 (
-    too_many_args(call, cls, limit) and too = "too many arguments" and should = "no more than "
+    too_many_args_objectapi(call, cls, limit) and too = "too many arguments" and should = "no more than "
     or
     too_few_args_objectapi(call, cls, limit) and too = "too few arguments" and should = "no fewer than "
 ) and init = get_function_or_initializer_objectapi(cls)

--- a/python/ql/src/Classes/WrongNumberArgumentsInClassInstantiation.ql
+++ b/python/ql/src/Classes/WrongNumberArgumentsInClassInstantiation.ql
@@ -20,6 +20,6 @@ where
 (
     too_many_args(call, cls, limit) and too = "too many arguments" and should = "no more than "
     or
-    too_few_args(call, cls, limit) and too = "too few arguments" and should = "no fewer than "
+    too_few_args_objectapi(call, cls, limit) and too = "too few arguments" and should = "no fewer than "
 ) and init = get_function_or_initializer_objectapi(cls)
 select call, "Call to $@ with " + too + "; should be " + should + limit.toString() + ".", init, init.getQualifiedName()

--- a/python/ql/src/Classes/WrongNumberArgumentsInClassInstantiation.ql
+++ b/python/ql/src/Classes/WrongNumberArgumentsInClassInstantiation.ql
@@ -21,5 +21,5 @@ where
     too_many_args(call, cls, limit) and too = "too many arguments" and should = "no more than "
     or
     too_few_args(call, cls, limit) and too = "too few arguments" and should = "no fewer than "
-) and init = get_function_or_initializer(cls)
+) and init = get_function_or_initializer_objectapi(cls)
 select call, "Call to $@ with " + too + "; should be " + should + limit.toString() + ".", init, init.getQualifiedName()

--- a/python/ql/src/Expressions/CallArgs.qll
+++ b/python/ql/src/Expressions/CallArgs.qll
@@ -26,7 +26,7 @@ private Keyword not_keyword_only_arg_objectapi(Call call, FunctionObject func) {
  *  plus the number of keyword arguments that do not match keyword-only arguments (if the function does not take **kwargs).
  */
 
-private int positional_arg_count_for_call_objectapi(Call call, Object callable) {
+private int positional_arg_count_objectapi_for_call_objectapi(Call call, Object callable) {
     call = get_a_call_objectapi(callable).getNode() and
     exists(int positional_keywords |
       exists(FunctionObject func | func = get_function_or_initializer(callable) |
@@ -40,7 +40,7 @@ private int positional_arg_count_for_call_objectapi(Call call, Object callable) 
     )
 }
 
-int arg_count(Call call) {
+int arg_count_objectapi(Call call) {
     result = count(call.getAnArg()) + varargs_length_objectapi(call) + count(call.getAKeyword())
 }
 
@@ -72,7 +72,7 @@ predicate too_few_args(Call call, Object callable, int limit) {
     // Exclude cases where an incorrect name is used as that is covered by 'Wrong name for an argument in a call'
     not illegally_named_parameter(call, callable, _) and
     not exists(call.getStarargs()) and not exists(call.getKwargs()) and
-    arg_count(call) < limit and
+    arg_count_objectapi(call) < limit and
     exists(FunctionObject func | func = get_function_or_initializer(callable) |
       call = func.getAFunctionCall().getNode() and limit = func.minParameters() and
       /* The combination of misuse of `mox.Mox().StubOutWithMock()`
@@ -103,7 +103,7 @@ predicate too_many_args(Call call, Object callable, int limit) {
         callable instanceof ClassObject and
         call.getAFlowNode() = get_a_call_objectapi(callable) and limit = func.maxParameters() - 1
     ) and
-    positional_arg_count_for_call_objectapi(call, callable) > limit
+    positional_arg_count_objectapi_for_call_objectapi(call, callable) > limit
 }
 
 /** Holds if `call` has too many or too few arguments for `func` */
@@ -118,9 +118,9 @@ predicate wrong_args(Call call, FunctionObject func, int limit, string too) {
  */
  bindingset[call, func]
 predicate correct_args_if_called_as_method(Call call, FunctionObject func) {
-    arg_count(call)+1 >= func.minParameters()
+    arg_count_objectapi(call)+1 >= func.minParameters()
     and
-    arg_count(call) < func.maxParameters()
+    arg_count_objectapi(call) < func.maxParameters()
 }
 
 /** Holds if `call` is a call to `overriding`, which overrides `func`. */

--- a/python/ql/src/Expressions/CallArgs.qll
+++ b/python/ql/src/Expressions/CallArgs.qll
@@ -107,7 +107,7 @@ predicate too_many_args_objectapi(Call call, Object callable, int limit) {
 }
 
 /** Holds if `call` has too many or too few arguments for `func` */
-predicate wrong_args(Call call, FunctionObject func, int limit, string too) {
+predicate wrong_args_objectapi(Call call, FunctionObject func, int limit, string too) {
     too_few_args_objectapi(call, func, limit) and too = "too few"
     or
     too_many_args_objectapi(call, func, limit) and too = "too many"

--- a/python/ql/src/Expressions/CallArgs.qll
+++ b/python/ql/src/Expressions/CallArgs.qll
@@ -68,7 +68,7 @@ predicate illegally_named_parameter_objectapi(Call call, Object func, string nam
 }
 
 /**Whether there are too few arguments in the `call` to `callable` where `limit` is the lowest number of legal arguments */
-predicate too_few_args(Call call, Object callable, int limit) {
+predicate too_few_args_objectapi(Call call, Object callable, int limit) {
     // Exclude cases where an incorrect name is used as that is covered by 'Wrong name for an argument in a call'
     not illegally_named_parameter_objectapi(call, callable, _) and
     not exists(call.getStarargs()) and not exists(call.getKwargs()) and
@@ -108,7 +108,7 @@ predicate too_many_args(Call call, Object callable, int limit) {
 
 /** Holds if `call` has too many or too few arguments for `func` */
 predicate wrong_args(Call call, FunctionObject func, int limit, string too) {
-    too_few_args(call, func, limit) and too = "too few"
+    too_few_args_objectapi(call, func, limit) and too = "too few"
     or
     too_many_args(call, func, limit) and too = "too many"
 }

--- a/python/ql/src/Expressions/CallArgs.qll
+++ b/python/ql/src/Expressions/CallArgs.qll
@@ -117,7 +117,7 @@ predicate wrong_args_objectapi(Call call, FunctionObject func, int limit, string
  * Implies nothing about whether `call` could call `func`.
  */
  bindingset[call, func]
-predicate correct_args_if_called_as_method(Call call, FunctionObject func) {
+predicate correct_args_if_called_as_method_objectapi(Call call, FunctionObject func) {
     arg_count_objectapi(call)+1 >= func.minParameters()
     and
     arg_count_objectapi(call) < func.maxParameters()

--- a/python/ql/src/Expressions/CallArgs.qll
+++ b/python/ql/src/Expressions/CallArgs.qll
@@ -89,7 +89,7 @@ predicate too_few_args_objectapi(Call call, Object callable, int limit) {
 }
 
 /**Whether there are too many arguments in the `call` to `func` where `limit` is the highest number of legal arguments */
-predicate too_many_args(Call call, Object callable, int limit) {
+predicate too_many_args_objectapi(Call call, Object callable, int limit) {
     // Exclude cases where an incorrect name is used as that is covered by 'Wrong name for an argument in a call'
     not illegally_named_parameter_objectapi(call, callable, _) and
     exists(FunctionObject func | 
@@ -110,7 +110,7 @@ predicate too_many_args(Call call, Object callable, int limit) {
 predicate wrong_args(Call call, FunctionObject func, int limit, string too) {
     too_few_args_objectapi(call, func, limit) and too = "too few"
     or
-    too_many_args(call, func, limit) and too = "too many"
+    too_many_args_objectapi(call, func, limit) and too = "too many"
 }
 
 /** Holds if `call` has correct number of arguments for `func`.

--- a/python/ql/src/Expressions/CallArgs.qll
+++ b/python/ql/src/Expressions/CallArgs.qll
@@ -2,7 +2,7 @@ import python
 
 import Testing.Mox
 
-private int varargs_length(Call call) {
+private int varargs_length_objectapi(Call call) {
     not exists(call.getStarargs()) and result = 0
     or
     exists(TupleObject t |
@@ -14,7 +14,7 @@ private int varargs_length(Call call) {
 }
 
 /** Gets a keyword argument that is not a keyword-only parameter. */
-private Keyword not_keyword_only_arg(Call call, FunctionObject func) {
+private Keyword not_keyword_only_arg_objectapi(Call call, FunctionObject func) {
     func.getACall().getNode() = call and
     result = call.getAKeyword() and
     not func.getFunction().getAKeywordOnlyArg().getId() = result.getArg()
@@ -26,26 +26,26 @@ private Keyword not_keyword_only_arg(Call call, FunctionObject func) {
  *  plus the number of keyword arguments that do not match keyword-only arguments (if the function does not take **kwargs).
  */
 
-private int positional_arg_count_for_call(Call call, Object callable) {
-    call = get_a_call(callable).getNode() and
+private int positional_arg_count_for_call_objectapi(Call call, Object callable) {
+    call = get_a_call_objectapi(callable).getNode() and
     exists(int positional_keywords |
       exists(FunctionObject func | func = get_function_or_initializer(callable) |
           not func.getFunction().hasKwArg() and
-          positional_keywords = count(not_keyword_only_arg(call, func))
+          positional_keywords = count(not_keyword_only_arg_objectapi(call, func))
         or
           func.getFunction().hasKwArg() and positional_keywords = 0
       )
       |
-      result = count(call.getAnArg()) + varargs_length(call) + positional_keywords
+      result = count(call.getAnArg()) + varargs_length_objectapi(call) + positional_keywords
     )
 }
 
 int arg_count(Call call) {
-    result = count(call.getAnArg()) + varargs_length(call) + count(call.getAKeyword())
+    result = count(call.getAnArg()) + varargs_length_objectapi(call) + count(call.getAKeyword())
 }
 
 /* Gets a call corresponding to the given class or function*/
-private ControlFlowNode get_a_call(Object callable) {
+private ControlFlowNode get_a_call_objectapi(Object callable) {
   result = callable.(ClassObject).getACall()
   or
   result = callable.(FunctionObject).getACall()
@@ -63,7 +63,7 @@ FunctionObject get_function_or_initializer(Object func_or_cls) {
 predicate illegally_named_parameter(Call call, Object func, string name) {
     not func.isC() and
     name = call.getANamedArgumentName() and
-    call.getAFlowNode() = get_a_call(func) and
+    call.getAFlowNode() = get_a_call_objectapi(func) and
     not get_function_or_initializer(func).isLegalArgumentName(name)
 }
 
@@ -84,7 +84,7 @@ predicate too_few_args(Call call, Object callable, int limit) {
       call = func.getAMethodCall().getNode() and limit = func.minParameters() - 1
       or
       callable instanceof ClassObject and
-      call.getAFlowNode() = get_a_call(callable) and limit = func.minParameters() - 1
+      call.getAFlowNode() = get_a_call_objectapi(callable) and limit = func.minParameters() - 1
     )
 }
 
@@ -101,9 +101,9 @@ predicate too_many_args(Call call, Object callable, int limit) {
         call = func.getAMethodCall().getNode() and limit = func.maxParameters() - 1
       or
         callable instanceof ClassObject and
-        call.getAFlowNode() = get_a_call(callable) and limit = func.maxParameters() - 1
+        call.getAFlowNode() = get_a_call_objectapi(callable) and limit = func.maxParameters() - 1
     ) and
-    positional_arg_count_for_call(call, callable) > limit
+    positional_arg_count_for_call_objectapi(call, callable) > limit
 }
 
 /** Holds if `call` has too many or too few arguments for `func` */

--- a/python/ql/src/Expressions/CallArgs.qll
+++ b/python/ql/src/Expressions/CallArgs.qll
@@ -60,7 +60,7 @@ FunctionObject get_function_or_initializer_objectapi(Object func_or_cls) {
 
 
 /**Whether there is an illegally named parameter called `name` in the `call` to `func` */
-predicate illegally_named_parameter(Call call, Object func, string name) {
+predicate illegally_named_parameter_objectapi(Call call, Object func, string name) {
     not func.isC() and
     name = call.getANamedArgumentName() and
     call.getAFlowNode() = get_a_call_objectapi(func) and
@@ -70,7 +70,7 @@ predicate illegally_named_parameter(Call call, Object func, string name) {
 /**Whether there are too few arguments in the `call` to `callable` where `limit` is the lowest number of legal arguments */
 predicate too_few_args(Call call, Object callable, int limit) {
     // Exclude cases where an incorrect name is used as that is covered by 'Wrong name for an argument in a call'
-    not illegally_named_parameter(call, callable, _) and
+    not illegally_named_parameter_objectapi(call, callable, _) and
     not exists(call.getStarargs()) and not exists(call.getKwargs()) and
     arg_count_objectapi(call) < limit and
     exists(FunctionObject func | func = get_function_or_initializer_objectapi(callable) |
@@ -91,7 +91,7 @@ predicate too_few_args(Call call, Object callable, int limit) {
 /**Whether there are too many arguments in the `call` to `func` where `limit` is the highest number of legal arguments */
 predicate too_many_args(Call call, Object callable, int limit) {
     // Exclude cases where an incorrect name is used as that is covered by 'Wrong name for an argument in a call'
-    not illegally_named_parameter(call, callable, _) and
+    not illegally_named_parameter_objectapi(call, callable, _) and
     exists(FunctionObject func | 
       func = get_function_or_initializer_objectapi(callable) and
       not func.getFunction().hasVarArg() and limit >= 0 

--- a/python/ql/src/Expressions/CallArgs.qll
+++ b/python/ql/src/Expressions/CallArgs.qll
@@ -124,7 +124,7 @@ predicate correct_args_if_called_as_method_objectapi(Call call, FunctionObject f
 }
 
 /** Holds if `call` is a call to `overriding`, which overrides `func`. */
-predicate overridden_call(FunctionObject func, FunctionObject overriding, Call call)  {
+predicate overridden_call_objectapi(FunctionObject func, FunctionObject overriding, Call call)  {
     overriding.overrides(func) and
     overriding.getACall().getNode() = call
 }

--- a/python/ql/src/Expressions/CallArgs.qll
+++ b/python/ql/src/Expressions/CallArgs.qll
@@ -29,7 +29,7 @@ private Keyword not_keyword_only_arg_objectapi(Call call, FunctionObject func) {
 private int positional_arg_count_objectapi_for_call_objectapi(Call call, Object callable) {
     call = get_a_call_objectapi(callable).getNode() and
     exists(int positional_keywords |
-      exists(FunctionObject func | func = get_function_or_initializer(callable) |
+      exists(FunctionObject func | func = get_function_or_initializer_objectapi(callable) |
           not func.getFunction().hasKwArg() and
           positional_keywords = count(not_keyword_only_arg_objectapi(call, func))
         or
@@ -52,7 +52,7 @@ private ControlFlowNode get_a_call_objectapi(Object callable) {
 }
 
 /* Gets the function object corresponding to the given class or function*/
-FunctionObject get_function_or_initializer(Object func_or_cls) {
+FunctionObject get_function_or_initializer_objectapi(Object func_or_cls) {
   result = func_or_cls.(FunctionObject)
   or
   result = func_or_cls.(ClassObject).declaredAttribute("__init__")
@@ -64,7 +64,7 @@ predicate illegally_named_parameter(Call call, Object func, string name) {
     not func.isC() and
     name = call.getANamedArgumentName() and
     call.getAFlowNode() = get_a_call_objectapi(func) and
-    not get_function_or_initializer(func).isLegalArgumentName(name)
+    not get_function_or_initializer_objectapi(func).isLegalArgumentName(name)
 }
 
 /**Whether there are too few arguments in the `call` to `callable` where `limit` is the lowest number of legal arguments */
@@ -73,7 +73,7 @@ predicate too_few_args(Call call, Object callable, int limit) {
     not illegally_named_parameter(call, callable, _) and
     not exists(call.getStarargs()) and not exists(call.getKwargs()) and
     arg_count_objectapi(call) < limit and
-    exists(FunctionObject func | func = get_function_or_initializer(callable) |
+    exists(FunctionObject func | func = get_function_or_initializer_objectapi(callable) |
       call = func.getAFunctionCall().getNode() and limit = func.minParameters() and
       /* The combination of misuse of `mox.Mox().StubOutWithMock()`
        * and a bug in mox's implementation of methods results in having to
@@ -93,7 +93,7 @@ predicate too_many_args(Call call, Object callable, int limit) {
     // Exclude cases where an incorrect name is used as that is covered by 'Wrong name for an argument in a call'
     not illegally_named_parameter(call, callable, _) and
     exists(FunctionObject func | 
-      func = get_function_or_initializer(callable) and
+      func = get_function_or_initializer_objectapi(callable) and
       not func.getFunction().hasVarArg() and limit >= 0 
       |
         call = func.getAFunctionCall().getNode() and limit = func.maxParameters()

--- a/python/ql/src/Expressions/WrongNameForArgumentInCall.ql
+++ b/python/ql/src/Expressions/WrongNameForArgumentInCall.ql
@@ -19,7 +19,7 @@ import Expressions.CallArgs
 
 from Call call, FunctionObject func, string name
 where
-illegally_named_parameter(call, func, name) and
+illegally_named_parameter_objectapi(call, func, name) and
 not func.isAbstract() and
 not exists(FunctionObject overridden | func.overrides(overridden) and overridden.getFunction().getAnArg().(Name).getId() = name)
 select

--- a/python/ql/src/Expressions/WrongNumberArgumentsInCall.ql
+++ b/python/ql/src/Expressions/WrongNumberArgumentsInCall.ql
@@ -22,7 +22,7 @@ where
     too_few_args_objectapi(call, func, limit) and too = "too few arguments" and should = "no fewer than "
 ) and
 not func.isAbstract() and
-not exists(FunctionObject overridden | func.overrides(overridden) and correct_args_if_called_as_method(call, overridden))
+not exists(FunctionObject overridden | func.overrides(overridden) and correct_args_if_called_as_method_objectapi(call, overridden))
 /* The semantics of `__new__` can be a bit subtle, so we simply exclude `__new__` methods */
 and not func.getName() = "__new__"
 

--- a/python/ql/src/Expressions/WrongNumberArgumentsInCall.ql
+++ b/python/ql/src/Expressions/WrongNumberArgumentsInCall.ql
@@ -17,7 +17,7 @@ import CallArgs
 from Call call, FunctionObject func, string too, string should, int limit
 where
 (
-    too_many_args(call, func, limit) and too = "too many arguments" and should = "no more than "
+    too_many_args_objectapi(call, func, limit) and too = "too many arguments" and should = "no more than "
     or
     too_few_args_objectapi(call, func, limit) and too = "too few arguments" and should = "no fewer than "
 ) and

--- a/python/ql/src/Expressions/WrongNumberArgumentsInCall.ql
+++ b/python/ql/src/Expressions/WrongNumberArgumentsInCall.ql
@@ -19,7 +19,7 @@ where
 (
     too_many_args(call, func, limit) and too = "too many arguments" and should = "no more than "
     or
-    too_few_args(call, func, limit) and too = "too few arguments" and should = "no fewer than "
+    too_few_args_objectapi(call, func, limit) and too = "too few arguments" and should = "no fewer than "
 ) and
 not func.isAbstract() and
 not exists(FunctionObject overridden | func.overrides(overridden) and correct_args_if_called_as_method(call, overridden))

--- a/python/ql/src/Functions/IncorrectlyOverriddenMethod.ql
+++ b/python/ql/src/Functions/IncorrectlyOverriddenMethod.ql
@@ -15,7 +15,7 @@ import Expressions.CallArgs
 from Call call, FunctionObject func, FunctionObject overridden, string problem
 where
 func.overrides(overridden) and (
-    wrong_args(call, func, _, problem) and correct_args_if_called_as_method(call, overridden)
+    wrong_args_objectapi(call, func, _, problem) and correct_args_if_called_as_method(call, overridden)
     or
     exists(string name | 
         illegally_named_parameter_objectapi(call, func, name) and problem = "an argument named '" + name + "'" and

--- a/python/ql/src/Functions/IncorrectlyOverriddenMethod.ql
+++ b/python/ql/src/Functions/IncorrectlyOverriddenMethod.ql
@@ -18,7 +18,7 @@ func.overrides(overridden) and (
     wrong_args(call, func, _, problem) and correct_args_if_called_as_method(call, overridden)
     or
     exists(string name | 
-        illegally_named_parameter(call, func, name) and problem = "an argument named '" + name + "'" and
+        illegally_named_parameter_objectapi(call, func, name) and problem = "an argument named '" + name + "'" and
         overridden.getFunction().getAnArg().(Name).getId() = name
     )
 )

--- a/python/ql/src/Functions/IncorrectlyOverriddenMethod.ql
+++ b/python/ql/src/Functions/IncorrectlyOverriddenMethod.ql
@@ -15,7 +15,7 @@ import Expressions.CallArgs
 from Call call, FunctionObject func, FunctionObject overridden, string problem
 where
 func.overrides(overridden) and (
-    wrong_args_objectapi(call, func, _, problem) and correct_args_if_called_as_method(call, overridden)
+    wrong_args_objectapi(call, func, _, problem) and correct_args_if_called_as_method_objectapi(call, overridden)
     or
     exists(string name | 
         illegally_named_parameter_objectapi(call, func, name) and problem = "an argument named '" + name + "'" and

--- a/python/ql/src/Functions/IncorrectlySpecifiedOverriddenMethod.ql
+++ b/python/ql/src/Functions/IncorrectlySpecifiedOverriddenMethod.ql
@@ -20,9 +20,9 @@ overriding.overrides(func) and
 call = overriding.getAMethodCall().getNode() and
 correct_args_if_called_as_method(call, overriding) and
 (
-    arg_count(call)+1 < func.minParameters() and problem = "too few arguments"
+    arg_count_objectapi(call)+1 < func.minParameters() and problem = "too few arguments"
     or
-    arg_count(call) >= func.maxParameters() and problem = "too many arguments"
+    arg_count_objectapi(call) >= func.maxParameters() and problem = "too many arguments"
     or
     exists(string name | call.getAKeyword().getArg() = name and 
         overriding.getFunction().getAnArg().(Name).getId() = name and

--- a/python/ql/src/Functions/IncorrectlySpecifiedOverriddenMethod.ql
+++ b/python/ql/src/Functions/IncorrectlySpecifiedOverriddenMethod.ql
@@ -18,7 +18,7 @@ where
 not func.getName() = "__init__" and
 overriding.overrides(func) and
 call = overriding.getAMethodCall().getNode() and
-correct_args_if_called_as_method(call, overriding) and
+correct_args_if_called_as_method_objectapi(call, overriding) and
 (
     arg_count_objectapi(call)+1 < func.minParameters() and problem = "too few arguments"
     or


### PR DESCRIPTION
This PR is part of the Expressions modernization effort.

This uniformly changes the of predicates names in CallArgs, and its dependents, so that modernizations don't cause unpredictable changes in test results when the new types are compatible with the old use context and silently affect test results.