### PR TITLE
Java: Remove some irrelevant bounds from TypeFlow.

### DIFF
--- a/java/ql/src/semmle/code/java/dispatch/ObjFlow.qll
+++ b/java/ql/src/semmle/code/java/dispatch/ObjFlow.qll
@@ -305,6 +305,7 @@ private module Unification {
     arg2 = t2.getTypeArgument(pos)
   }
 
+  pragma[nomagic]
   predicate failsUnification(Type t1, Type t2) {
     unificationTargets(t1, t2) and
     (

--- a/java/ql/test/library-tests/typeflow/typeflow.expected
+++ b/java/ql/test/library-tests/typeflow/typeflow.expected
@@ -1,9 +1,7 @@
 | A.java:9:10:9:11 | f1 | ArrayList<Long> | true |
-| A.java:10:10:10:10 | l | List<Long> | false |
 | A.java:11:19:11:20 | f2 | List<Long> | false |
 | A.java:12:16:12:16 | x | List<Long> | false |
 | A.java:14:9:14:9 | y | A | false |
-| A.java:18:11:18:12 | l2 | List<Integer> | false |
 | A.java:19:9:19:9 | y | List<Integer> | false |
 | A.java:26:14:26:14 | o | List<Long> | false |
 | A.java:34:11:34:11 | x | Integer | false |


### PR DESCRIPTION
This improves the filtering of irrelevant bounds that are returned from `TypeFlow`.  It is a minor improvement, but it gives a small reduction in the size of the virtual dispatch relation and should technically also yield a very small improvement to type pruning in data flow.