### PR TITLE
Java: Add data-flow consistency checks.

### DIFF
--- a/config/identical-files.json
+++ b/config/identical-files.json
@@ -39,6 +39,12 @@
     "java/ql/src/semmle/code/java/dataflow/internal/tainttracking1/TaintTrackingImpl.qll",
     "java/ql/src/semmle/code/java/dataflow/internal/tainttracking2/TaintTrackingImpl.qll"
   ],
+  "DataFlow Java/C++/C# Consistency checks": [
+    "java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll",
+    "cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll",
+    "cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll",
+    "csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplConsistency.qll"
+  ],
   "C++ SubBasicBlocks": [
     "cpp/ql/src/semmle/code/cpp/controlflow/SubBasicBlocks.qll",
     "cpp/ql/src/semmle/code/cpp/dataflow/internal/SubBasicBlocks.qll"

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
@@ -1,0 +1,136 @@
+/**
+ * Provides consistency queries for checking invariants in the language-specific
+ * data-flow classes and predicates.
+ */
+
+private import DataFlowImplSpecific::Private
+private import DataFlowImplSpecific::Public
+private import TaintTrackingUtil
+
+module Consistency {
+  private class RelevantNode extends Node {
+    RelevantNode() {
+      this instanceof ArgumentNode or
+      this instanceof ParameterNode or
+      this instanceof ReturnNode or
+      this = getAnOutNode(_, _) or
+      simpleLocalFlowStep(this, _) or
+      simpleLocalFlowStep(_, this) or
+      jumpStep(this, _) or
+      jumpStep(_, this) or
+      storeStep(this, _, _) or
+      storeStep(_, _, this) or
+      readStep(this, _, _) or
+      readStep(_, _, this) or
+      defaultAdditionalTaintStep(this, _) or
+      defaultAdditionalTaintStep(_, this)
+    }
+  }
+
+  query predicate uniqueEnclosingCallable(Node n, string msg) {
+    exists(int c |
+      n instanceof RelevantNode and
+      c = count(n.getEnclosingCallable()) and
+      c != 1 and
+      msg = "Node should have one enclosing callable but has " + c + "."
+    )
+  }
+
+  query predicate uniqueTypeBound(Node n, string msg) {
+    exists(int c |
+      n instanceof RelevantNode and
+      c = count(n.getTypeBound()) and
+      c != 1 and
+      msg = "Node should have one type bound but has " + c + "."
+    )
+  }
+
+  query predicate uniqueTypeRepr(Node n, string msg) {
+    exists(int c |
+      n instanceof RelevantNode and
+      c = count(getErasedRepr(n.getTypeBound())) and
+      c != 1 and
+      msg = "Node should have one type representation but has " + c + "."
+    )
+  }
+
+  query predicate parameterCallable(ParameterNode p, string msg) {
+    exists(DataFlowCallable c | p.isParameterOf(c, _) and c != p.getEnclosingCallable()) and
+    msg = "Callable mismatch for parameter."
+  }
+
+  query predicate localFlowIsLocal(Node n1, Node n2, string msg) {
+    simpleLocalFlowStep(n1, n2) and
+    n1.getEnclosingCallable() != n2.getEnclosingCallable() and
+    msg = "Local flow step does not preserve enclosing callable."
+  }
+
+  private DataFlowType typeRepr() { result = getErasedRepr(any(Node n).getTypeBound()) }
+
+  query predicate compatibleTypesReflexive(DataFlowType t, string msg) {
+    t = typeRepr() and
+    not compatibleTypes(t, t) and
+    msg = "Type compatibility predicate is not reflexive."
+  }
+
+  query predicate unreachableNodeCCtx(Node n, DataFlowCall call, string msg) {
+    isUnreachableInCall(n, call) and
+    exists(DataFlowCallable c |
+      c = n.getEnclosingCallable() and
+      not viableCallable(call) = c
+    ) and
+    msg = "Call context for isUnreachableInCall is inconsistent with call graph."
+  }
+
+  query predicate localCallNodes(DataFlowCall call, Node n, string msg) {
+    (
+      n = getAnOutNode(call, _) and
+      msg = "OutNode and call does not share enclosing callable."
+      or
+      n.(ArgumentNode).argumentOf(call, _) and
+      msg = "ArgumentNode and call does not share enclosing callable."
+    ) and
+    n.getEnclosingCallable() != call.getEnclosingCallable()
+  }
+
+  query predicate postIsNotPre(PostUpdateNode n, string msg) {
+    n.getPreUpdateNode() = n and msg = "PostUpdateNode should not equal its pre-update node."
+  }
+
+  query predicate postHasUniquePre(PostUpdateNode n, string msg) {
+    exists(int c |
+      c = count(n.getPreUpdateNode()) and
+      c != 1 and
+      msg = "PostUpdateNode should have one pre-update node but has " + c + "."
+    )
+  }
+
+  query predicate uniquePostUpdate(Node n, string msg) {
+    1 < strictcount(PostUpdateNode post | post.getPreUpdateNode() = n) and
+    msg = "Node has multiple PostUpdateNodes."
+  }
+
+  query predicate postIsInSameCallable(PostUpdateNode n, string msg) {
+    n.getEnclosingCallable() != n.getPreUpdateNode().getEnclosingCallable() and
+    msg = "PostUpdateNode does not share callable with its pre-update node."
+  }
+
+  private predicate hasPost(Node n) { exists(PostUpdateNode post | post.getPreUpdateNode() = n) }
+
+  query predicate reverseRead(Node n, string msg) {
+    exists(Node n2 | readStep(n, _, n2) and hasPost(n2) and not hasPost(n)) and
+    msg = "Origin of readStep is missing a PostUpdateNode."
+  }
+
+  query predicate storeIsPostUpdate(Node n, string msg) {
+    storeStep(_, _, n) and
+    not n instanceof PostUpdateNode and
+    msg = "Store targets should be PostUpdateNodes."
+  }
+
+  query predicate argHasPostUpdate(ArgumentNode n, string msg) {
+    not hasPost(n) and
+    not isImmutableOrUnobservable(n) and
+    msg = "ArgumentNode is missing PostUpdateNode."
+  }
+}

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
@@ -5,7 +5,8 @@
 
 private import DataFlowImplSpecific::Private
 private import DataFlowImplSpecific::Public
-private import TaintTrackingUtil
+private import tainttracking1.TaintTrackingParameter::Private
+private import tainttracking1.TaintTrackingParameter::Public
 
 module Consistency {
   private class RelevantNode extends Node {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplConsistency.qll
@@ -55,6 +55,44 @@ module Consistency {
     )
   }
 
+  query predicate uniqueNodeLocation(Node n, string msg) {
+    exists(int c |
+      c =
+        count(string filepath, int startline, int startcolumn, int endline, int endcolumn |
+          n.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+        ) and
+      c != 1 and
+      msg = "Node should have one location but has " + c + "."
+    )
+  }
+
+  query predicate missingLocation(string msg) {
+    exists(int c |
+      c =
+        strictcount(Node n |
+          not exists(string filepath, int startline, int startcolumn, int endline, int endcolumn |
+            n.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+          )
+        ) and
+      msg = "Nodes without location: " + c
+    )
+  }
+
+  query predicate uniqueNodeToString(Node n, string msg) {
+    exists(int c |
+      c = count(n.toString()) and
+      c != 1 and
+      msg = "Node should have one toString but has " + c + "."
+    )
+  }
+
+  query predicate missingToString(string msg) {
+    exists(int c |
+      c = strictcount(Node n | not exists(n.toString())) and
+      msg = "Nodes without toString: " + c
+    )
+  }
+
   query predicate parameterCallable(ParameterNode p, string msg) {
     exists(DataFlowCallable c | p.isParameterOf(c, _) and c != p.getEnclosingCallable()) and
     msg = "Callable mismatch for parameter."

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowPrivate.qll
@@ -293,3 +293,12 @@ class DataFlowCall extends Expr {
 predicate isUnreachableInCall(Node n, DataFlowCall call) { none() } // stub implementation
 
 int accessPathLimit() { result = 5 }
+
+/**
+ * Holds if `n` does not require a `PostUpdateNode` as it either cannot be
+ * modified or its modification cannot be observed, for example if it is a
+ * freshly created object that is not saved in a variable.
+ *
+ * This predicate is only used for consistency checks.
+ */
+predicate isImmutableOrUnobservable(Node n) { none() }

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
@@ -1,0 +1,136 @@
+/**
+ * Provides consistency queries for checking invariants in the language-specific
+ * data-flow classes and predicates.
+ */
+
+private import DataFlowImplSpecific::Private
+private import DataFlowImplSpecific::Public
+private import TaintTrackingUtil
+
+module Consistency {
+  private class RelevantNode extends Node {
+    RelevantNode() {
+      this instanceof ArgumentNode or
+      this instanceof ParameterNode or
+      this instanceof ReturnNode or
+      this = getAnOutNode(_, _) or
+      simpleLocalFlowStep(this, _) or
+      simpleLocalFlowStep(_, this) or
+      jumpStep(this, _) or
+      jumpStep(_, this) or
+      storeStep(this, _, _) or
+      storeStep(_, _, this) or
+      readStep(this, _, _) or
+      readStep(_, _, this) or
+      defaultAdditionalTaintStep(this, _) or
+      defaultAdditionalTaintStep(_, this)
+    }
+  }
+
+  query predicate uniqueEnclosingCallable(Node n, string msg) {
+    exists(int c |
+      n instanceof RelevantNode and
+      c = count(n.getEnclosingCallable()) and
+      c != 1 and
+      msg = "Node should have one enclosing callable but has " + c + "."
+    )
+  }
+
+  query predicate uniqueTypeBound(Node n, string msg) {
+    exists(int c |
+      n instanceof RelevantNode and
+      c = count(n.getTypeBound()) and
+      c != 1 and
+      msg = "Node should have one type bound but has " + c + "."
+    )
+  }
+
+  query predicate uniqueTypeRepr(Node n, string msg) {
+    exists(int c |
+      n instanceof RelevantNode and
+      c = count(getErasedRepr(n.getTypeBound())) and
+      c != 1 and
+      msg = "Node should have one type representation but has " + c + "."
+    )
+  }
+
+  query predicate parameterCallable(ParameterNode p, string msg) {
+    exists(DataFlowCallable c | p.isParameterOf(c, _) and c != p.getEnclosingCallable()) and
+    msg = "Callable mismatch for parameter."
+  }
+
+  query predicate localFlowIsLocal(Node n1, Node n2, string msg) {
+    simpleLocalFlowStep(n1, n2) and
+    n1.getEnclosingCallable() != n2.getEnclosingCallable() and
+    msg = "Local flow step does not preserve enclosing callable."
+  }
+
+  private DataFlowType typeRepr() { result = getErasedRepr(any(Node n).getTypeBound()) }
+
+  query predicate compatibleTypesReflexive(DataFlowType t, string msg) {
+    t = typeRepr() and
+    not compatibleTypes(t, t) and
+    msg = "Type compatibility predicate is not reflexive."
+  }
+
+  query predicate unreachableNodeCCtx(Node n, DataFlowCall call, string msg) {
+    isUnreachableInCall(n, call) and
+    exists(DataFlowCallable c |
+      c = n.getEnclosingCallable() and
+      not viableCallable(call) = c
+    ) and
+    msg = "Call context for isUnreachableInCall is inconsistent with call graph."
+  }
+
+  query predicate localCallNodes(DataFlowCall call, Node n, string msg) {
+    (
+      n = getAnOutNode(call, _) and
+      msg = "OutNode and call does not share enclosing callable."
+      or
+      n.(ArgumentNode).argumentOf(call, _) and
+      msg = "ArgumentNode and call does not share enclosing callable."
+    ) and
+    n.getEnclosingCallable() != call.getEnclosingCallable()
+  }
+
+  query predicate postIsNotPre(PostUpdateNode n, string msg) {
+    n.getPreUpdateNode() = n and msg = "PostUpdateNode should not equal its pre-update node."
+  }
+
+  query predicate postHasUniquePre(PostUpdateNode n, string msg) {
+    exists(int c |
+      c = count(n.getPreUpdateNode()) and
+      c != 1 and
+      msg = "PostUpdateNode should have one pre-update node but has " + c + "."
+    )
+  }
+
+  query predicate uniquePostUpdate(Node n, string msg) {
+    1 < strictcount(PostUpdateNode post | post.getPreUpdateNode() = n) and
+    msg = "Node has multiple PostUpdateNodes."
+  }
+
+  query predicate postIsInSameCallable(PostUpdateNode n, string msg) {
+    n.getEnclosingCallable() != n.getPreUpdateNode().getEnclosingCallable() and
+    msg = "PostUpdateNode does not share callable with its pre-update node."
+  }
+
+  private predicate hasPost(Node n) { exists(PostUpdateNode post | post.getPreUpdateNode() = n) }
+
+  query predicate reverseRead(Node n, string msg) {
+    exists(Node n2 | readStep(n, _, n2) and hasPost(n2) and not hasPost(n)) and
+    msg = "Origin of readStep is missing a PostUpdateNode."
+  }
+
+  query predicate storeIsPostUpdate(Node n, string msg) {
+    storeStep(_, _, n) and
+    not n instanceof PostUpdateNode and
+    msg = "Store targets should be PostUpdateNodes."
+  }
+
+  query predicate argHasPostUpdate(ArgumentNode n, string msg) {
+    not hasPost(n) and
+    not isImmutableOrUnobservable(n) and
+    msg = "ArgumentNode is missing PostUpdateNode."
+  }
+}

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
@@ -5,7 +5,8 @@
 
 private import DataFlowImplSpecific::Private
 private import DataFlowImplSpecific::Public
-private import TaintTrackingUtil
+private import tainttracking1.TaintTrackingParameter::Private
+private import tainttracking1.TaintTrackingParameter::Public
 
 module Consistency {
   private class RelevantNode extends Node {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImplConsistency.qll
@@ -55,6 +55,44 @@ module Consistency {
     )
   }
 
+  query predicate uniqueNodeLocation(Node n, string msg) {
+    exists(int c |
+      c =
+        count(string filepath, int startline, int startcolumn, int endline, int endcolumn |
+          n.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+        ) and
+      c != 1 and
+      msg = "Node should have one location but has " + c + "."
+    )
+  }
+
+  query predicate missingLocation(string msg) {
+    exists(int c |
+      c =
+        strictcount(Node n |
+          not exists(string filepath, int startline, int startcolumn, int endline, int endcolumn |
+            n.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+          )
+        ) and
+      msg = "Nodes without location: " + c
+    )
+  }
+
+  query predicate uniqueNodeToString(Node n, string msg) {
+    exists(int c |
+      c = count(n.toString()) and
+      c != 1 and
+      msg = "Node should have one toString but has " + c + "."
+    )
+  }
+
+  query predicate missingToString(string msg) {
+    exists(int c |
+      c = strictcount(Node n | not exists(n.toString())) and
+      msg = "Nodes without toString: " + c
+    )
+  }
+
   query predicate parameterCallable(ParameterNode p, string msg) {
     exists(DataFlowCallable c | p.isParameterOf(c, _) and c != p.getEnclosingCallable()) and
     msg = "Callable mismatch for parameter."

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowPrivate.qll
@@ -202,3 +202,12 @@ class DataFlowCall extends CallInstruction {
 predicate isUnreachableInCall(Node n, DataFlowCall call) { none() } // stub implementation
 
 int accessPathLimit() { result = 5 }
+
+/**
+ * Holds if `n` does not require a `PostUpdateNode` as it either cannot be
+ * modified or its modification cannot be observed, for example if it is a
+ * freshly created object that is not saved in a variable.
+ *
+ * This predicate is only used for consistency checks.
+ */
+predicate isImmutableOrUnobservable(Node n) { none() }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.expected
@@ -1,0 +1,261 @@
+uniqueEnclosingCallable
+uniqueTypeBound
+uniqueTypeRepr
+uniqueNodeLocation
+| dispatch.cpp:60:18:60:29 | call to Bottom | Node should have one location but has 2. |
+| dispatch.cpp:61:18:61:29 | call to Middle | Node should have one location but has 2. |
+| dispatch.cpp:65:10:65:21 | call to Bottom | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to Bottom | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to Bottom | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to Middle | Node should have one location but has 2. |
+missingLocation
+uniqueNodeToString
+missingToString
+parameterCallable
+localFlowIsLocal
+compatibleTypesReflexive
+unreachableNodeCCtx
+localCallNodes
+postIsNotPre
+postHasUniquePre
+uniquePostUpdate
+postIsInSameCallable
+reverseRead
+storeIsPostUpdate
+argHasPostUpdate
+| BarrierGuard.cpp:6:15:6:20 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:7:10:7:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:9:10:9:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:14:16:14:21 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:15:10:15:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:17:10:17:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:22:15:22:20 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:23:10:23:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:25:10:25:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:30:15:30:20 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:31:10:31:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:33:10:33:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:38:16:38:21 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:41:8:41:13 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:50:18:50:18 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:51:13:51:13 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:52:25:52:25 | y | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:53:13:53:13 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:54:25:54:25 | y | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:55:13:55:13 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:61:19:61:19 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:62:14:62:14 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:63:26:63:26 | y | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:64:14:64:14 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:65:26:65:26 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:66:14:66:14 | x | ArgumentNode is missing PostUpdateNode. |
+| acrossLinkTargets.cpp:12:8:12:8 | x | ArgumentNode is missing PostUpdateNode. |
+| acrossLinkTargets.cpp:19:27:19:32 | call to source | ArgumentNode is missing PostUpdateNode. |
+| acrossLinkTargets.cpp:28:8:28:8 | x | ArgumentNode is missing PostUpdateNode. |
+| acrossLinkTargets.cpp:34:8:34:8 | x | ArgumentNode is missing PostUpdateNode. |
+| acrossLinkTargets.cpp:41:19:41:24 | call to source | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:18:8:18:19 | sourceArray1 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:20:8:20:22 | access to array | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:21:8:21:20 | * ... | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:24:22:24:23 | m1 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:25:27:25:28 | m1 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:26:27:26:34 | call to getFirst | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:29:27:29:28 | m1 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:30:27:30:34 | call to getFirst | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:31:27:31:28 | m2 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:32:22:32:23 | m1 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:37:10:37:11 | m2 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:41:18:41:19 | m2 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:45:17:45:18 | m2 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:47:8:47:30 | call to expression | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:51:8:51:17 | stackArray | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:11:38:11:38 | x | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:23:38:23:38 | x | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:31:16:31:24 | call to isSource1 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:32:16:32:24 | call to isSource2 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:33:18:33:23 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:35:16:35:25 | call to notSource1 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:36:16:36:25 | call to notSource2 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:37:19:37:24 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:39:15:39:23 | call to isSource1 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:40:15:40:23 | call to isSource2 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:41:17:41:22 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:43:15:43:24 | call to notSource1 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:44:15:44:24 | call to notSource2 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:45:18:45:23 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:55:22:55:30 | call to isSource1 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:56:22:56:30 | call to isSource1 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:58:28:58:36 | call to isSource1 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:69:15:69:20 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:73:14:73:19 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:77:21:77:34 | call to allocateBottom | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:78:23:78:39 | * ... | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:81:13:81:18 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:89:28:89:33 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:90:25:90:30 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:96:8:96:8 | x | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:107:17:107:22 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:108:16:108:21 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:129:18:129:25 | call to isSource | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:130:17:130:24 | call to isSource | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:140:8:140:13 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:144:8:144:13 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:153:37:153:37 | f | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:154:37:154:37 | g | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:160:8:160:13 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:164:8:164:13 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:173:42:173:42 | f | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:174:42:174:42 | g | ArgumentNode is missing PostUpdateNode. |
+| globals.cpp:6:10:6:14 | local | ArgumentNode is missing PostUpdateNode. |
+| globals.cpp:12:10:12:24 | flowTestGlobal1 | ArgumentNode is missing PostUpdateNode. |
+| globals.cpp:19:10:19:24 | flowTestGlobal2 | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:14:3:14:6 | t | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:15:3:15:6 | u | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:18:7:18:7 | a | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:18:8:18:8 | call to operator() | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:21:3:21:6 | t | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:22:3:22:6 | u | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:25:2:25:2 | b | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:26:7:26:7 | v | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:29:3:29:6 | t | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:30:3:30:6 | u | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:32:2:32:2 | c | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:35:8:35:8 | a | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:36:8:36:8 | b | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:38:2:38:2 | d | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:38:4:38:4 | t | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:38:7:38:7 | u | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:41:8:41:8 | a | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:42:8:42:8 | b | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:45:2:45:2 | e | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:46:7:46:7 | w | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:16:12:16:14 | lhs | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:16:17:16:19 | rhs | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:16:17:16:19 | rhs | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:55:23:55:28 | call to source | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:56:10:56:11 | x1 | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:58:19:58:24 | call to source | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:59:10:59:11 | x2 | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:62:10:62:11 | x3 | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:65:10:65:11 | x4 | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:79:17:79:19 | rhs | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:122:23:122:28 | call to source | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:123:13:123:15 | val | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:125:19:125:24 | call to source | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:126:13:126:15 | val | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:129:13:129:15 | val | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:132:13:132:15 | val | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:7:8:7:9 | t1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:9:8:9:9 | t1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:10:8:10:9 | t2 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:13:10:13:11 | t2 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:15:8:15:9 | t2 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:21:8:21:9 | t1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:26:8:26:9 | t1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:30:8:30:8 | t | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:31:8:31:8 | c | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:35:10:35:15 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:35:20:35:20 | 0 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:36:10:36:10 | 1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:36:13:36:18 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:43:10:43:20 | ... ? ... : ... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:46:10:46:10 | t | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:58:10:58:10 | t | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:71:8:71:9 | x4 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:76:8:76:9 | u1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:78:8:78:9 | u1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:81:8:81:9 | i1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:84:8:84:18 | ... ? ... : ... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:86:8:86:9 | i1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:90:8:90:14 | source1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:92:8:92:14 | source1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:103:10:103:12 | ref | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:110:10:110:12 | ref | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:138:27:138:32 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:140:8:140:8 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:144:8:144:8 | s | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:149:33:149:33 | 0 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:150:8:150:8 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:151:33:151:38 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:152:8:152:8 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:157:8:157:8 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:162:34:162:34 | 0 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:163:8:163:8 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:164:34:164:39 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:165:8:165:8 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:178:8:178:8 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:194:29:194:34 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:197:10:197:10 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:202:10:202:16 | barrier | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:207:35:207:35 | 0 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:208:10:208:10 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:209:35:209:40 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:210:10:210:10 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:216:10:216:10 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:221:36:221:36 | 0 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:222:10:222:10 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:223:36:223:41 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:224:10:224:10 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:238:10:238:10 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:245:14:245:19 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:246:18:246:23 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:251:14:251:14 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:256:14:256:20 | barrier | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:260:12:260:12 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:265:22:265:27 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:266:12:266:12 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:267:22:267:27 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:268:12:268:12 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:273:21:273:21 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:278:21:278:27 | barrier | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:289:14:289:14 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:291:14:291:14 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:314:4:314:9 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:317:12:317:12 | p | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:318:7:318:7 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:319:12:319:12 | 0 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:320:7:320:7 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:337:10:337:18 | globalVar | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:339:10:339:18 | globalVar | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:343:10:343:18 | globalVar | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:349:10:349:18 | globalVar | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:363:10:363:14 | field | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:365:10:365:14 | field | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:369:10:369:14 | field | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:375:10:375:14 | field | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:384:16:384:23 | & ... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:384:26:384:35 | sizeof(<expr>) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:385:8:385:10 | tmp | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:391:16:391:23 | & ... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:391:26:391:35 | sizeof(<expr>) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:392:8:392:10 | tmp | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:394:10:394:12 | tmp | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:400:16:400:22 | & ... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:400:25:400:34 | sizeof(<expr>) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:401:8:401:10 | tmp | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:407:16:407:22 | & ... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:407:25:407:34 | sizeof(<expr>) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:408:8:408:10 | tmp | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:418:8:418:12 | local | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:424:8:424:12 | local | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:430:8:430:12 | local | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:431:8:431:13 | * ... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:436:26:436:26 | 1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:437:8:437:12 | local | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:442:25:442:25 | 2 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:443:8:443:12 | local | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:444:8:444:13 | * ... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:450:9:450:22 | (statement expression) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:451:9:451:21 | (statement expression) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:461:8:461:12 | local | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:13:8:13:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:21:8:21:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:29:8:29:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:39:8:39:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:49:8:49:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:57:8:57:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:66:8:66:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:78:8:78:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:86:8:86:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:93:8:93:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:105:8:105:8 | x | ArgumentNode is missing PostUpdateNode. |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.ql
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-consistency.ql
@@ -1,0 +1,1 @@
+import semmle.code.cpp.dataflow.internal.DataFlowImplConsistency::Consistency

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.expected
@@ -1,0 +1,354 @@
+uniqueEnclosingCallable
+uniqueTypeBound
+uniqueTypeRepr
+uniqueNodeLocation
+| BarrierGuard.cpp:2:11:2:13 | p#0 | Node should have one location but has 6. |
+| acrossLinkTargets.cpp:2:11:2:13 | p#0 | Node should have one location but has 6. |
+| clang.cpp:4:11:4:13 | p#0 | Node should have one location but has 6. |
+| clang.cpp:4:27:4:35 | p#0 | Node should have one location but has 2. |
+| clang.cpp:4:51:4:53 | p#0 | Node should have one location but has 2. |
+| dispatch.cpp:2:11:2:13 | p#0 | Node should have one location but has 6. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| globals.cpp:2:11:2:13 | p#0 | Node should have one location but has 6. |
+| test.cpp:2:11:2:13 | p#0 | Node should have one location but has 6. |
+| test.cpp:2:27:2:35 | p#0 | Node should have one location but has 2. |
+| test.cpp:2:51:2:53 | p#0 | Node should have one location but has 2. |
+missingLocation
+| Nodes without location: 4 |
+uniqueNodeToString
+missingToString
+parameterCallable
+localFlowIsLocal
+compatibleTypesReflexive
+unreachableNodeCCtx
+localCallNodes
+postIsNotPre
+postHasUniquePre
+uniquePostUpdate
+postIsInSameCallable
+reverseRead
+storeIsPostUpdate
+argHasPostUpdate
+| BarrierGuard.cpp:6:15:6:20 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:7:10:7:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:9:10:9:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:14:16:14:21 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:15:10:15:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:17:10:17:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:22:15:22:20 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:23:10:23:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:25:10:25:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:30:15:30:20 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:31:10:31:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:33:10:33:15 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:38:16:38:21 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:41:8:41:13 | source | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:50:18:50:18 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:51:13:51:13 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:52:25:52:25 | y | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:53:13:53:13 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:54:25:54:25 | y | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:55:13:55:13 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:61:19:61:19 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:62:14:62:14 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:63:26:63:26 | y | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:64:14:64:14 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:65:26:65:26 | x | ArgumentNode is missing PostUpdateNode. |
+| BarrierGuard.cpp:66:14:66:14 | x | ArgumentNode is missing PostUpdateNode. |
+| acrossLinkTargets.cpp:12:8:12:8 | (int)... | ArgumentNode is missing PostUpdateNode. |
+| acrossLinkTargets.cpp:19:27:19:32 | call to source | ArgumentNode is missing PostUpdateNode. |
+| acrossLinkTargets.cpp:28:8:28:8 | (int)... | ArgumentNode is missing PostUpdateNode. |
+| acrossLinkTargets.cpp:34:8:34:8 | (int)... | ArgumentNode is missing PostUpdateNode. |
+| acrossLinkTargets.cpp:41:19:41:24 | call to source | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:18:8:18:19 | (const int *)... | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:20:8:20:22 | access to array | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:21:8:21:20 | * ... | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:22:8:22:20 | & ... | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:24:22:24:23 | m1 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:25:27:25:28 | m1 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:26:8:26:24 | sourceStruct1_ptr | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:26:27:26:34 | call to getFirst | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:29:27:29:28 | m1 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:30:8:30:24 | sourceStruct1_ptr | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:30:27:30:34 | call to getFirst | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:31:27:31:28 | m2 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:32:22:32:23 | m1 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:37:10:37:11 | m2 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:41:18:41:19 | m2 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:45:17:45:18 | m2 | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:47:8:47:30 | call to expression | ArgumentNode is missing PostUpdateNode. |
+| clang.cpp:51:8:51:17 | (const int *)... | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:11:38:11:38 | x | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:15:8:15:8 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:21:8:21:8 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:23:38:23:38 | x | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:31:8:31:13 | topPtr | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:31:16:31:24 | call to isSource1 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:32:8:32:13 | topPtr | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:32:16:32:24 | call to isSource2 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:33:3:33:8 | topPtr | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:33:18:33:23 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:35:8:35:13 | topPtr | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:35:16:35:25 | call to notSource1 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:36:8:36:13 | topPtr | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:36:16:36:25 | call to notSource2 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:37:3:37:8 | topPtr | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:37:19:37:24 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:39:8:39:13 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:39:15:39:23 | call to isSource1 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:40:8:40:13 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:40:15:40:23 | call to isSource2 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:41:3:41:8 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:41:17:41:22 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:43:8:43:13 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:43:15:43:24 | call to notSource1 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:44:8:44:13 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:44:15:44:24 | call to notSource2 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:45:3:45:8 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:45:18:45:23 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:55:8:55:19 | globalBottom | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:55:22:55:30 | call to isSource1 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:56:8:56:19 | globalMiddle | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:56:22:56:30 | call to isSource1 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:58:8:58:23 | call to readGlobalBottom | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:58:28:58:36 | call to isSource1 | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:60:18:60:29 | Constant | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:60:18:60:29 | new | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:61:18:61:29 | Constant | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:61:18:61:29 | new | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:65:10:65:21 | Constant | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:65:10:65:21 | new | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:69:3:69:5 | top | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:69:15:69:20 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:73:3:73:5 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:73:14:73:19 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:77:21:77:34 | call to allocateBottom | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:78:23:78:39 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:81:3:81:3 | x | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:81:13:81:18 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:89:3:89:10 | call to identity | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:89:12:89:17 | (Top *)... | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:89:28:89:33 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:90:3:90:10 | call to identity | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:90:12:90:14 | top | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:90:25:90:30 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:96:8:96:8 | x | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:107:17:107:22 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:108:16:108:21 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:129:10:129:15 | topPtr | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:129:18:129:25 | call to isSource | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:130:10:130:15 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:130:17:130:24 | call to isSource | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:140:8:140:13 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:144:8:144:13 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:153:37:153:37 | f | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:154:37:154:37 | g | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:160:8:160:13 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:164:8:164:13 | call to source | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:173:42:173:42 | f | ArgumentNode is missing PostUpdateNode. |
+| dispatch.cpp:174:42:174:42 | g | ArgumentNode is missing PostUpdateNode. |
+| example.c:26:18:26:24 | & ... | ArgumentNode is missing PostUpdateNode. |
+| example.c:28:14:28:25 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | t | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | t | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | u | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | u | ArgumentNode is missing PostUpdateNode. |
+| globals.cpp:6:10:6:14 | local | ArgumentNode is missing PostUpdateNode. |
+| globals.cpp:12:10:12:24 | flowTestGlobal1 | ArgumentNode is missing PostUpdateNode. |
+| globals.cpp:19:10:19:24 | flowTestGlobal2 | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:18:7:18:7 | (const lambda [] type at line 13, col. 11)... | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:18:8:18:8 | call to operator() | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:21:8:21:8 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:22:8:22:8 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:25:2:25:2 | (const lambda [] type at line 20, col. 11)... | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:26:7:26:7 | v | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:32:2:32:2 | (const lambda [] type at line 28, col. 11)... | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:35:8:35:8 | a | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:36:8:36:8 | b | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:38:2:38:2 | (const lambda [] type at line 34, col. 11)... | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:38:4:38:4 | t | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:38:7:38:7 | u | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:41:8:41:8 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:42:8:42:8 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:45:2:45:2 | (const lambda [] type at line 40, col. 11)... | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:45:4:45:4 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:45:7:45:7 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:45:10:45:10 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| lambdas.cpp:46:7:46:7 | w | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:16:12:16:14 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:16:17:16:19 | rhs | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:37:21:37:23 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:55:19:55:20 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:55:23:55:28 | call to source | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:56:10:56:11 | x1 | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:58:15:58:16 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:58:19:58:24 | call to source | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:59:10:59:11 | x2 | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:61:26:61:27 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:62:10:62:11 | x3 | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:64:15:64:16 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:65:10:65:11 | x4 | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:79:12:79:14 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:79:17:79:19 | rhs | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:102:21:102:23 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:122:19:122:20 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:122:23:122:28 | call to source | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:123:13:123:15 | val | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:125:15:125:16 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:125:19:125:24 | call to source | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:126:13:126:15 | val | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:128:26:128:27 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:129:13:129:15 | val | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:131:15:131:16 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ref.cpp:132:13:132:15 | val | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:7:8:7:9 | t1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:9:8:9:9 | t1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:10:8:10:9 | t2 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:13:10:13:11 | t2 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:15:8:15:9 | t2 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:21:8:21:9 | t1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:26:8:26:9 | t1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:30:8:30:8 | t | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:31:8:31:8 | c | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:35:10:35:15 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:35:20:35:20 | 0 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:36:10:36:10 | 1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:36:13:36:18 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:43:10:43:20 | ... ? ... : ... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:46:10:46:10 | t | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:58:10:58:10 | t | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:67:29:67:35 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:71:8:71:9 | x4 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:76:8:76:9 | u1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:78:8:78:9 | u1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:81:8:81:9 | i1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:84:8:84:18 | ... ? ... : ... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:86:8:86:9 | i1 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:90:8:90:14 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:92:8:92:14 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:103:10:103:12 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:110:10:110:12 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:138:27:138:32 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:140:8:140:8 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:144:8:144:8 | s | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:149:33:149:33 | 0 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:150:8:150:8 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:151:33:151:38 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:152:8:152:8 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:157:8:157:8 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:162:34:162:34 | 0 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:163:8:163:8 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:164:34:164:39 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:165:8:165:8 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:178:8:178:8 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:194:29:194:34 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:197:10:197:10 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:202:10:202:16 | barrier | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:207:35:207:35 | 0 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:208:10:208:10 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:209:35:209:40 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:210:10:210:10 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:216:10:216:10 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:221:36:221:36 | 0 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:222:10:222:10 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:223:36:223:41 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:224:10:224:10 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:238:10:238:10 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:245:14:245:19 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:246:18:246:23 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:251:14:251:14 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:256:14:256:20 | barrier | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:260:12:260:12 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:265:22:265:27 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:266:12:266:12 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:267:22:267:27 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:268:12:268:12 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:273:21:273:21 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:278:21:278:27 | barrier | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:289:14:289:14 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:291:14:291:14 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:314:4:314:9 | call to source | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:317:12:317:12 | p | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:318:7:318:7 | x | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:319:12:319:12 | 0 | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:320:7:320:7 | y | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:337:10:337:18 | globalVar | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:339:10:339:18 | globalVar | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:343:10:343:18 | globalVar | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:349:10:349:18 | globalVar | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:363:10:363:14 | field | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:365:10:365:14 | field | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:369:10:369:14 | field | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:375:10:375:14 | field | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:384:10:384:13 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:384:16:384:23 | (const void *)... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:384:26:384:35 | sizeof(<expr>) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:385:8:385:10 | tmp | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:391:10:391:13 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:391:16:391:23 | (const void *)... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:391:26:391:35 | sizeof(<expr>) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:392:8:392:10 | tmp | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:394:10:394:12 | tmp | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:400:10:400:13 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:400:16:400:22 | (const void *)... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:400:25:400:34 | sizeof(<expr>) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:401:8:401:10 | tmp | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:407:10:407:13 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:407:16:407:22 | (const void *)... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:407:25:407:34 | sizeof(<expr>) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:408:8:408:10 | tmp | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:417:16:417:20 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:418:8:418:12 | local | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:423:20:423:25 | & ... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:424:8:424:12 | local | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:429:20:429:24 | array to pointer conversion | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:430:8:430:12 | (const int *)... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:431:8:431:13 | * ... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:436:18:436:23 | & ... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:436:26:436:26 | (size_t)... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:437:8:437:12 | local | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:442:18:442:22 | array to pointer conversion | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:442:25:442:25 | (size_t)... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:443:8:443:12 | (const int *)... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:444:8:444:13 | * ... | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:450:9:450:22 | (statement expression) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:451:9:451:21 | (statement expression) | ArgumentNode is missing PostUpdateNode. |
+| test.cpp:461:8:461:12 | local | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:13:8:13:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:21:8:21:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:29:8:29:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:39:8:39:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:49:8:49:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:57:8:57:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:66:8:66:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:78:8:78:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:86:8:86:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:93:8:93:8 | x | ArgumentNode is missing PostUpdateNode. |
+| true_upon_entry.cpp:105:8:105:8 | x | ArgumentNode is missing PostUpdateNode. |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.ql
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/dataflow-ir-consistency.ql
@@ -1,0 +1,1 @@
+import semmle.code.cpp.ir.dataflow.internal.DataFlowImplConsistency::Consistency

--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.expected
@@ -1,0 +1,134 @@
+uniqueEnclosingCallable
+| C.cpp:37:24:37:33 | 0 | Node should have one enclosing callable but has 0. |
+| C.cpp:37:24:37:33 | new | Node should have one enclosing callable but has 0. |
+uniqueTypeBound
+| complex.cpp:22:11:22:17 | constructor init of field f [post-this] | Node should have one type bound but has 0. |
+| complex.cpp:22:11:22:17 | constructor init of field f [pre-this] | Node should have one type bound but has 0. |
+uniqueTypeRepr
+| complex.cpp:22:11:22:17 | constructor init of field f [post-this] | Node should have one type representation but has 0. |
+| complex.cpp:22:11:22:17 | constructor init of field f [pre-this] | Node should have one type representation but has 0. |
+uniqueNodeLocation
+| A.cpp:38:7:38:8 | call to C | Node should have one location but has 2. |
+| A.cpp:39:7:39:8 | call to C | Node should have one location but has 2. |
+| A.cpp:41:15:41:21 | call to C | Node should have one location but has 2. |
+| A.cpp:47:12:47:18 | call to C | Node should have one location but has 2. |
+| A.cpp:57:17:57:23 | call to C | Node should have one location but has 2. |
+| A.cpp:64:21:64:28 | call to C2 | Node should have one location but has 2. |
+| A.cpp:73:25:73:32 | call to C2 | Node should have one location but has 2. |
+| A.cpp:126:12:126:18 | call to C | Node should have one location but has 2. |
+| A.cpp:142:14:142:20 | call to C | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to C | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to C | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to C | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to C | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to C | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to C | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to C | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to C2 | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to C2 | Node should have one location but has 2. |
+missingLocation
+uniqueNodeToString
+missingToString
+parameterCallable
+localFlowIsLocal
+compatibleTypesReflexive
+unreachableNodeCCtx
+localCallNodes
+postIsNotPre
+postHasUniquePre
+uniquePostUpdate
+postIsInSameCallable
+reverseRead
+storeIsPostUpdate
+argHasPostUpdate
+| A.cpp:40:15:40:21 | 0 | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:41:15:41:21 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:55:12:55:19 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:56:13:56:15 | call to get | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:57:17:57:23 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:57:28:57:30 | call to get | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:64:21:64:28 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:73:25:73:32 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:126:12:126:18 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:151:21:151:21 | call to r | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:160:32:160:59 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:160:43:160:49 | 0 | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:160:52:160:58 | 0 | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:161:29:161:35 | 0 | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:162:29:162:35 | 0 | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:7:28:7:34 | 0 | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:16:28:16:34 | 0 | ArgumentNode is missing PostUpdateNode. |
+| C.cpp:29:10:29:11 | s1 | ArgumentNode is missing PostUpdateNode. |
+| C.cpp:30:10:30:11 | s2 | ArgumentNode is missing PostUpdateNode. |
+| C.cpp:31:10:31:11 | s3 | ArgumentNode is missing PostUpdateNode. |
+| C.cpp:32:10:32:11 | s4 | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:22:25:22:31 | call to getElem | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:29:24:29:40 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:29:33:29:39 | 0 | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:36:24:36:40 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:36:33:36:39 | 0 | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:43:24:43:40 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:43:33:43:39 | 0 | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:50:24:50:40 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:50:33:50:39 | 0 | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:57:25:57:41 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:57:34:57:40 | 0 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:27:14:27:15 | s3 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:29:11:29:12 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:30:11:30:12 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:31:11:31:12 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:38:11:38:12 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:43:13:43:14 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:50:11:50:12 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:55:14:55:15 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:62:14:62:15 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:73:12:73:13 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:80:12:80:13 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:87:12:87:13 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:93:12:93:13 | m1 | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:40:12:40:15 | this | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:44:26:44:29 | this | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:50:17:50:26 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:51:8:51:8 | s | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:51:10:51:20 | call to getDirectly | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:56:19:56:28 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:57:8:57:8 | s | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:57:10:57:22 | call to getIndirectly | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:62:25:62:34 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:63:8:63:8 | s | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:63:10:63:28 | call to getThroughNonMember | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:68:21:68:30 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:69:8:69:20 | call to nonMemberGetA | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:69:22:69:23 | & ... | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:22:13:22:13 | 0 | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:22:16:22:16 | 0 | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:44:12:44:12 | call to a | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:45:12:45:12 | call to b | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:55:13:55:22 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:56:13:56:22 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:57:13:57:22 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:58:13:58:22 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:28:12:28:12 | call to a | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:29:12:29:12 | call to b | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:34:11:34:20 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:34:25:34:25 | 0 | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:35:11:35:11 | 0 | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:35:14:35:23 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:36:11:36:20 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:36:25:36:34 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:37:11:37:11 | 0 | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:37:14:37:14 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:28:12:28:12 | call to a | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:29:12:29:12 | call to b | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:34:11:34:11 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:34:14:34:14 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:35:11:35:11 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:35:14:35:14 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:36:11:36:11 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:36:14:36:14 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:37:11:37:11 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:37:14:37:14 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:39:12:39:21 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:40:12:40:21 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:41:12:41:21 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:42:12:42:21 | call to user_input | ArgumentNode is missing PostUpdateNode. |

--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.ql
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-consistency.ql
@@ -1,0 +1,1 @@
+import semmle.code.cpp.dataflow.internal.DataFlowImplConsistency::Consistency

--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-ir-consistency.expected
@@ -1,0 +1,338 @@
+uniqueEnclosingCallable
+uniqueTypeBound
+uniqueTypeRepr
+uniqueNodeLocation
+| D.cpp:1:17:1:17 | o | Node should have one location but has 2. |
+| by_reference.cpp:1:17:1:17 | o | Node should have one location but has 2. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+missingLocation
+| Nodes without location: 4 |
+uniqueNodeToString
+missingToString
+parameterCallable
+localFlowIsLocal
+compatibleTypesReflexive
+unreachableNodeCCtx
+localCallNodes
+postIsNotPre
+postHasUniquePre
+uniquePostUpdate
+postIsInSameCallable
+reverseRead
+storeIsPostUpdate
+argHasPostUpdate
+| A.cpp:9:9:9:9 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:14:9:14:9 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:31:14:31:21 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:31:14:31:21 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:31:20:31:20 | c | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:38:7:38:8 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:39:7:39:8 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:40:5:40:6 | cc | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:40:15:40:21 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:41:5:41:6 | ct | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:41:15:41:21 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:41:15:41:21 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:41:15:41:21 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:42:10:42:12 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:43:10:43:12 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:47:12:47:18 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:47:12:47:18 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:48:20:48:20 | c | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:49:10:49:13 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:54:12:54:18 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:54:12:54:18 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:55:5:55:5 | b | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:55:12:55:19 | (C *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:55:12:55:19 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:55:12:55:19 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:56:10:56:10 | b | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:56:10:56:17 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:57:10:57:32 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:57:11:57:24 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:57:11:57:24 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:57:17:57:23 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:57:17:57:23 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:62:13:62:19 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:62:13:62:19 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:64:17:64:18 | b1 | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:64:21:64:28 | (C *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:64:21:64:28 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:64:21:64:28 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:65:10:65:14 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:66:10:66:14 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:71:13:71:19 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:71:13:71:19 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:73:21:73:22 | b1 | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:73:25:73:32 | (C *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:73:25:73:32 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:73:25:73:32 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:74:10:74:14 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:75:10:75:14 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:81:17:81:18 | b1 | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:81:21:81:21 | c | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:89:15:89:21 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:89:15:89:21 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:90:7:90:8 | b2 | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:90:15:90:15 | c | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:98:12:98:18 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:99:14:99:21 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:99:14:99:21 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:101:8:101:9 | (C *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:107:12:107:16 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:116:12:116:19 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:116:12:116:19 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:120:12:120:16 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:126:5:126:5 | b | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:126:12:126:18 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:126:12:126:18 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:130:12:130:18 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:130:12:130:18 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:131:8:131:8 | b | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:132:10:132:13 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:142:14:142:20 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:142:14:142:20 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:143:25:143:31 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:143:25:143:31 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:150:12:150:18 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:150:12:150:18 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:151:12:151:24 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:151:12:151:24 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:151:18:151:18 | b | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:151:21:151:21 | call to r | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:152:10:152:13 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:153:10:153:16 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:154:10:154:13 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:159:12:159:18 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:159:12:159:18 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:160:18:160:60 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:160:18:160:60 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:160:29:160:29 | b | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:160:32:160:59 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:160:32:160:59 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:160:43:160:49 | (B *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:160:52:160:58 | (MyList *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:161:18:161:40 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:161:18:161:40 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:161:29:161:35 | (B *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:161:38:161:39 | l1 | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:162:18:162:40 | Constant | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:162:18:162:40 | new | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:162:29:162:35 | (B *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:162:38:162:39 | l2 | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:163:10:163:17 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:164:10:164:23 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:165:10:165:29 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:166:10:166:35 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| A.cpp:169:12:169:18 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:6:15:6:24 | Constant | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:7:16:7:35 | Constant | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:7:16:7:35 | new | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:7:25:7:25 | e | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:7:28:7:34 | (Elem *)... | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:8:16:8:27 | Constant | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:8:16:8:27 | new | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:8:25:8:26 | b1 | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:9:10:9:24 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:10:10:10:24 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:15:15:15:27 | Constant | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:16:16:16:38 | Constant | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:16:16:16:38 | new | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:16:28:16:34 | (Elem *)... | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:16:37:16:37 | e | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:17:16:17:27 | Constant | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:17:16:17:27 | new | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:17:25:17:26 | b1 | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:18:10:18:24 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| B.cpp:19:10:19:24 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| C.cpp:18:12:18:18 | Constant | ArgumentNode is missing PostUpdateNode. |
+| C.cpp:18:12:18:18 | new | ArgumentNode is missing PostUpdateNode. |
+| C.cpp:19:5:19:5 | c | ArgumentNode is missing PostUpdateNode. |
+| C.cpp:22:12:22:21 | Constant | ArgumentNode is missing PostUpdateNode. |
+| C.cpp:24:16:24:25 | Constant | ArgumentNode is missing PostUpdateNode. |
+| C.cpp:32:10:32:11 | (const void *)... | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:22:10:22:11 | b2 | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:22:10:22:33 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:22:14:22:20 | call to getBox1 | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:28:15:28:24 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:29:15:29:41 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:29:15:29:41 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:29:24:29:40 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:29:24:29:40 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:29:33:29:39 | (Elem *)... | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:31:14:31:14 | b | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:35:15:35:24 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:36:15:36:41 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:36:15:36:41 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:36:24:36:40 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:36:24:36:40 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:36:33:36:39 | (Elem *)... | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:37:8:37:10 | box | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:37:21:37:21 | e | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:38:14:38:14 | b | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:42:15:42:24 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:43:15:43:41 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:43:15:43:41 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:43:24:43:40 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:43:24:43:40 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:43:33:43:39 | (Elem *)... | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:44:5:44:5 | b | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:45:14:45:14 | b | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:49:15:49:24 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:50:15:50:41 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:50:15:50:41 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:50:24:50:40 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:50:24:50:40 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:50:33:50:39 | (Elem *)... | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:51:5:51:5 | b | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:51:8:51:14 | call to getBox1 | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:51:27:51:27 | e | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:52:14:52:14 | b | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:56:15:56:24 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:57:16:57:42 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:57:16:57:42 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:57:25:57:41 | Constant | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:57:25:57:41 | new | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:57:34:57:40 | (Elem *)... | ArgumentNode is missing PostUpdateNode. |
+| D.cpp:64:10:64:28 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| E.cpp:21:18:21:23 | buffer | ArgumentNode is missing PostUpdateNode. |
+| E.cpp:28:21:28:23 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| E.cpp:29:21:29:29 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| E.cpp:30:21:30:33 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| E.cpp:31:10:31:12 | raw | ArgumentNode is missing PostUpdateNode. |
+| E.cpp:32:13:32:18 | buffer | ArgumentNode is missing PostUpdateNode. |
+| E.cpp:33:18:33:19 | & ... | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:25:17:25:19 | & ... | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:26:19:26:20 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:27:14:27:15 | s3 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:29:11:29:12 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:30:11:30:12 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:31:11:31:12 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:38:11:38:12 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:43:13:43:14 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:50:11:50:12 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:55:14:55:15 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:62:14:62:15 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:73:12:73:13 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:80:12:80:13 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:87:12:87:13 | m1 | ArgumentNode is missing PostUpdateNode. |
+| aliasing.cpp:93:12:93:13 | m1 | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:20:5:20:8 | this | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:20:23:20:27 | value | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:24:19:24:22 | this | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:24:25:24:29 | value | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:40:12:40:15 | this | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:44:26:44:29 | this | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:50:3:50:3 | s | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:50:17:50:26 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:51:8:51:8 | (const S)... | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:51:10:51:20 | call to getDirectly | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:56:3:56:3 | s | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:56:19:56:28 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:57:8:57:8 | (const S)... | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:57:10:57:22 | call to getIndirectly | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:62:3:62:3 | s | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:62:25:62:34 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:63:8:63:8 | (const S)... | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:63:10:63:28 | call to getThroughNonMember | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:68:17:68:18 | & ... | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:68:21:68:30 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:69:8:69:20 | call to nonMemberGetA | ArgumentNode is missing PostUpdateNode. |
+| by_reference.cpp:69:22:69:23 | (const S *)... | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:22:11:22:17 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:22:13:22:13 | 0 | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:22:16:22:16 | 0 | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:44:10:44:10 | f | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:44:12:44:12 | call to a | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:45:10:45:10 | f | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:45:12:45:12 | call to b | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:50:7:50:8 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:51:7:51:8 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:52:7:52:8 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:53:7:53:8 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:55:6:55:6 | f | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:55:13:55:22 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:56:6:56:6 | f | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:56:13:56:22 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:57:6:57:6 | f | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:57:13:57:22 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:58:6:58:6 | f | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:58:13:58:22 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:61:7:61:8 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:64:7:64:8 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:67:7:67:8 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| complex.cpp:70:7:70:8 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:28:10:28:10 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:28:12:28:12 | call to a | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:29:10:29:10 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:29:12:29:12 | call to b | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:34:9:34:9 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:34:11:34:20 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:34:25:34:25 | 0 | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:35:9:35:9 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:35:11:35:11 | 0 | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:35:14:35:23 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:36:9:36:9 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:36:11:36:20 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:36:25:36:34 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:37:9:37:9 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:37:11:37:11 | 0 | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:37:14:37:14 | 0 | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:40:9:40:9 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:43:9:43:9 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:46:9:46:9 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| constructors.cpp:49:9:49:9 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (const void *)... | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (const void *)... | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (const void *)... | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:28:10:28:10 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:28:12:28:12 | call to a | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:29:10:29:10 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:29:12:29:12 | call to b | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:34:9:34:9 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:34:11:34:11 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:34:14:34:14 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:35:9:35:9 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:35:11:35:11 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:35:14:35:14 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:36:9:36:9 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:36:11:36:11 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:36:14:36:14 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:37:9:37:9 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:37:11:37:11 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:37:14:37:14 | 0 | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:39:5:39:5 | f | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:39:12:39:21 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:40:5:40:5 | g | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:40:12:40:21 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:41:5:41:5 | h | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:41:12:41:21 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:42:5:42:5 | h | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:42:12:42:21 | call to user_input | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:45:9:45:9 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:48:9:48:9 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:51:9:51:9 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| simple.cpp:54:9:54:9 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| struct_init.c:15:12:15:12 | a | ArgumentNode is missing PostUpdateNode. |
+| struct_init.c:16:12:16:12 | b | ArgumentNode is missing PostUpdateNode. |
+| struct_init.c:22:11:22:11 | a | ArgumentNode is missing PostUpdateNode. |
+| struct_init.c:23:11:23:11 | b | ArgumentNode is missing PostUpdateNode. |
+| struct_init.c:24:10:24:12 | & ... | ArgumentNode is missing PostUpdateNode. |
+| struct_init.c:31:23:31:23 | a | ArgumentNode is missing PostUpdateNode. |
+| struct_init.c:32:23:32:23 | b | ArgumentNode is missing PostUpdateNode. |
+| struct_init.c:33:25:33:25 | a | ArgumentNode is missing PostUpdateNode. |
+| struct_init.c:34:25:34:25 | b | ArgumentNode is missing PostUpdateNode. |
+| struct_init.c:36:10:36:24 | & ... | ArgumentNode is missing PostUpdateNode. |
+| struct_init.c:46:16:46:24 | pointerAB | ArgumentNode is missing PostUpdateNode. |

--- a/cpp/ql/test/library-tests/dataflow/fields/dataflow-ir-consistency.ql
+++ b/cpp/ql/test/library-tests/dataflow/fields/dataflow-ir-consistency.ql
@@ -1,0 +1,1 @@
+import semmle.code.cpp.ir.dataflow.internal.DataFlowImplConsistency::Consistency

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.expected
@@ -1,0 +1,286 @@
+uniqueEnclosingCallable
+| enum.c:2:6:2:6 | 1 | Node should have one enclosing callable but has 0. |
+| enum.c:2:6:2:10 | ... + ... | Node should have one enclosing callable but has 0. |
+| enum.c:2:10:2:10 | 1 | Node should have one enclosing callable but has 0. |
+| misc.c:11:17:11:17 | 1 | Node should have one enclosing callable but has 0. |
+| misc.c:11:17:11:21 | ... + ... | Node should have one enclosing callable but has 0. |
+| misc.c:11:21:11:21 | 2 | Node should have one enclosing callable but has 0. |
+| misc.c:210:24:210:24 | 0 | Node should have one enclosing callable but has 0. |
+| misc.c:210:24:210:28 | ... + ... | Node should have one enclosing callable but has 0. |
+| misc.c:210:28:210:28 | 1 | Node should have one enclosing callable but has 0. |
+uniqueTypeBound
+| bad_asts.cpp:19:10:19:10 | constructor init of field x [post-this] | Node should have one type bound but has 0. |
+| bad_asts.cpp:19:10:19:10 | constructor init of field x [pre-this] | Node should have one type bound but has 0. |
+| bad_asts.cpp:19:10:19:10 | constructor init of field y [post-this] | Node should have one type bound but has 0. |
+| bad_asts.cpp:19:10:19:10 | constructor init of field y [pre-this] | Node should have one type bound but has 0. |
+| cpp17.cpp:15:5:15:45 | call to unknown function | Node should have one type bound but has 0. |
+| ir.cpp:784:15:784:15 | constructor init of field middlevb2_s [post-this] | Node should have one type bound but has 0. |
+| ir.cpp:784:15:784:15 | constructor init of field middlevb2_s [pre-this] | Node should have one type bound but has 0. |
+| static_init_templates.cpp:240:7:240:7 | constructor init of field mcc [post-this] | Node should have one type bound but has 0. |
+| static_init_templates.cpp:240:7:240:7 | constructor init of field mcc [pre-this] | Node should have one type bound but has 0. |
+uniqueTypeRepr
+| bad_asts.cpp:19:10:19:10 | constructor init of field x [post-this] | Node should have one type representation but has 0. |
+| bad_asts.cpp:19:10:19:10 | constructor init of field x [pre-this] | Node should have one type representation but has 0. |
+| bad_asts.cpp:19:10:19:10 | constructor init of field y [post-this] | Node should have one type representation but has 0. |
+| bad_asts.cpp:19:10:19:10 | constructor init of field y [pre-this] | Node should have one type representation but has 0. |
+| cpp17.cpp:15:5:15:45 | call to unknown function | Node should have one type representation but has 0. |
+| ir.cpp:784:15:784:15 | constructor init of field middlevb2_s [post-this] | Node should have one type representation but has 0. |
+| ir.cpp:784:15:784:15 | constructor init of field middlevb2_s [pre-this] | Node should have one type representation but has 0. |
+| static_init_templates.cpp:240:7:240:7 | constructor init of field mcc [post-this] | Node should have one type representation but has 0. |
+| static_init_templates.cpp:240:7:240:7 | constructor init of field mcc [pre-this] | Node should have one type representation but has 0. |
+uniqueNodeLocation
+| break_labels.c:2:11:2:11 | i | Node should have one location but has 4. |
+| break_labels.c:2:11:2:11 | x | Node should have one location but has 4. |
+| cpp11.cpp:82:17:82:55 | call to Val | Node should have one location but has 2. |
+| cpp11.cpp:82:17:82:55 | call to Val | Node should have one location but has 2. |
+| duff.c:2:12:2:12 | i | Node should have one location but has 4. |
+| duff.c:2:12:2:12 | x | Node should have one location but has 4. |
+| file://:0:0:0:0 | call to PolymorphicBase | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to PolymorphicDerived | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to Val | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to Val | Node should have one location but has 2. |
+| file://:0:0:0:0 | call to exn1 | Node should have one location but has 2. |
+| file://:0:0:0:0 | p#2 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#2 | Node should have one location but has 0. |
+| ifelsestmt.c:37:17:37:17 | x | Node should have one location but has 2. |
+| ifelsestmt.c:37:24:37:24 | y | Node should have one location but has 2. |
+| ifstmt.c:27:17:27:17 | x | Node should have one location but has 2. |
+| ifstmt.c:27:24:27:24 | y | Node should have one location but has 2. |
+| ir.cpp:850:19:850:19 | call to PolymorphicBase | Node should have one location but has 2. |
+| ir.cpp:851:22:851:22 | call to PolymorphicDerived | Node should have one location but has 2. |
+| nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
+| nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
+| switchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
+| switchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
+| try_catch.cpp:13:5:13:16 | call to exn1 | Node should have one location but has 2. |
+missingLocation
+| Nodes without location: 2 |
+uniqueNodeToString
+| break_labels.c:2:11:2:11 | i | Node should have one toString but has 2. |
+| break_labels.c:2:11:2:11 | x | Node should have one toString but has 2. |
+| break_labels.c:4:9:4:9 | i | Node should have one toString but has 2. |
+| break_labels.c:4:9:4:9 | x | Node should have one toString but has 2. |
+| break_labels.c:6:16:6:16 | i | Node should have one toString but has 2. |
+| break_labels.c:6:16:6:16 | x | Node should have one toString but has 2. |
+| break_labels.c:7:17:7:17 | i | Node should have one toString but has 2. |
+| break_labels.c:7:17:7:17 | x | Node should have one toString but has 2. |
+| duff.c:2:12:2:12 | i | Node should have one toString but has 2. |
+| duff.c:2:12:2:12 | x | Node should have one toString but has 2. |
+| duff.c:3:14:3:14 | i | Node should have one toString but has 2. |
+| duff.c:3:14:3:14 | x | Node should have one toString but has 2. |
+| duff.c:4:13:4:13 | i | Node should have one toString but has 2. |
+| duff.c:4:13:4:13 | x | Node should have one toString but has 2. |
+| nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
+| nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
+| nodefaultswitchstmt.c:2:14:2:14 | i | Node should have one toString but has 2. |
+| nodefaultswitchstmt.c:2:14:2:14 | x | Node should have one toString but has 2. |
+| switchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
+| switchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
+| switchstmt.c:2:14:2:14 | i | Node should have one toString but has 2. |
+| switchstmt.c:2:14:2:14 | x | Node should have one toString but has 2. |
+missingToString
+parameterCallable
+localFlowIsLocal
+compatibleTypesReflexive
+unreachableNodeCCtx
+localCallNodes
+postIsNotPre
+postHasUniquePre
+uniquePostUpdate
+postIsInSameCallable
+reverseRead
+storeIsPostUpdate
+argHasPostUpdate
+| CPP-309.cpp:7:5:7:20 | <error expr> | ArgumentNode is missing PostUpdateNode. |
+| CPP-309.cpp:7:9:7:9 | 2 | ArgumentNode is missing PostUpdateNode. |
+| CPP-309.cpp:7:12:7:12 | 3 | ArgumentNode is missing PostUpdateNode. |
+| CPP-309.cpp:11:13:11:13 | 1 | ArgumentNode is missing PostUpdateNode. |
+| VacuousDestructorCall.cpp:10:18:10:18 | i | ArgumentNode is missing PostUpdateNode. |
+| abortingfunctions.cpp:45:13:45:13 | 0 | ArgumentNode is missing PostUpdateNode. |
+| abortingfunctions.cpp:45:16:45:16 | 0 | ArgumentNode is missing PostUpdateNode. |
+| allocators.cpp:16:14:16:36 | <error expr> | ArgumentNode is missing PostUpdateNode. |
+| allocators.cpp:16:18:16:19 | 11 | ArgumentNode is missing PostUpdateNode. |
+| allocators.cpp:16:22:16:23 | 22 | ArgumentNode is missing PostUpdateNode. |
+| allocators.cpp:16:30:16:31 | 33 | ArgumentNode is missing PostUpdateNode. |
+| allocators.cpp:16:34:16:35 | 44 | ArgumentNode is missing PostUpdateNode. |
+| bad_asts.cpp:16:25:16:25 | 1 | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:8:32:8:32 | 0 | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:8:35:8:37 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:8:40:8:40 | y | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:10:20:10:26 | ... != ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:20:33:20:35 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:21:33:21:35 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:21:38:21:38 | y | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:22:34:22:36 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:22:39:22:39 | y | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:28:31:28:38 | ... == ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:34:34:34:34 | x | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:39:25:39:27 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:39:30:39:30 | y | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:39:33:39:33 | 1 | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:43:26:43:28 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:43:37:43:37 | y | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:45:33:45:41 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:47:24:47:30 | Hello | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:47:33:47:35 | 101 | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:47:38:47:38 | 5 | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:51:41:51:43 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:51:46:51:46 | 0 | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:54:41:54:41 | 0 | ArgumentNode is missing PostUpdateNode. |
+| builtin.cpp:14:40:14:44 | ... - ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.cpp:15:31:15:35 | * ... | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:16:20:16:20 | x | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:26:24:26:24 | x | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:41:23:41:23 | x | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:48:23:48:24 | - ... | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:48:35:48:36 | - ... | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:48:53:48:53 | x | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:30:9:30:13 | call to C1 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:30:12:30:12 | 1 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:30:18:30:22 | call to C1 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:30:21:30:21 | 2 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:33:9:33:13 | call to C1 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:33:12:33:12 | 3 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:33:18:33:22 | call to C1 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:33:21:33:21 | 3 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:39:9:39:13 | call to C2 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:39:12:39:12 | 1 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:39:18:39:22 | call to C2 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:39:21:39:21 | 2 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:42:9:42:13 | call to C2 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:42:12:42:12 | 3 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:42:18:42:22 | call to C2 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:42:21:42:21 | 3 | ArgumentNode is missing PostUpdateNode. |
+| constructorinitializer.cpp:8:6:8:10 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| constructorinitializer.cpp:8:13:8:17 | ... - ... | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:28:21:28:21 | (__end) | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:77:5:77:17 | unaryFunction | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:77:19:77:21 | arg | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:77:19:77:21 | arg | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:77:19:77:21 | call to Val | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:11:82:14 | arg2 | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:11:82:14 | arg2 | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:11:82:14 | call to Val | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:17:82:55 | [...](...){...} | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:17:82:55 | [...](...){...} | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:30:82:52 | arg1 | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:45:82:48 | arg1 | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:45:82:48 | call to Val | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:51:82:51 | call to Val | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:51:82:51 | x | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:51:82:51 | x | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:88:12:88:22 | doSomething | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:88:25:88:30 | call to Val | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:88:29:88:29 | 1 | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:88:33:88:38 | call to Val | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:88:37:88:37 | 2 | ArgumentNode is missing PostUpdateNode. |
+| cpp17.cpp:15:5:15:45 | <error expr> | ArgumentNode is missing PostUpdateNode. |
+| cpp17.cpp:15:38:15:41 | args | ArgumentNode is missing PostUpdateNode. |
+| cpp17.cpp:15:38:15:41 | args | ArgumentNode is missing PostUpdateNode. |
+| cpp17.cpp:15:38:15:41 | p#2 | ArgumentNode is missing PostUpdateNode. |
+| cpp17.cpp:19:13:19:13 | 1 | ArgumentNode is missing PostUpdateNode. |
+| cpp17.cpp:19:16:19:16 | 2 | ArgumentNode is missing PostUpdateNode. |
+| destructors.cpp:52:14:52:16 | ref | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:377:16:377:16 | x | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:377:19:377:19 | y | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:381:32:381:32 | x | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:381:35:381:35 | y | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:552:16:552:16 | 5 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:585:20:585:26 | %d %s | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:585:29:585:29 | 1 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:585:32:585:39 | string | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:617:15:617:21 | hello | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:619:24:619:29 | test | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:623:5:623:5 | r | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:624:5:624:5 | p | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:625:5:625:5 | s | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:653:38:653:38 | 0 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:654:40:654:40 | 1 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:655:32:655:32 | 2 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:662:13:662:18 | test | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:700:7:700:7 | 5 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:709:14:709:14 | x | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:709:17:709:17 | y | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:721:41:721:47 | 0 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:721:50:721:52 | 111 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:731:32:731:46 | String object | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:736:18:736:18 | s | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:745:8:745:8 | base_s | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:754:8:754:8 | * ... | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:754:8:754:8 | middle_s | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:763:8:763:8 | * ... | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:763:8:763:8 | derived_s | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:808:7:808:7 | m | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:809:7:809:13 | call to Base | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:809:13:809:13 | m | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:810:7:810:26 | call to Base | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:810:25:810:25 | m | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:816:16:816:16 | b | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:817:28:817:28 | b | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:822:7:822:7 | d | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:823:7:823:13 | call to Base | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:823:13:823:13 | d | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:824:7:824:26 | call to Base | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:824:25:824:25 | d | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:830:17:830:17 | b | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:831:29:831:29 | b | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:868:10:868:11 |  | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:942:3:942:15 | <error expr> | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:942:7:942:10 | 1.0 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:945:3:945:27 | <error expr> | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:945:7:945:10 | 1.0 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:945:20:945:26 | hello | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:947:3:947:25 | <error expr> | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:947:7:947:10 | 1.0 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:947:25:947:25 | 128 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:953:3:953:18 | <error expr> | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:953:7:953:10 | 1.0 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:956:3:956:27 | <error expr> | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:956:7:956:10 | 1.0 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:956:28:956:28 | 128 | ArgumentNode is missing PostUpdateNode. |
+| membercallexpr_args.cpp:10:10:10:14 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| membercallexpr_args.cpp:10:17:10:21 | ... - ... | ArgumentNode is missing PostUpdateNode. |
+| misc.c:83:14:83:14 | i | ArgumentNode is missing PostUpdateNode. |
+| misc.c:83:17:83:17 | j | ArgumentNode is missing PostUpdateNode. |
+| misc.c:84:16:84:16 | i | ArgumentNode is missing PostUpdateNode. |
+| misc.c:84:19:84:19 | j | ArgumentNode is missing PostUpdateNode. |
+| misc.c:147:16:147:16 | i | ArgumentNode is missing PostUpdateNode. |
+| misc.c:147:19:147:19 | j | ArgumentNode is missing PostUpdateNode. |
+| misc.c:228:31:228:40 | global_int | ArgumentNode is missing PostUpdateNode. |
+| misc.c:229:32:229:41 | global_int | ArgumentNode is missing PostUpdateNode. |
+| misc.c:230:27:230:36 | global_int | ArgumentNode is missing PostUpdateNode. |
+| misc.c:231:29:231:38 | global_int | ArgumentNode is missing PostUpdateNode. |
+| ms_assume.cpp:13:21:13:35 | Hello, world! | ArgumentNode is missing PostUpdateNode. |
+| ms_assume.cpp:14:21:14:21 | 0 | ArgumentNode is missing PostUpdateNode. |
+| ms_assume.cpp:28:26:28:28 | 256 | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:11:12:11:14 | 101 | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:14:16:14:18 | 102 | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:18:16:18:18 | 103 | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:21:16:21:18 | 104 | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:24:12:24:14 | 105 | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:28:12:28:14 | 101 | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:31:16:31:18 | 106 | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:35:16:35:18 | 107 | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:38:16:38:18 | 108 | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:41:12:41:14 | 109 | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:48:10:48:12 | 201 | ArgumentNode is missing PostUpdateNode. |
+| newexpr.cpp:8:8:8:12 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| newexpr.cpp:8:15:8:19 | ... - ... | ArgumentNode is missing PostUpdateNode. |
+| no_dynamic_init.cpp:5:12:5:35 | Goodbye cruel world.\n | ArgumentNode is missing PostUpdateNode. |
+| ops.cpp:19:15:19:22 | <error expr> | ArgumentNode is missing PostUpdateNode. |
+| ops.cpp:20:18:20:30 | <error expr> | ArgumentNode is missing PostUpdateNode. |
+| ops.cpp:21:18:21:34 | <error expr> | ArgumentNode is missing PostUpdateNode. |
+| ops.cpp:26:31:26:53 | <error expr> | ArgumentNode is missing PostUpdateNode. |
+| parameterinitializer.cpp:8:12:8:21 | Got %d\n | ArgumentNode is missing PostUpdateNode. |
+| parameterinitializer.cpp:8:24:8:24 | i | ArgumentNode is missing PostUpdateNode. |
+| parameterinitializer.cpp:19:7:19:7 | 3 | ArgumentNode is missing PostUpdateNode. |
+| parameterinitializer.cpp:21:7:21:7 | 4 | ArgumentNode is missing PostUpdateNode. |
+| pointer_to_member.cpp:23:46:23:50 | 0 | ArgumentNode is missing PostUpdateNode. |
+| pointer_to_member.cpp:24:42:24:45 | 1 | ArgumentNode is missing PostUpdateNode. |
+| staticlocals.cpp:27:27:27:29 | two | ArgumentNode is missing PostUpdateNode. |
+| staticlocals.cpp:28:27:28:27 | 2 | ArgumentNode is missing PostUpdateNode. |
+| staticmembercallexpr_args.cpp:10:9:10:13 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| staticmembercallexpr_args.cpp:10:16:10:20 | ... - ... | ArgumentNode is missing PostUpdateNode. |
+| stmt_expr.cpp:13:18:13:18 | 1 | ArgumentNode is missing PostUpdateNode. |
+| stmt_expr.cpp:30:20:30:20 | 3 | ArgumentNode is missing PostUpdateNode. |
+| vla.c:5:27:5:33 | access to array | ArgumentNode is missing PostUpdateNode. |

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.ql
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-consistency.ql
@@ -1,0 +1,1 @@
+import semmle.code.cpp.dataflow.internal.DataFlowImplConsistency::Consistency

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.expected
@@ -1,0 +1,1105 @@
+uniqueEnclosingCallable
+uniqueTypeBound
+| break_labels.c:13:5:13:18 | VariableAddress | Node should have one type bound but has 2. |
+| break_labels.c:13:12:13:17 | Store | Node should have one type bound but has 2. |
+| enum.c:6:2:6:10 | VariableAddress | Node should have one type bound but has 2. |
+| enum.c:6:9:6:9 | Store | Node should have one type bound but has 2. |
+| parameterinitializer.cpp:4:5:4:13 | VariableAddress | Node should have one type bound but has 2. |
+| parameterinitializer.cpp:4:12:4:12 | Store | Node should have one type bound but has 2. |
+uniqueTypeRepr
+uniqueNodeLocation
+| aggregateinitializer.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| aggregateinitializer.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| aggregateinitializer.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| aggregateinitializer.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| aggregateinitializer.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| aggregateinitializer.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| aggregateinitializer.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| aggregateinitializer.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| aggregateinitializer.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| aggregateinitializer.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| aggregateinitializer.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| allocators.cpp:14:5:14:8 | AliasedDefinition | Node should have one location but has 4. |
+| allocators.cpp:14:5:14:8 | AliasedUse | Node should have one location but has 4. |
+| allocators.cpp:14:5:14:8 | Chi | Node should have one location but has 4. |
+| allocators.cpp:14:5:14:8 | EnterFunction | Node should have one location but has 4. |
+| allocators.cpp:14:5:14:8 | ExitFunction | Node should have one location but has 4. |
+| allocators.cpp:14:5:14:8 | InitializeNonLocal | Node should have one location but has 4. |
+| allocators.cpp:14:5:14:8 | Phi | Node should have one location but has 4. |
+| allocators.cpp:14:5:14:8 | Phi | Node should have one location but has 4. |
+| allocators.cpp:14:5:14:8 | ReturnValue | Node should have one location but has 4. |
+| allocators.cpp:14:5:14:8 | UnmodeledDefinition | Node should have one location but has 4. |
+| allocators.cpp:14:5:14:8 | UnmodeledUse | Node should have one location but has 4. |
+| allocators.cpp:14:5:14:8 | VariableAddress | Node should have one location but has 4. |
+| array_delete.cpp:5:6:5:6 | AliasedDefinition | Node should have one location but has 14. |
+| array_delete.cpp:5:6:5:6 | AliasedUse | Node should have one location but has 14. |
+| array_delete.cpp:5:6:5:6 | Chi | Node should have one location but has 14. |
+| array_delete.cpp:5:6:5:6 | EnterFunction | Node should have one location but has 14. |
+| array_delete.cpp:5:6:5:6 | ExitFunction | Node should have one location but has 14. |
+| array_delete.cpp:5:6:5:6 | InitializeNonLocal | Node should have one location but has 14. |
+| array_delete.cpp:5:6:5:6 | Phi | Node should have one location but has 14. |
+| array_delete.cpp:5:6:5:6 | ReturnVoid | Node should have one location but has 14. |
+| array_delete.cpp:5:6:5:6 | UnmodeledDefinition | Node should have one location but has 14. |
+| array_delete.cpp:5:6:5:6 | UnmodeledUse | Node should have one location but has 14. |
+| assignexpr.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
+| assignexpr.cpp:6:6:6:6 | AliasedUse | Node should have one location but has 14. |
+| assignexpr.cpp:6:6:6:6 | Chi | Node should have one location but has 14. |
+| assignexpr.cpp:6:6:6:6 | EnterFunction | Node should have one location but has 14. |
+| assignexpr.cpp:6:6:6:6 | ExitFunction | Node should have one location but has 14. |
+| assignexpr.cpp:6:6:6:6 | InitializeNonLocal | Node should have one location but has 14. |
+| assignexpr.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
+| assignexpr.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
+| assignexpr.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
+| assignexpr.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
+| break_labels.c:2:5:2:5 | AliasedDefinition | Node should have one location but has 20. |
+| break_labels.c:2:5:2:5 | AliasedUse | Node should have one location but has 20. |
+| break_labels.c:2:5:2:5 | Chi | Node should have one location but has 20. |
+| break_labels.c:2:5:2:5 | EnterFunction | Node should have one location but has 20. |
+| break_labels.c:2:5:2:5 | ExitFunction | Node should have one location but has 20. |
+| break_labels.c:2:5:2:5 | InitializeNonLocal | Node should have one location but has 20. |
+| break_labels.c:2:5:2:5 | Phi | Node should have one location but has 20. |
+| break_labels.c:2:5:2:5 | ReturnVoid | Node should have one location but has 20. |
+| break_labels.c:2:5:2:5 | UnmodeledDefinition | Node should have one location but has 20. |
+| break_labels.c:2:5:2:5 | UnmodeledUse | Node should have one location but has 20. |
+| break_labels.c:2:5:2:5 | Unreached | Node should have one location but has 20. |
+| break_labels.c:2:11:2:11 | VariableAddress | Node should have one location but has 4. |
+| break_labels.c:2:11:2:11 | i | Node should have one location but has 4. |
+| break_labels.c:2:11:2:11 | i | Node should have one location but has 4. |
+| break_labels.c:2:11:2:11 | x | Node should have one location but has 4. |
+| break_labels.c:2:11:2:11 | x | Node should have one location but has 4. |
+| conditional_destructors.cpp:29:6:29:7 | AliasedDefinition | Node should have one location but has 2. |
+| conditional_destructors.cpp:29:6:29:7 | AliasedUse | Node should have one location but has 2. |
+| conditional_destructors.cpp:29:6:29:7 | Chi | Node should have one location but has 2. |
+| conditional_destructors.cpp:29:6:29:7 | EnterFunction | Node should have one location but has 2. |
+| conditional_destructors.cpp:29:6:29:7 | ExitFunction | Node should have one location but has 2. |
+| conditional_destructors.cpp:29:6:29:7 | InitializeNonLocal | Node should have one location but has 2. |
+| conditional_destructors.cpp:29:6:29:7 | Phi | Node should have one location but has 2. |
+| conditional_destructors.cpp:29:6:29:7 | ReturnVoid | Node should have one location but has 2. |
+| conditional_destructors.cpp:29:6:29:7 | UnmodeledDefinition | Node should have one location but has 2. |
+| conditional_destructors.cpp:29:6:29:7 | UnmodeledUse | Node should have one location but has 2. |
+| conditional_destructors.cpp:38:6:38:7 | AliasedDefinition | Node should have one location but has 2. |
+| conditional_destructors.cpp:38:6:38:7 | AliasedUse | Node should have one location but has 2. |
+| conditional_destructors.cpp:38:6:38:7 | Chi | Node should have one location but has 2. |
+| conditional_destructors.cpp:38:6:38:7 | EnterFunction | Node should have one location but has 2. |
+| conditional_destructors.cpp:38:6:38:7 | ExitFunction | Node should have one location but has 2. |
+| conditional_destructors.cpp:38:6:38:7 | InitializeNonLocal | Node should have one location but has 2. |
+| conditional_destructors.cpp:38:6:38:7 | Phi | Node should have one location but has 2. |
+| conditional_destructors.cpp:38:6:38:7 | ReturnVoid | Node should have one location but has 2. |
+| conditional_destructors.cpp:38:6:38:7 | UnmodeledDefinition | Node should have one location but has 2. |
+| conditional_destructors.cpp:38:6:38:7 | UnmodeledUse | Node should have one location but has 2. |
+| conditional_destructors.cpp:38:6:38:7 | Unreached | Node should have one location but has 2. |
+| constmemberaccess.cpp:3:7:3:7 | x | Node should have one location but has 2. |
+| constmemberaccess.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
+| constmemberaccess.cpp:6:6:6:6 | AliasedUse | Node should have one location but has 14. |
+| constmemberaccess.cpp:6:6:6:6 | Chi | Node should have one location but has 14. |
+| constmemberaccess.cpp:6:6:6:6 | EnterFunction | Node should have one location but has 14. |
+| constmemberaccess.cpp:6:6:6:6 | ExitFunction | Node should have one location but has 14. |
+| constmemberaccess.cpp:6:6:6:6 | InitializeNonLocal | Node should have one location but has 14. |
+| constmemberaccess.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
+| constmemberaccess.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
+| constmemberaccess.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
+| constmemberaccess.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
+| constructorinitializer.cpp:3:9:3:9 | i | Node should have one location but has 2. |
+| constructorinitializer.cpp:3:9:3:9 | x | Node should have one location but has 2. |
+| constructorinitializer.cpp:3:16:3:16 | j | Node should have one location but has 2. |
+| constructorinitializer.cpp:3:16:3:16 | y | Node should have one location but has 2. |
+| constructorinitializer.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
+| constructorinitializer.cpp:6:6:6:6 | AliasedUse | Node should have one location but has 14. |
+| constructorinitializer.cpp:6:6:6:6 | Chi | Node should have one location but has 14. |
+| constructorinitializer.cpp:6:6:6:6 | EnterFunction | Node should have one location but has 14. |
+| constructorinitializer.cpp:6:6:6:6 | ExitFunction | Node should have one location but has 14. |
+| constructorinitializer.cpp:6:6:6:6 | InitializeNonLocal | Node should have one location but has 14. |
+| constructorinitializer.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
+| constructorinitializer.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
+| constructorinitializer.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
+| constructorinitializer.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
+| defconstructornewexpr.cpp:3:6:3:6 | AliasedDefinition | Node should have one location but has 14. |
+| defconstructornewexpr.cpp:3:6:3:6 | AliasedUse | Node should have one location but has 14. |
+| defconstructornewexpr.cpp:3:6:3:6 | Chi | Node should have one location but has 14. |
+| defconstructornewexpr.cpp:3:6:3:6 | EnterFunction | Node should have one location but has 14. |
+| defconstructornewexpr.cpp:3:6:3:6 | ExitFunction | Node should have one location but has 14. |
+| defconstructornewexpr.cpp:3:6:3:6 | InitializeNonLocal | Node should have one location but has 14. |
+| defconstructornewexpr.cpp:3:6:3:6 | Phi | Node should have one location but has 14. |
+| defconstructornewexpr.cpp:3:6:3:6 | ReturnVoid | Node should have one location but has 14. |
+| defconstructornewexpr.cpp:3:6:3:6 | UnmodeledDefinition | Node should have one location but has 14. |
+| defconstructornewexpr.cpp:3:6:3:6 | UnmodeledUse | Node should have one location but has 14. |
+| defdestructordeleteexpr.cpp:3:6:3:6 | AliasedDefinition | Node should have one location but has 14. |
+| defdestructordeleteexpr.cpp:3:6:3:6 | AliasedUse | Node should have one location but has 14. |
+| defdestructordeleteexpr.cpp:3:6:3:6 | Chi | Node should have one location but has 14. |
+| defdestructordeleteexpr.cpp:3:6:3:6 | EnterFunction | Node should have one location but has 14. |
+| defdestructordeleteexpr.cpp:3:6:3:6 | ExitFunction | Node should have one location but has 14. |
+| defdestructordeleteexpr.cpp:3:6:3:6 | InitializeNonLocal | Node should have one location but has 14. |
+| defdestructordeleteexpr.cpp:3:6:3:6 | Phi | Node should have one location but has 14. |
+| defdestructordeleteexpr.cpp:3:6:3:6 | ReturnVoid | Node should have one location but has 14. |
+| defdestructordeleteexpr.cpp:3:6:3:6 | UnmodeledDefinition | Node should have one location but has 14. |
+| defdestructordeleteexpr.cpp:3:6:3:6 | UnmodeledUse | Node should have one location but has 14. |
+| deleteexpr.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
+| deleteexpr.cpp:6:6:6:6 | AliasedUse | Node should have one location but has 14. |
+| deleteexpr.cpp:6:6:6:6 | Chi | Node should have one location but has 14. |
+| deleteexpr.cpp:6:6:6:6 | EnterFunction | Node should have one location but has 14. |
+| deleteexpr.cpp:6:6:6:6 | ExitFunction | Node should have one location but has 14. |
+| deleteexpr.cpp:6:6:6:6 | InitializeNonLocal | Node should have one location but has 14. |
+| deleteexpr.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
+| deleteexpr.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
+| deleteexpr.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
+| deleteexpr.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
+| dostmt.c:8:6:8:18 | AliasedDefinition | Node should have one location but has 4. |
+| dostmt.c:8:6:8:18 | AliasedUse | Node should have one location but has 4. |
+| dostmt.c:8:6:8:18 | Chi | Node should have one location but has 4. |
+| dostmt.c:8:6:8:18 | EnterFunction | Node should have one location but has 4. |
+| dostmt.c:8:6:8:18 | ExitFunction | Node should have one location but has 4. |
+| dostmt.c:8:6:8:18 | InitializeNonLocal | Node should have one location but has 4. |
+| dostmt.c:8:6:8:18 | ReturnVoid | Node should have one location but has 4. |
+| dostmt.c:8:6:8:18 | UnmodeledDefinition | Node should have one location but has 4. |
+| dostmt.c:8:6:8:18 | UnmodeledUse | Node should have one location but has 4. |
+| dostmt.c:8:6:8:18 | Unreached | Node should have one location but has 4. |
+| dostmt.c:16:6:16:18 | AliasedDefinition | Node should have one location but has 4. |
+| dostmt.c:16:6:16:18 | AliasedUse | Node should have one location but has 4. |
+| dostmt.c:16:6:16:18 | Chi | Node should have one location but has 4. |
+| dostmt.c:16:6:16:18 | EnterFunction | Node should have one location but has 4. |
+| dostmt.c:16:6:16:18 | ExitFunction | Node should have one location but has 4. |
+| dostmt.c:16:6:16:18 | InitializeNonLocal | Node should have one location but has 4. |
+| dostmt.c:16:6:16:18 | ReturnVoid | Node should have one location but has 4. |
+| dostmt.c:16:6:16:18 | UnmodeledDefinition | Node should have one location but has 4. |
+| dostmt.c:16:6:16:18 | UnmodeledUse | Node should have one location but has 4. |
+| dostmt.c:16:6:16:18 | Unreached | Node should have one location but has 4. |
+| dostmt.c:25:6:25:18 | AliasedDefinition | Node should have one location but has 2. |
+| dostmt.c:25:6:25:18 | Chi | Node should have one location but has 2. |
+| dostmt.c:25:6:25:18 | EnterFunction | Node should have one location but has 2. |
+| dostmt.c:25:6:25:18 | InitializeNonLocal | Node should have one location but has 2. |
+| dostmt.c:25:6:25:18 | UnmodeledDefinition | Node should have one location but has 2. |
+| dostmt.c:25:6:25:18 | Unreached | Node should have one location but has 2. |
+| dostmt.c:32:6:32:11 | AliasedDefinition | Node should have one location but has 4. |
+| dostmt.c:32:6:32:11 | AliasedUse | Node should have one location but has 4. |
+| dostmt.c:32:6:32:11 | Chi | Node should have one location but has 4. |
+| dostmt.c:32:6:32:11 | EnterFunction | Node should have one location but has 4. |
+| dostmt.c:32:6:32:11 | ExitFunction | Node should have one location but has 4. |
+| dostmt.c:32:6:32:11 | InitializeNonLocal | Node should have one location but has 4. |
+| dostmt.c:32:6:32:11 | ReturnVoid | Node should have one location but has 4. |
+| dostmt.c:32:6:32:11 | UnmodeledDefinition | Node should have one location but has 4. |
+| dostmt.c:32:6:32:11 | UnmodeledUse | Node should have one location but has 4. |
+| duff.c:2:6:2:6 | AliasedDefinition | Node should have one location but has 20. |
+| duff.c:2:6:2:6 | AliasedUse | Node should have one location but has 20. |
+| duff.c:2:6:2:6 | Chi | Node should have one location but has 20. |
+| duff.c:2:6:2:6 | EnterFunction | Node should have one location but has 20. |
+| duff.c:2:6:2:6 | ExitFunction | Node should have one location but has 20. |
+| duff.c:2:6:2:6 | InitializeNonLocal | Node should have one location but has 20. |
+| duff.c:2:6:2:6 | Phi | Node should have one location but has 20. |
+| duff.c:2:6:2:6 | ReturnVoid | Node should have one location but has 20. |
+| duff.c:2:6:2:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| duff.c:2:6:2:6 | UnmodeledUse | Node should have one location but has 20. |
+| duff.c:2:6:2:6 | Unreached | Node should have one location but has 20. |
+| duff.c:2:12:2:12 | VariableAddress | Node should have one location but has 4. |
+| duff.c:2:12:2:12 | i | Node should have one location but has 4. |
+| duff.c:2:12:2:12 | i | Node should have one location but has 4. |
+| duff.c:2:12:2:12 | x | Node should have one location but has 4. |
+| duff.c:2:12:2:12 | x | Node should have one location but has 4. |
+| dummyblock.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| dummyblock.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| dummyblock.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| dummyblock.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| dummyblock.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| dummyblock.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| dummyblock.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| dummyblock.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| dummyblock.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| dummyblock.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| dummyblock.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| emptyblock.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| emptyblock.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| emptyblock.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| emptyblock.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| emptyblock.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| emptyblock.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| emptyblock.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| emptyblock.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| emptyblock.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| emptyblock.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| emptyblock.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| enum.c:5:5:5:5 | AliasedDefinition | Node should have one location but has 20. |
+| enum.c:5:5:5:5 | AliasedUse | Node should have one location but has 20. |
+| enum.c:5:5:5:5 | Chi | Node should have one location but has 20. |
+| enum.c:5:5:5:5 | EnterFunction | Node should have one location but has 20. |
+| enum.c:5:5:5:5 | ExitFunction | Node should have one location but has 20. |
+| enum.c:5:5:5:5 | InitializeNonLocal | Node should have one location but has 20. |
+| enum.c:5:5:5:5 | Phi | Node should have one location but has 20. |
+| enum.c:5:5:5:5 | ReturnVoid | Node should have one location but has 20. |
+| enum.c:5:5:5:5 | UnmodeledDefinition | Node should have one location but has 20. |
+| enum.c:5:5:5:5 | UnmodeledUse | Node should have one location but has 20. |
+| enum.c:5:5:5:5 | Unreached | Node should have one location but has 20. |
+| exprstmt.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| exprstmt.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| exprstmt.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| exprstmt.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| exprstmt.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| exprstmt.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| exprstmt.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| exprstmt.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| exprstmt.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| exprstmt.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| exprstmt.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| fieldaccess.cpp:3:7:3:7 | x | Node should have one location but has 2. |
+| fieldaccess.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
+| fieldaccess.cpp:6:6:6:6 | AliasedUse | Node should have one location but has 14. |
+| fieldaccess.cpp:6:6:6:6 | Chi | Node should have one location but has 14. |
+| fieldaccess.cpp:6:6:6:6 | EnterFunction | Node should have one location but has 14. |
+| fieldaccess.cpp:6:6:6:6 | ExitFunction | Node should have one location but has 14. |
+| fieldaccess.cpp:6:6:6:6 | InitializeNonLocal | Node should have one location but has 14. |
+| fieldaccess.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
+| fieldaccess.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
+| fieldaccess.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
+| fieldaccess.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
+| file://:0:0:0:0 | InitializeIndirection | Node should have one location but has 0. |
+| file://:0:0:0:0 | Load | Node should have one location but has 0. |
+| file://:0:0:0:0 | ReturnIndirection | Node should have one location but has 0. |
+| file://:0:0:0:0 | VariableAddress | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#0 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#1 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#1 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#1 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#1 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#1 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#1 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#1 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#1 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#2 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#2 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#2 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#2 | Node should have one location but has 0. |
+| file://:0:0:0:0 | p#3 | Node should have one location but has 0. |
+| forstmt.cpp:1:6:1:7 | AliasedDefinition | Node should have one location but has 2. |
+| forstmt.cpp:1:6:1:7 | AliasedUse | Node should have one location but has 2. |
+| forstmt.cpp:1:6:1:7 | Chi | Node should have one location but has 2. |
+| forstmt.cpp:1:6:1:7 | EnterFunction | Node should have one location but has 2. |
+| forstmt.cpp:1:6:1:7 | ExitFunction | Node should have one location but has 2. |
+| forstmt.cpp:1:6:1:7 | InitializeNonLocal | Node should have one location but has 2. |
+| forstmt.cpp:1:6:1:7 | Phi | Node should have one location but has 2. |
+| forstmt.cpp:1:6:1:7 | ReturnVoid | Node should have one location but has 2. |
+| forstmt.cpp:1:6:1:7 | UnmodeledDefinition | Node should have one location but has 2. |
+| forstmt.cpp:1:6:1:7 | UnmodeledUse | Node should have one location but has 2. |
+| forstmt.cpp:8:6:8:7 | AliasedDefinition | Node should have one location but has 2. |
+| forstmt.cpp:8:6:8:7 | AliasedUse | Node should have one location but has 2. |
+| forstmt.cpp:8:6:8:7 | Chi | Node should have one location but has 2. |
+| forstmt.cpp:8:6:8:7 | EnterFunction | Node should have one location but has 2. |
+| forstmt.cpp:8:6:8:7 | ExitFunction | Node should have one location but has 2. |
+| forstmt.cpp:8:6:8:7 | InitializeNonLocal | Node should have one location but has 2. |
+| forstmt.cpp:8:6:8:7 | Phi | Node should have one location but has 2. |
+| forstmt.cpp:8:6:8:7 | ReturnVoid | Node should have one location but has 2. |
+| forstmt.cpp:8:6:8:7 | UnmodeledDefinition | Node should have one location but has 2. |
+| forstmt.cpp:8:6:8:7 | UnmodeledUse | Node should have one location but has 2. |
+| forstmt.cpp:8:6:8:7 | Unreached | Node should have one location but has 2. |
+| ifelsestmt.c:1:6:1:19 | AliasedDefinition | Node should have one location but has 3. |
+| ifelsestmt.c:1:6:1:19 | AliasedUse | Node should have one location but has 3. |
+| ifelsestmt.c:1:6:1:19 | Chi | Node should have one location but has 3. |
+| ifelsestmt.c:1:6:1:19 | EnterFunction | Node should have one location but has 3. |
+| ifelsestmt.c:1:6:1:19 | ExitFunction | Node should have one location but has 3. |
+| ifelsestmt.c:1:6:1:19 | InitializeNonLocal | Node should have one location but has 3. |
+| ifelsestmt.c:1:6:1:19 | ReturnVoid | Node should have one location but has 3. |
+| ifelsestmt.c:1:6:1:19 | UnmodeledDefinition | Node should have one location but has 3. |
+| ifelsestmt.c:1:6:1:19 | UnmodeledUse | Node should have one location but has 3. |
+| ifelsestmt.c:1:6:1:19 | Unreached | Node should have one location but has 3. |
+| ifelsestmt.c:11:6:11:19 | AliasedDefinition | Node should have one location but has 3. |
+| ifelsestmt.c:11:6:11:19 | AliasedUse | Node should have one location but has 3. |
+| ifelsestmt.c:11:6:11:19 | Chi | Node should have one location but has 3. |
+| ifelsestmt.c:11:6:11:19 | EnterFunction | Node should have one location but has 3. |
+| ifelsestmt.c:11:6:11:19 | ExitFunction | Node should have one location but has 3. |
+| ifelsestmt.c:11:6:11:19 | InitializeNonLocal | Node should have one location but has 3. |
+| ifelsestmt.c:11:6:11:19 | ReturnVoid | Node should have one location but has 3. |
+| ifelsestmt.c:11:6:11:19 | UnmodeledDefinition | Node should have one location but has 3. |
+| ifelsestmt.c:11:6:11:19 | UnmodeledUse | Node should have one location but has 3. |
+| ifelsestmt.c:11:6:11:19 | Unreached | Node should have one location but has 3. |
+| ifelsestmt.c:19:6:19:18 | AliasedDefinition | Node should have one location but has 4. |
+| ifelsestmt.c:19:6:19:18 | AliasedUse | Node should have one location but has 4. |
+| ifelsestmt.c:19:6:19:18 | Chi | Node should have one location but has 4. |
+| ifelsestmt.c:19:6:19:18 | EnterFunction | Node should have one location but has 4. |
+| ifelsestmt.c:19:6:19:18 | ExitFunction | Node should have one location but has 4. |
+| ifelsestmt.c:19:6:19:18 | InitializeNonLocal | Node should have one location but has 4. |
+| ifelsestmt.c:19:6:19:18 | ReturnVoid | Node should have one location but has 4. |
+| ifelsestmt.c:19:6:19:18 | UnmodeledDefinition | Node should have one location but has 4. |
+| ifelsestmt.c:19:6:19:18 | UnmodeledUse | Node should have one location but has 4. |
+| ifelsestmt.c:19:6:19:18 | Unreached | Node should have one location but has 4. |
+| ifelsestmt.c:29:6:29:18 | AliasedDefinition | Node should have one location but has 4. |
+| ifelsestmt.c:29:6:29:18 | AliasedUse | Node should have one location but has 4. |
+| ifelsestmt.c:29:6:29:18 | Chi | Node should have one location but has 4. |
+| ifelsestmt.c:29:6:29:18 | EnterFunction | Node should have one location but has 4. |
+| ifelsestmt.c:29:6:29:18 | ExitFunction | Node should have one location but has 4. |
+| ifelsestmt.c:29:6:29:18 | InitializeNonLocal | Node should have one location but has 4. |
+| ifelsestmt.c:29:6:29:18 | ReturnVoid | Node should have one location but has 4. |
+| ifelsestmt.c:29:6:29:18 | UnmodeledDefinition | Node should have one location but has 4. |
+| ifelsestmt.c:29:6:29:18 | UnmodeledUse | Node should have one location but has 4. |
+| ifelsestmt.c:29:6:29:18 | Unreached | Node should have one location but has 4. |
+| ifelsestmt.c:37:6:37:11 | AliasedDefinition | Node should have one location but has 4. |
+| ifelsestmt.c:37:6:37:11 | AliasedUse | Node should have one location but has 4. |
+| ifelsestmt.c:37:6:37:11 | Chi | Node should have one location but has 4. |
+| ifelsestmt.c:37:6:37:11 | EnterFunction | Node should have one location but has 4. |
+| ifelsestmt.c:37:6:37:11 | ExitFunction | Node should have one location but has 4. |
+| ifelsestmt.c:37:6:37:11 | InitializeNonLocal | Node should have one location but has 4. |
+| ifelsestmt.c:37:6:37:11 | ReturnVoid | Node should have one location but has 4. |
+| ifelsestmt.c:37:6:37:11 | UnmodeledDefinition | Node should have one location but has 4. |
+| ifelsestmt.c:37:6:37:11 | UnmodeledUse | Node should have one location but has 4. |
+| ifelsestmt.c:37:17:37:17 | VariableAddress | Node should have one location but has 2. |
+| ifelsestmt.c:37:17:37:17 | x | Node should have one location but has 2. |
+| ifelsestmt.c:37:17:37:17 | x | Node should have one location but has 2. |
+| ifelsestmt.c:37:24:37:24 | VariableAddress | Node should have one location but has 2. |
+| ifelsestmt.c:37:24:37:24 | y | Node should have one location but has 2. |
+| ifelsestmt.c:37:24:37:24 | y | Node should have one location but has 2. |
+| ifstmt.c:1:6:1:19 | AliasedDefinition | Node should have one location but has 3. |
+| ifstmt.c:1:6:1:19 | AliasedUse | Node should have one location but has 3. |
+| ifstmt.c:1:6:1:19 | Chi | Node should have one location but has 3. |
+| ifstmt.c:1:6:1:19 | EnterFunction | Node should have one location but has 3. |
+| ifstmt.c:1:6:1:19 | ExitFunction | Node should have one location but has 3. |
+| ifstmt.c:1:6:1:19 | InitializeNonLocal | Node should have one location but has 3. |
+| ifstmt.c:1:6:1:19 | ReturnVoid | Node should have one location but has 3. |
+| ifstmt.c:1:6:1:19 | UnmodeledDefinition | Node should have one location but has 3. |
+| ifstmt.c:1:6:1:19 | UnmodeledUse | Node should have one location but has 3. |
+| ifstmt.c:1:6:1:19 | Unreached | Node should have one location but has 3. |
+| ifstmt.c:8:6:8:19 | AliasedDefinition | Node should have one location but has 3. |
+| ifstmt.c:8:6:8:19 | AliasedUse | Node should have one location but has 3. |
+| ifstmt.c:8:6:8:19 | Chi | Node should have one location but has 3. |
+| ifstmt.c:8:6:8:19 | EnterFunction | Node should have one location but has 3. |
+| ifstmt.c:8:6:8:19 | ExitFunction | Node should have one location but has 3. |
+| ifstmt.c:8:6:8:19 | InitializeNonLocal | Node should have one location but has 3. |
+| ifstmt.c:8:6:8:19 | ReturnVoid | Node should have one location but has 3. |
+| ifstmt.c:8:6:8:19 | UnmodeledDefinition | Node should have one location but has 3. |
+| ifstmt.c:8:6:8:19 | UnmodeledUse | Node should have one location but has 3. |
+| ifstmt.c:8:6:8:19 | Unreached | Node should have one location but has 3. |
+| ifstmt.c:14:6:14:18 | AliasedDefinition | Node should have one location but has 4. |
+| ifstmt.c:14:6:14:18 | AliasedUse | Node should have one location but has 4. |
+| ifstmt.c:14:6:14:18 | Chi | Node should have one location but has 4. |
+| ifstmt.c:14:6:14:18 | EnterFunction | Node should have one location but has 4. |
+| ifstmt.c:14:6:14:18 | ExitFunction | Node should have one location but has 4. |
+| ifstmt.c:14:6:14:18 | InitializeNonLocal | Node should have one location but has 4. |
+| ifstmt.c:14:6:14:18 | ReturnVoid | Node should have one location but has 4. |
+| ifstmt.c:14:6:14:18 | UnmodeledDefinition | Node should have one location but has 4. |
+| ifstmt.c:14:6:14:18 | UnmodeledUse | Node should have one location but has 4. |
+| ifstmt.c:14:6:14:18 | Unreached | Node should have one location but has 4. |
+| ifstmt.c:21:6:21:18 | AliasedDefinition | Node should have one location but has 4. |
+| ifstmt.c:21:6:21:18 | AliasedUse | Node should have one location but has 4. |
+| ifstmt.c:21:6:21:18 | Chi | Node should have one location but has 4. |
+| ifstmt.c:21:6:21:18 | EnterFunction | Node should have one location but has 4. |
+| ifstmt.c:21:6:21:18 | ExitFunction | Node should have one location but has 4. |
+| ifstmt.c:21:6:21:18 | InitializeNonLocal | Node should have one location but has 4. |
+| ifstmt.c:21:6:21:18 | ReturnVoid | Node should have one location but has 4. |
+| ifstmt.c:21:6:21:18 | UnmodeledDefinition | Node should have one location but has 4. |
+| ifstmt.c:21:6:21:18 | UnmodeledUse | Node should have one location but has 4. |
+| ifstmt.c:21:6:21:18 | Unreached | Node should have one location but has 4. |
+| ifstmt.c:27:6:27:11 | AliasedDefinition | Node should have one location but has 4. |
+| ifstmt.c:27:6:27:11 | AliasedUse | Node should have one location but has 4. |
+| ifstmt.c:27:6:27:11 | Chi | Node should have one location but has 4. |
+| ifstmt.c:27:6:27:11 | EnterFunction | Node should have one location but has 4. |
+| ifstmt.c:27:6:27:11 | ExitFunction | Node should have one location but has 4. |
+| ifstmt.c:27:6:27:11 | InitializeNonLocal | Node should have one location but has 4. |
+| ifstmt.c:27:6:27:11 | ReturnVoid | Node should have one location but has 4. |
+| ifstmt.c:27:6:27:11 | UnmodeledDefinition | Node should have one location but has 4. |
+| ifstmt.c:27:6:27:11 | UnmodeledUse | Node should have one location but has 4. |
+| ifstmt.c:27:17:27:17 | VariableAddress | Node should have one location but has 2. |
+| ifstmt.c:27:17:27:17 | x | Node should have one location but has 2. |
+| ifstmt.c:27:17:27:17 | x | Node should have one location but has 2. |
+| ifstmt.c:27:24:27:24 | VariableAddress | Node should have one location but has 2. |
+| ifstmt.c:27:24:27:24 | y | Node should have one location but has 2. |
+| ifstmt.c:27:24:27:24 | y | Node should have one location but has 2. |
+| initializer.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| initializer.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| initializer.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| initializer.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| initializer.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| initializer.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| initializer.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| initializer.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| initializer.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| initializer.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| initializer.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| landexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| landexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| landexpr.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| landexpr.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| landexpr.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| landexpr.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| landexpr.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| landexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| landexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| landexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| landexpr.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| lorexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| lorexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| lorexpr.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| lorexpr.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| lorexpr.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| lorexpr.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| lorexpr.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| lorexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| lorexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| lorexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| lorexpr.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| ltrbinopexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| ltrbinopexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| ltrbinopexpr.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| ltrbinopexpr.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| ltrbinopexpr.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| ltrbinopexpr.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| ltrbinopexpr.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| ltrbinopexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| ltrbinopexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| ltrbinopexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| ltrbinopexpr.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| membercallexpr.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
+| membercallexpr.cpp:6:6:6:6 | AliasedUse | Node should have one location but has 14. |
+| membercallexpr.cpp:6:6:6:6 | Chi | Node should have one location but has 14. |
+| membercallexpr.cpp:6:6:6:6 | EnterFunction | Node should have one location but has 14. |
+| membercallexpr.cpp:6:6:6:6 | ExitFunction | Node should have one location but has 14. |
+| membercallexpr.cpp:6:6:6:6 | InitializeNonLocal | Node should have one location but has 14. |
+| membercallexpr.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
+| membercallexpr.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
+| membercallexpr.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
+| membercallexpr.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
+| membercallexpr_args.cpp:3:6:3:6 | d | Node should have one location but has 2. |
+| membercallexpr_args.cpp:4:14:4:14 | x | Node should have one location but has 2. |
+| membercallexpr_args.cpp:4:21:4:21 | y | Node should have one location but has 2. |
+| membercallexpr_args.cpp:7:6:7:6 | AliasedDefinition | Node should have one location but has 14. |
+| membercallexpr_args.cpp:7:6:7:6 | AliasedUse | Node should have one location but has 14. |
+| membercallexpr_args.cpp:7:6:7:6 | Chi | Node should have one location but has 14. |
+| membercallexpr_args.cpp:7:6:7:6 | EnterFunction | Node should have one location but has 14. |
+| membercallexpr_args.cpp:7:6:7:6 | ExitFunction | Node should have one location but has 14. |
+| membercallexpr_args.cpp:7:6:7:6 | InitializeNonLocal | Node should have one location but has 14. |
+| membercallexpr_args.cpp:7:6:7:6 | Phi | Node should have one location but has 14. |
+| membercallexpr_args.cpp:7:6:7:6 | ReturnVoid | Node should have one location but has 14. |
+| membercallexpr_args.cpp:7:6:7:6 | UnmodeledDefinition | Node should have one location but has 14. |
+| membercallexpr_args.cpp:7:6:7:6 | UnmodeledUse | Node should have one location but has 14. |
+| newexpr.cpp:3:9:3:9 | i | Node should have one location but has 2. |
+| newexpr.cpp:3:9:3:9 | x | Node should have one location but has 2. |
+| newexpr.cpp:3:16:3:16 | j | Node should have one location but has 2. |
+| newexpr.cpp:3:16:3:16 | y | Node should have one location but has 2. |
+| newexpr.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
+| newexpr.cpp:6:6:6:6 | AliasedUse | Node should have one location but has 14. |
+| newexpr.cpp:6:6:6:6 | Chi | Node should have one location but has 14. |
+| newexpr.cpp:6:6:6:6 | EnterFunction | Node should have one location but has 14. |
+| newexpr.cpp:6:6:6:6 | ExitFunction | Node should have one location but has 14. |
+| newexpr.cpp:6:6:6:6 | InitializeNonLocal | Node should have one location but has 14. |
+| newexpr.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
+| newexpr.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
+| newexpr.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
+| newexpr.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
+| no_dynamic_init.cpp:9:5:9:8 | AliasedDefinition | Node should have one location but has 4. |
+| no_dynamic_init.cpp:9:5:9:8 | AliasedUse | Node should have one location but has 4. |
+| no_dynamic_init.cpp:9:5:9:8 | Chi | Node should have one location but has 4. |
+| no_dynamic_init.cpp:9:5:9:8 | EnterFunction | Node should have one location but has 4. |
+| no_dynamic_init.cpp:9:5:9:8 | ExitFunction | Node should have one location but has 4. |
+| no_dynamic_init.cpp:9:5:9:8 | InitializeNonLocal | Node should have one location but has 4. |
+| no_dynamic_init.cpp:9:5:9:8 | Phi | Node should have one location but has 4. |
+| no_dynamic_init.cpp:9:5:9:8 | Phi | Node should have one location but has 4. |
+| no_dynamic_init.cpp:9:5:9:8 | ReturnValue | Node should have one location but has 4. |
+| no_dynamic_init.cpp:9:5:9:8 | UnmodeledDefinition | Node should have one location but has 4. |
+| no_dynamic_init.cpp:9:5:9:8 | UnmodeledUse | Node should have one location but has 4. |
+| no_dynamic_init.cpp:9:5:9:8 | VariableAddress | Node should have one location but has 4. |
+| nodefaultswitchstmt.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| nodefaultswitchstmt.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| nodefaultswitchstmt.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| nodefaultswitchstmt.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| nodefaultswitchstmt.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| nodefaultswitchstmt.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| nodefaultswitchstmt.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| nodefaultswitchstmt.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| nodefaultswitchstmt.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| nodefaultswitchstmt.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| nodefaultswitchstmt.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| nodefaultswitchstmt.c:1:12:1:12 | VariableAddress | Node should have one location but has 4. |
+| nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
+| nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
+| nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
+| nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
+| nonmembercallexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 2. |
+| nonmembercallexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 2. |
+| nonmembercallexpr.c:1:6:1:6 | Chi | Node should have one location but has 2. |
+| nonmembercallexpr.c:1:6:1:6 | EnterFunction | Node should have one location but has 2. |
+| nonmembercallexpr.c:1:6:1:6 | ExitFunction | Node should have one location but has 2. |
+| nonmembercallexpr.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 2. |
+| nonmembercallexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 2. |
+| nonmembercallexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 2. |
+| nonmembercallexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 2. |
+| nonmembercallexpr.c:3:6:3:6 | AliasedDefinition | Node should have one location but has 20. |
+| nonmembercallexpr.c:3:6:3:6 | AliasedUse | Node should have one location but has 20. |
+| nonmembercallexpr.c:3:6:3:6 | Chi | Node should have one location but has 20. |
+| nonmembercallexpr.c:3:6:3:6 | EnterFunction | Node should have one location but has 20. |
+| nonmembercallexpr.c:3:6:3:6 | ExitFunction | Node should have one location but has 20. |
+| nonmembercallexpr.c:3:6:3:6 | InitializeNonLocal | Node should have one location but has 20. |
+| nonmembercallexpr.c:3:6:3:6 | Phi | Node should have one location but has 20. |
+| nonmembercallexpr.c:3:6:3:6 | ReturnVoid | Node should have one location but has 20. |
+| nonmembercallexpr.c:3:6:3:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| nonmembercallexpr.c:3:6:3:6 | UnmodeledUse | Node should have one location but has 20. |
+| nonmembercallexpr.c:3:6:3:6 | Unreached | Node should have one location but has 20. |
+| nonmemberfp2callexpr.c:3:6:3:6 | AliasedDefinition | Node should have one location but has 20. |
+| nonmemberfp2callexpr.c:3:6:3:6 | AliasedUse | Node should have one location but has 20. |
+| nonmemberfp2callexpr.c:3:6:3:6 | Chi | Node should have one location but has 20. |
+| nonmemberfp2callexpr.c:3:6:3:6 | EnterFunction | Node should have one location but has 20. |
+| nonmemberfp2callexpr.c:3:6:3:6 | ExitFunction | Node should have one location but has 20. |
+| nonmemberfp2callexpr.c:3:6:3:6 | InitializeNonLocal | Node should have one location but has 20. |
+| nonmemberfp2callexpr.c:3:6:3:6 | Phi | Node should have one location but has 20. |
+| nonmemberfp2callexpr.c:3:6:3:6 | ReturnVoid | Node should have one location but has 20. |
+| nonmemberfp2callexpr.c:3:6:3:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| nonmemberfp2callexpr.c:3:6:3:6 | UnmodeledUse | Node should have one location but has 20. |
+| nonmemberfp2callexpr.c:3:6:3:6 | Unreached | Node should have one location but has 20. |
+| nonmemberfpcallexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| nonmemberfpcallexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| nonmemberfpcallexpr.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| nonmemberfpcallexpr.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| nonmemberfpcallexpr.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| nonmemberfpcallexpr.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| nonmemberfpcallexpr.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| nonmemberfpcallexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| nonmemberfpcallexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| nonmemberfpcallexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| nonmemberfpcallexpr.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| parameterinitializer.cpp:18:5:18:8 | AliasedDefinition | Node should have one location but has 4. |
+| parameterinitializer.cpp:18:5:18:8 | AliasedUse | Node should have one location but has 4. |
+| parameterinitializer.cpp:18:5:18:8 | Chi | Node should have one location but has 4. |
+| parameterinitializer.cpp:18:5:18:8 | EnterFunction | Node should have one location but has 4. |
+| parameterinitializer.cpp:18:5:18:8 | ExitFunction | Node should have one location but has 4. |
+| parameterinitializer.cpp:18:5:18:8 | InitializeNonLocal | Node should have one location but has 4. |
+| parameterinitializer.cpp:18:5:18:8 | Phi | Node should have one location but has 4. |
+| parameterinitializer.cpp:18:5:18:8 | Phi | Node should have one location but has 4. |
+| parameterinitializer.cpp:18:5:18:8 | ReturnValue | Node should have one location but has 4. |
+| parameterinitializer.cpp:18:5:18:8 | UnmodeledDefinition | Node should have one location but has 4. |
+| parameterinitializer.cpp:18:5:18:8 | UnmodeledUse | Node should have one location but has 4. |
+| parameterinitializer.cpp:18:5:18:8 | VariableAddress | Node should have one location but has 4. |
+| pmcallexpr.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
+| pmcallexpr.cpp:6:6:6:6 | AliasedUse | Node should have one location but has 14. |
+| pmcallexpr.cpp:6:6:6:6 | Chi | Node should have one location but has 14. |
+| pmcallexpr.cpp:6:6:6:6 | EnterFunction | Node should have one location but has 14. |
+| pmcallexpr.cpp:6:6:6:6 | ExitFunction | Node should have one location but has 14. |
+| pmcallexpr.cpp:6:6:6:6 | InitializeNonLocal | Node should have one location but has 14. |
+| pmcallexpr.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
+| pmcallexpr.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
+| pmcallexpr.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
+| pmcallexpr.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
+| questionexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| questionexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| questionexpr.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| questionexpr.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| questionexpr.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| questionexpr.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| questionexpr.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| questionexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| questionexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| questionexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| questionexpr.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| revsubscriptexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 2. |
+| revsubscriptexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 2. |
+| revsubscriptexpr.c:1:6:1:6 | Chi | Node should have one location but has 2. |
+| revsubscriptexpr.c:1:6:1:6 | EnterFunction | Node should have one location but has 2. |
+| revsubscriptexpr.c:1:6:1:6 | ExitFunction | Node should have one location but has 2. |
+| revsubscriptexpr.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 2. |
+| revsubscriptexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 2. |
+| revsubscriptexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 2. |
+| revsubscriptexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 2. |
+| staticmembercallexpr.cpp:6:6:6:6 | AliasedDefinition | Node should have one location but has 14. |
+| staticmembercallexpr.cpp:6:6:6:6 | AliasedUse | Node should have one location but has 14. |
+| staticmembercallexpr.cpp:6:6:6:6 | Chi | Node should have one location but has 14. |
+| staticmembercallexpr.cpp:6:6:6:6 | EnterFunction | Node should have one location but has 14. |
+| staticmembercallexpr.cpp:6:6:6:6 | ExitFunction | Node should have one location but has 14. |
+| staticmembercallexpr.cpp:6:6:6:6 | InitializeNonLocal | Node should have one location but has 14. |
+| staticmembercallexpr.cpp:6:6:6:6 | Phi | Node should have one location but has 14. |
+| staticmembercallexpr.cpp:6:6:6:6 | ReturnVoid | Node should have one location but has 14. |
+| staticmembercallexpr.cpp:6:6:6:6 | UnmodeledDefinition | Node should have one location but has 14. |
+| staticmembercallexpr.cpp:6:6:6:6 | UnmodeledUse | Node should have one location but has 14. |
+| staticmembercallexpr_args.cpp:3:6:3:6 | d | Node should have one location but has 2. |
+| staticmembercallexpr_args.cpp:4:21:4:21 | x | Node should have one location but has 2. |
+| staticmembercallexpr_args.cpp:4:28:4:28 | y | Node should have one location but has 2. |
+| staticmembercallexpr_args.cpp:7:6:7:6 | AliasedDefinition | Node should have one location but has 14. |
+| staticmembercallexpr_args.cpp:7:6:7:6 | AliasedUse | Node should have one location but has 14. |
+| staticmembercallexpr_args.cpp:7:6:7:6 | Chi | Node should have one location but has 14. |
+| staticmembercallexpr_args.cpp:7:6:7:6 | EnterFunction | Node should have one location but has 14. |
+| staticmembercallexpr_args.cpp:7:6:7:6 | ExitFunction | Node should have one location but has 14. |
+| staticmembercallexpr_args.cpp:7:6:7:6 | InitializeNonLocal | Node should have one location but has 14. |
+| staticmembercallexpr_args.cpp:7:6:7:6 | Phi | Node should have one location but has 14. |
+| staticmembercallexpr_args.cpp:7:6:7:6 | ReturnVoid | Node should have one location but has 14. |
+| staticmembercallexpr_args.cpp:7:6:7:6 | UnmodeledDefinition | Node should have one location but has 14. |
+| staticmembercallexpr_args.cpp:7:6:7:6 | UnmodeledUse | Node should have one location but has 14. |
+| stream_it.cpp:16:5:16:8 | AliasedDefinition | Node should have one location but has 4. |
+| stream_it.cpp:16:5:16:8 | AliasedUse | Node should have one location but has 4. |
+| stream_it.cpp:16:5:16:8 | Chi | Node should have one location but has 4. |
+| stream_it.cpp:16:5:16:8 | EnterFunction | Node should have one location but has 4. |
+| stream_it.cpp:16:5:16:8 | ExitFunction | Node should have one location but has 4. |
+| stream_it.cpp:16:5:16:8 | InitializeNonLocal | Node should have one location but has 4. |
+| stream_it.cpp:16:5:16:8 | Phi | Node should have one location but has 4. |
+| stream_it.cpp:16:5:16:8 | Phi | Node should have one location but has 4. |
+| stream_it.cpp:16:5:16:8 | ReturnValue | Node should have one location but has 4. |
+| stream_it.cpp:16:5:16:8 | UnmodeledDefinition | Node should have one location but has 4. |
+| stream_it.cpp:16:5:16:8 | UnmodeledUse | Node should have one location but has 4. |
+| stream_it.cpp:16:5:16:8 | VariableAddress | Node should have one location but has 4. |
+| subscriptexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| subscriptexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| subscriptexpr.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| subscriptexpr.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| subscriptexpr.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| subscriptexpr.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| subscriptexpr.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| subscriptexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| subscriptexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| subscriptexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| subscriptexpr.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| switchstmt.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| switchstmt.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| switchstmt.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| switchstmt.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| switchstmt.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| switchstmt.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| switchstmt.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| switchstmt.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| switchstmt.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| switchstmt.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| switchstmt.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| switchstmt.c:1:12:1:12 | VariableAddress | Node should have one location but has 4. |
+| switchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
+| switchstmt.c:1:12:1:12 | i | Node should have one location but has 4. |
+| switchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
+| switchstmt.c:1:12:1:12 | x | Node should have one location but has 4. |
+| tinyforstmt.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| tinyforstmt.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| tinyforstmt.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| tinyforstmt.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| tinyforstmt.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| tinyforstmt.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| tinyforstmt.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| tinyforstmt.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| tinyforstmt.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| tinyforstmt.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| tinyforstmt.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| unaryopexpr.c:1:6:1:6 | AliasedDefinition | Node should have one location but has 20. |
+| unaryopexpr.c:1:6:1:6 | AliasedUse | Node should have one location but has 20. |
+| unaryopexpr.c:1:6:1:6 | Chi | Node should have one location but has 20. |
+| unaryopexpr.c:1:6:1:6 | EnterFunction | Node should have one location but has 20. |
+| unaryopexpr.c:1:6:1:6 | ExitFunction | Node should have one location but has 20. |
+| unaryopexpr.c:1:6:1:6 | InitializeNonLocal | Node should have one location but has 20. |
+| unaryopexpr.c:1:6:1:6 | Phi | Node should have one location but has 20. |
+| unaryopexpr.c:1:6:1:6 | ReturnVoid | Node should have one location but has 20. |
+| unaryopexpr.c:1:6:1:6 | UnmodeledDefinition | Node should have one location but has 20. |
+| unaryopexpr.c:1:6:1:6 | UnmodeledUse | Node should have one location but has 20. |
+| unaryopexpr.c:1:6:1:6 | Unreached | Node should have one location but has 20. |
+| whilestmt.c:1:6:1:19 | AliasedDefinition | Node should have one location but has 3. |
+| whilestmt.c:1:6:1:19 | AliasedUse | Node should have one location but has 3. |
+| whilestmt.c:1:6:1:19 | Chi | Node should have one location but has 3. |
+| whilestmt.c:1:6:1:19 | EnterFunction | Node should have one location but has 3. |
+| whilestmt.c:1:6:1:19 | ExitFunction | Node should have one location but has 3. |
+| whilestmt.c:1:6:1:19 | InitializeNonLocal | Node should have one location but has 3. |
+| whilestmt.c:1:6:1:19 | ReturnVoid | Node should have one location but has 3. |
+| whilestmt.c:1:6:1:19 | UnmodeledDefinition | Node should have one location but has 3. |
+| whilestmt.c:1:6:1:19 | UnmodeledUse | Node should have one location but has 3. |
+| whilestmt.c:1:6:1:19 | Unreached | Node should have one location but has 3. |
+| whilestmt.c:8:6:8:19 | AliasedDefinition | Node should have one location but has 3. |
+| whilestmt.c:8:6:8:19 | AliasedUse | Node should have one location but has 3. |
+| whilestmt.c:8:6:8:19 | Chi | Node should have one location but has 3. |
+| whilestmt.c:8:6:8:19 | EnterFunction | Node should have one location but has 3. |
+| whilestmt.c:8:6:8:19 | ExitFunction | Node should have one location but has 3. |
+| whilestmt.c:8:6:8:19 | InitializeNonLocal | Node should have one location but has 3. |
+| whilestmt.c:8:6:8:19 | ReturnVoid | Node should have one location but has 3. |
+| whilestmt.c:8:6:8:19 | UnmodeledDefinition | Node should have one location but has 3. |
+| whilestmt.c:8:6:8:19 | UnmodeledUse | Node should have one location but has 3. |
+| whilestmt.c:8:6:8:19 | Unreached | Node should have one location but has 3. |
+| whilestmt.c:15:6:15:18 | AliasedDefinition | Node should have one location but has 4. |
+| whilestmt.c:15:6:15:18 | AliasedUse | Node should have one location but has 4. |
+| whilestmt.c:15:6:15:18 | Chi | Node should have one location but has 4. |
+| whilestmt.c:15:6:15:18 | EnterFunction | Node should have one location but has 4. |
+| whilestmt.c:15:6:15:18 | ExitFunction | Node should have one location but has 4. |
+| whilestmt.c:15:6:15:18 | InitializeNonLocal | Node should have one location but has 4. |
+| whilestmt.c:15:6:15:18 | ReturnVoid | Node should have one location but has 4. |
+| whilestmt.c:15:6:15:18 | UnmodeledDefinition | Node should have one location but has 4. |
+| whilestmt.c:15:6:15:18 | UnmodeledUse | Node should have one location but has 4. |
+| whilestmt.c:15:6:15:18 | Unreached | Node should have one location but has 4. |
+| whilestmt.c:23:6:23:18 | AliasedDefinition | Node should have one location but has 4. |
+| whilestmt.c:23:6:23:18 | AliasedUse | Node should have one location but has 4. |
+| whilestmt.c:23:6:23:18 | Chi | Node should have one location but has 4. |
+| whilestmt.c:23:6:23:18 | EnterFunction | Node should have one location but has 4. |
+| whilestmt.c:23:6:23:18 | ExitFunction | Node should have one location but has 4. |
+| whilestmt.c:23:6:23:18 | InitializeNonLocal | Node should have one location but has 4. |
+| whilestmt.c:23:6:23:18 | ReturnVoid | Node should have one location but has 4. |
+| whilestmt.c:23:6:23:18 | UnmodeledDefinition | Node should have one location but has 4. |
+| whilestmt.c:23:6:23:18 | UnmodeledUse | Node should have one location but has 4. |
+| whilestmt.c:23:6:23:18 | Unreached | Node should have one location but has 4. |
+| whilestmt.c:32:6:32:18 | AliasedDefinition | Node should have one location but has 2. |
+| whilestmt.c:32:6:32:18 | Chi | Node should have one location but has 2. |
+| whilestmt.c:32:6:32:18 | EnterFunction | Node should have one location but has 2. |
+| whilestmt.c:32:6:32:18 | InitializeNonLocal | Node should have one location but has 2. |
+| whilestmt.c:32:6:32:18 | UnmodeledDefinition | Node should have one location but has 2. |
+| whilestmt.c:32:6:32:18 | Unreached | Node should have one location but has 2. |
+| whilestmt.c:39:6:39:11 | AliasedDefinition | Node should have one location but has 4. |
+| whilestmt.c:39:6:39:11 | AliasedUse | Node should have one location but has 4. |
+| whilestmt.c:39:6:39:11 | Chi | Node should have one location but has 4. |
+| whilestmt.c:39:6:39:11 | EnterFunction | Node should have one location but has 4. |
+| whilestmt.c:39:6:39:11 | ExitFunction | Node should have one location but has 4. |
+| whilestmt.c:39:6:39:11 | InitializeNonLocal | Node should have one location but has 4. |
+| whilestmt.c:39:6:39:11 | ReturnVoid | Node should have one location but has 4. |
+| whilestmt.c:39:6:39:11 | UnmodeledDefinition | Node should have one location but has 4. |
+| whilestmt.c:39:6:39:11 | UnmodeledUse | Node should have one location but has 4. |
+missingLocation
+| Nodes without location: 30 |
+uniqueNodeToString
+| break_labels.c:2:11:2:11 | i | Node should have one toString but has 2. |
+| break_labels.c:2:11:2:11 | i | Node should have one toString but has 2. |
+| break_labels.c:2:11:2:11 | x | Node should have one toString but has 2. |
+| break_labels.c:2:11:2:11 | x | Node should have one toString but has 2. |
+| break_labels.c:4:9:4:9 | i | Node should have one toString but has 2. |
+| break_labels.c:4:9:4:9 | x | Node should have one toString but has 2. |
+| break_labels.c:6:16:6:16 | i | Node should have one toString but has 2. |
+| break_labels.c:6:16:6:16 | x | Node should have one toString but has 2. |
+| break_labels.c:7:17:7:17 | i | Node should have one toString but has 2. |
+| break_labels.c:7:17:7:17 | x | Node should have one toString but has 2. |
+| constructorinitializer.cpp:3:9:3:9 | i | Node should have one toString but has 2. |
+| constructorinitializer.cpp:3:9:3:9 | x | Node should have one toString but has 2. |
+| constructorinitializer.cpp:3:16:3:16 | j | Node should have one toString but has 2. |
+| constructorinitializer.cpp:3:16:3:16 | y | Node should have one toString but has 2. |
+| duff.c:2:12:2:12 | i | Node should have one toString but has 2. |
+| duff.c:2:12:2:12 | i | Node should have one toString but has 2. |
+| duff.c:2:12:2:12 | x | Node should have one toString but has 2. |
+| duff.c:2:12:2:12 | x | Node should have one toString but has 2. |
+| duff.c:3:14:3:14 | i | Node should have one toString but has 2. |
+| duff.c:3:14:3:14 | x | Node should have one toString but has 2. |
+| duff.c:4:13:4:13 | i | Node should have one toString but has 2. |
+| duff.c:4:13:4:13 | x | Node should have one toString but has 2. |
+| newexpr.cpp:3:9:3:9 | i | Node should have one toString but has 2. |
+| newexpr.cpp:3:9:3:9 | x | Node should have one toString but has 2. |
+| newexpr.cpp:3:16:3:16 | j | Node should have one toString but has 2. |
+| newexpr.cpp:3:16:3:16 | y | Node should have one toString but has 2. |
+| nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
+| nodefaultswitchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
+| nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
+| nodefaultswitchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
+| nodefaultswitchstmt.c:2:14:2:14 | i | Node should have one toString but has 2. |
+| nodefaultswitchstmt.c:2:14:2:14 | x | Node should have one toString but has 2. |
+| switchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
+| switchstmt.c:1:12:1:12 | i | Node should have one toString but has 2. |
+| switchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
+| switchstmt.c:1:12:1:12 | x | Node should have one toString but has 2. |
+| switchstmt.c:2:14:2:14 | i | Node should have one toString but has 2. |
+| switchstmt.c:2:14:2:14 | x | Node should have one toString but has 2. |
+missingToString
+parameterCallable
+localFlowIsLocal
+compatibleTypesReflexive
+unreachableNodeCCtx
+localCallNodes
+postIsNotPre
+postHasUniquePre
+uniquePostUpdate
+postIsInSameCallable
+reverseRead
+storeIsPostUpdate
+argHasPostUpdate
+| CPP-309.cpp:7:5:7:20 | Constant | ArgumentNode is missing PostUpdateNode. |
+| CPP-309.cpp:7:9:7:9 | 2 | ArgumentNode is missing PostUpdateNode. |
+| CPP-309.cpp:7:12:7:12 | 3 | ArgumentNode is missing PostUpdateNode. |
+| CPP-309.cpp:11:13:11:13 | 1 | ArgumentNode is missing PostUpdateNode. |
+| VacuousDestructorCall.cpp:10:18:10:18 | i | ArgumentNode is missing PostUpdateNode. |
+| VacuousDestructorCall.cpp:10:21:10:22 | & ... | ArgumentNode is missing PostUpdateNode. |
+| abortingfunctions.cpp:45:13:45:13 | 0 | ArgumentNode is missing PostUpdateNode. |
+| abortingfunctions.cpp:45:16:45:16 | 0 | ArgumentNode is missing PostUpdateNode. |
+| allocators.cpp:16:14:16:36 | Constant | ArgumentNode is missing PostUpdateNode. |
+| allocators.cpp:16:14:16:36 | new | ArgumentNode is missing PostUpdateNode. |
+| allocators.cpp:16:18:16:19 | 11 | ArgumentNode is missing PostUpdateNode. |
+| allocators.cpp:16:22:16:23 | 22 | ArgumentNode is missing PostUpdateNode. |
+| allocators.cpp:16:30:16:31 | 33 | ArgumentNode is missing PostUpdateNode. |
+| allocators.cpp:16:34:16:35 | 44 | ArgumentNode is missing PostUpdateNode. |
+| bad_asts.cpp:16:5:16:5 | s | ArgumentNode is missing PostUpdateNode. |
+| bad_asts.cpp:16:25:16:25 | 1 | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:8:32:8:32 | 0 | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:8:35:8:37 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:8:40:8:40 | y | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:10:20:10:26 | (bool)... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:20:33:20:35 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:21:33:21:35 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:21:38:21:38 | y | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:22:34:22:36 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:22:39:22:39 | y | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:28:31:28:38 | ... == ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:34:22:34:31 | (volatile void *)... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:34:34:34:34 | x | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:39:25:39:27 | (unsigned int)... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:39:30:39:30 | (unsigned int)... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:39:33:39:33 | (unsigned int)... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:39:36:39:45 | & ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:43:26:43:28 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:43:31:43:37 | (long)... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:43:40:43:49 | & ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:45:33:45:41 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:47:24:47:30 | (const void *)... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:47:33:47:35 | 101 | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:47:38:47:38 | (unsigned long)... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:51:29:51:38 | & ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:51:41:51:43 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:51:46:51:46 | 0 | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:54:28:54:38 | & ... | ArgumentNode is missing PostUpdateNode. |
+| builtin.c:54:41:54:41 | 0 | ArgumentNode is missing PostUpdateNode. |
+| builtin.cpp:10:24:10:24 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| builtin.cpp:14:40:14:44 | (unsigned long)... | ArgumentNode is missing PostUpdateNode. |
+| builtin.cpp:15:31:15:35 | * ... | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:3:13:3:22 | Constant | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:16:6:16:20 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:16:20:16:20 | x | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:26:10:26:24 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:26:24:26:24 | x | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:41:9:41:23 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:41:23:41:23 | x | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:48:16:48:19 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:48:23:48:24 | - ... | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:48:27:48:31 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:48:35:48:36 | - ... | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:48:39:48:53 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| condition_decls.cpp:48:53:48:53 | x | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:30:9:30:13 | (const C1)... | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:30:12:30:12 | 1 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:30:18:30:22 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:30:21:30:21 | 2 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:33:9:33:13 | (const C1)... | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:33:12:33:12 | 3 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:33:18:33:22 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:33:21:33:21 | 3 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:39:9:39:13 | (const C2)... | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:39:12:39:12 | 1 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:39:18:39:22 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:39:21:39:21 | 2 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:42:9:42:13 | (const C2)... | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:42:12:42:12 | 3 | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:42:18:42:22 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| conditional_destructors.cpp:42:21:42:21 | 3 | ArgumentNode is missing PostUpdateNode. |
+| constructorinitializer.cpp:8:4:8:4 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| constructorinitializer.cpp:8:6:8:10 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| constructorinitializer.cpp:8:13:8:17 | ... - ... | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:77:5:77:17 | (const lambda [] type at line 82, col. 17)... | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:77:19:77:21 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:77:19:77:21 | call to Val | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:11:82:14 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:11:82:14 | call to Val | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:17:82:55 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:17:82:55 | [...](...){...} | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:45:82:48 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:45:82:48 | call to Val | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:51:82:51 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:82:51:82:51 | call to Val | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:88:12:88:22 | doSomething | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:88:25:88:30 | call to Val | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:88:29:88:29 | 1 | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:88:33:88:38 | call to Val | ArgumentNode is missing PostUpdateNode. |
+| cpp11.cpp:88:37:88:37 | 2 | ArgumentNode is missing PostUpdateNode. |
+| cpp17.cpp:15:5:15:45 | Constant | ArgumentNode is missing PostUpdateNode. |
+| cpp17.cpp:15:5:15:45 | new | ArgumentNode is missing PostUpdateNode. |
+| cpp17.cpp:15:19:15:21 | ptr | ArgumentNode is missing PostUpdateNode. |
+| cpp17.cpp:15:38:15:41 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| cpp17.cpp:15:38:15:41 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| cpp17.cpp:19:10:19:10 | p | ArgumentNode is missing PostUpdateNode. |
+| cpp17.cpp:19:13:19:13 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| cpp17.cpp:19:16:19:16 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| defconstructornewexpr.cpp:4:2:4:6 | Constant | ArgumentNode is missing PostUpdateNode. |
+| defdestructordeleteexpr.cpp:4:9:4:15 | Constant | ArgumentNode is missing PostUpdateNode. |
+| deleteexpr.cpp:7:9:7:15 | Constant | ArgumentNode is missing PostUpdateNode. |
+| destructors.cpp:50:9:50:13 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| destructors.cpp:52:14:52:16 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | & ... | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | & ... | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | & ... | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (Base *)... | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (Middle *)... | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (__begin) | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (__begin) | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (reference dereference) | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| file://:0:0:0:0 | this | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:377:16:377:16 | x | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:377:19:377:19 | y | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:381:32:381:32 | x | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:381:35:381:35 | y | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:552:16:552:16 | 5 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:585:20:585:26 | array to pointer conversion | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:585:29:585:29 | 1 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:585:32:585:39 | array to pointer conversion | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:616:12:616:13 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:617:12:617:13 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:617:15:617:21 | array to pointer conversion | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:619:12:619:13 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:619:24:619:29 | array to pointer conversion | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:623:5:623:5 | (const String)... | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:624:5:624:5 | (const String *)... | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:625:5:625:5 | (const String)... | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:653:9:653:12 | this | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:653:38:653:38 | 0 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:654:10:654:14 | * ... | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:654:40:654:40 | 1 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:655:32:655:32 | 2 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:662:9:662:19 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:662:13:662:18 | array to pointer conversion | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:663:5:663:5 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:700:7:700:7 | 5 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:709:14:709:14 | x | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:709:17:709:17 | y | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:721:41:721:47 | (void *)... | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:721:50:721:52 | 111 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:736:5:736:19 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:736:18:736:18 | s | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:745:8:745:8 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:748:10:748:10 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:751:3:751:3 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:757:12:757:12 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:757:12:757:12 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:760:3:760:3 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:760:3:760:3 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:766:13:766:13 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:766:13:766:13 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:769:3:769:3 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:769:3:769:3 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:775:15:775:15 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:775:15:775:15 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:778:3:778:3 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:778:3:778:3 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:784:15:784:15 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:784:15:784:15 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:787:3:787:3 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:787:3:787:3 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:793:15:793:15 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:793:15:793:15 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:793:15:793:15 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:793:15:793:15 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:796:3:796:3 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:796:3:796:3 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:796:3:796:3 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:796:3:796:3 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:800:8:800:8 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:801:10:801:10 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:802:11:802:11 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:808:3:808:3 | b | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:808:7:808:7 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:809:3:809:3 | b | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:809:7:809:13 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:809:13:809:13 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:810:3:810:3 | b | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:810:7:810:26 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:810:25:810:25 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:816:3:816:3 | m | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:816:7:816:16 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:817:3:817:3 | m | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:817:7:817:29 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:822:3:822:3 | b | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:822:7:822:7 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:823:3:823:3 | b | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:823:7:823:13 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:823:13:823:13 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:824:3:824:3 | b | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:824:7:824:26 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:824:25:824:25 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:830:3:830:3 | d | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:830:7:830:17 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:831:3:831:3 | d | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:831:7:831:30 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:846:8:846:8 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:846:8:846:8 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:850:19:850:19 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:851:22:851:22 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:867:1:867:14 | this | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:868:10:868:11 | array to pointer conversion | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:941:3:941:9 | Constant | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:942:3:942:15 | Constant | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:942:7:942:10 | 1.0 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:943:3:943:11 | Constant | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:944:3:944:14 | Constant | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:944:3:944:14 | new | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:945:3:945:27 | Constant | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:945:3:945:27 | new | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:945:7:945:10 | 1.0 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:945:20:945:26 | array to pointer conversion | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:946:3:946:17 | Constant | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:946:18:946:18 | 128 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:947:3:947:25 | Constant | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:947:7:947:10 | 1.0 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:947:25:947:25 | 128 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:951:3:951:13 | Constant | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:952:3:952:12 | Mul | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:953:3:953:18 | Mul | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:953:7:953:10 | 1.0 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:954:3:954:15 | Mul | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:955:3:955:20 | Mul | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:955:21:955:21 | 128 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:956:3:956:27 | Constant | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:956:7:956:10 | 1.0 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:956:28:956:28 | 128 | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:957:3:957:36 | Mul | ArgumentNode is missing PostUpdateNode. |
+| ir.cpp:958:3:958:24 | Mul | ArgumentNode is missing PostUpdateNode. |
+| membercallexpr.cpp:8:2:8:2 | c | ArgumentNode is missing PostUpdateNode. |
+| membercallexpr_args.cpp:10:5:10:5 | d | ArgumentNode is missing PostUpdateNode. |
+| membercallexpr_args.cpp:10:10:10:14 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| membercallexpr_args.cpp:10:17:10:21 | ... - ... | ArgumentNode is missing PostUpdateNode. |
+| misc.c:147:16:147:16 | i | ArgumentNode is missing PostUpdateNode. |
+| misc.c:147:19:147:19 | j | ArgumentNode is missing PostUpdateNode. |
+| misc.c:228:31:228:40 | global_int | ArgumentNode is missing PostUpdateNode. |
+| misc.c:229:32:229:41 | global_int | ArgumentNode is missing PostUpdateNode. |
+| misc.c:230:27:230:36 | global_int | ArgumentNode is missing PostUpdateNode. |
+| misc.c:231:29:231:38 | global_int | ArgumentNode is missing PostUpdateNode. |
+| ms_assume.cpp:13:21:13:35 | array to pointer conversion | ArgumentNode is missing PostUpdateNode. |
+| ms_assume.cpp:14:21:14:21 | (const char *)... | ArgumentNode is missing PostUpdateNode. |
+| ms_assume.cpp:28:18:28:23 | array to pointer conversion | ArgumentNode is missing PostUpdateNode. |
+| ms_assume.cpp:28:26:28:28 | 256 | ArgumentNode is missing PostUpdateNode. |
+| ms_assume.cpp:28:31:28:31 | s | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:11:7:11:10 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:11:12:11:14 | 101 | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:28:7:28:10 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:28:12:28:14 | 101 | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:48:5:48:8 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| ms_try_mix.cpp:48:10:48:12 | 201 | ArgumentNode is missing PostUpdateNode. |
+| newexpr.cpp:8:2:8:20 | Constant | ArgumentNode is missing PostUpdateNode. |
+| newexpr.cpp:8:2:8:20 | new | ArgumentNode is missing PostUpdateNode. |
+| newexpr.cpp:8:8:8:12 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| newexpr.cpp:8:15:8:19 | ... - ... | ArgumentNode is missing PostUpdateNode. |
+| no_dynamic_init.cpp:5:12:5:35 | array to pointer conversion | ArgumentNode is missing PostUpdateNode. |
+| ops.cpp:19:15:19:22 | Constant | ArgumentNode is missing PostUpdateNode. |
+| ops.cpp:20:18:20:30 | Constant | ArgumentNode is missing PostUpdateNode. |
+| ops.cpp:21:18:21:34 | Mul | ArgumentNode is missing PostUpdateNode. |
+| ops.cpp:26:31:26:53 | Constant | ArgumentNode is missing PostUpdateNode. |
+| ops.cpp:26:31:26:53 | new | ArgumentNode is missing PostUpdateNode. |
+| parameterinitializer.cpp:8:12:8:21 | (char *)... | ArgumentNode is missing PostUpdateNode. |
+| parameterinitializer.cpp:8:24:8:24 | i | ArgumentNode is missing PostUpdateNode. |
+| parameterinitializer.cpp:19:7:19:7 | 3 | ArgumentNode is missing PostUpdateNode. |
+| parameterinitializer.cpp:21:7:21:7 | 4 | ArgumentNode is missing PostUpdateNode. |
+| parameterinitializer.cpp:25:5:25:8 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| parameterinitializer.cpp:27:3:27:6 | my_c | ArgumentNode is missing PostUpdateNode. |
+| pmcallexpr.cpp:8:11:8:11 | g | ArgumentNode is missing PostUpdateNode. |
+| pointer_to_member.cpp:23:6:23:8 | obj | ArgumentNode is missing PostUpdateNode. |
+| pointer_to_member.cpp:23:21:23:44 | call to getFunctionMemberPointer | ArgumentNode is missing PostUpdateNode. |
+| pointer_to_member.cpp:23:46:23:50 | 0 | ArgumentNode is missing PostUpdateNode. |
+| pointer_to_member.cpp:24:17:24:40 | call to getFunctionMemberPointer | ArgumentNode is missing PostUpdateNode. |
+| pointer_to_member.cpp:24:42:24:45 | 1 | ArgumentNode is missing PostUpdateNode. |
+| pointer_to_member.cpp:27:12:27:14 | obj | ArgumentNode is missing PostUpdateNode. |
+| static_init_templates.cpp:20:12:20:12 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| static_init_templates.cpp:31:10:31:11 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| static_init_templates.cpp:236:7:236:7 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| static_init_templates.cpp:240:7:240:7 | FieldAddress | ArgumentNode is missing PostUpdateNode. |
+| static_init_templates.cpp:249:21:249:23 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| static_init_templates.cpp:250:17:250:19 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| static_init_templates.cpp:251:20:251:23 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| staticlocals.cpp:29:14:29:14 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| staticmembercallexpr.cpp:8:2:8:2 | c | ArgumentNode is missing PostUpdateNode. |
+| staticmembercallexpr_args.cpp:10:4:10:4 | d | ArgumentNode is missing PostUpdateNode. |
+| staticmembercallexpr_args.cpp:10:9:10:13 | ... + ... | ArgumentNode is missing PostUpdateNode. |
+| staticmembercallexpr_args.cpp:10:16:10:20 | ... - ... | ArgumentNode is missing PostUpdateNode. |
+| stmt_expr.cpp:13:16:13:16 | VariableAddress | ArgumentNode is missing PostUpdateNode. |
+| stmt_expr.cpp:13:18:13:18 | 1 | ArgumentNode is missing PostUpdateNode. |
+| stream_it.cpp:19:13:19:14 | (reference to) | ArgumentNode is missing PostUpdateNode. |
+| try_catch.cpp:7:8:7:8 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| try_catch.cpp:7:8:7:8 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| try_catch.cpp:7:8:7:8 | ConvertToNonVirtualBase | ArgumentNode is missing PostUpdateNode. |
+| try_catch.cpp:13:5:13:16 | VariableAddress | ArgumentNode is missing PostUpdateNode. |

--- a/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.ql
+++ b/cpp/ql/test/library-tests/syntax-zoo/dataflow-ir-consistency.ql
@@ -1,0 +1,1 @@
+import semmle.code.cpp.ir.dataflow.internal.DataFlowImplConsistency::Consistency

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplConsistency.qll
@@ -1,0 +1,136 @@
+/**
+ * Provides consistency queries for checking invariants in the language-specific
+ * data-flow classes and predicates.
+ */
+
+private import DataFlowImplSpecific::Private
+private import DataFlowImplSpecific::Public
+private import TaintTrackingUtil
+
+module Consistency {
+  private class RelevantNode extends Node {
+    RelevantNode() {
+      this instanceof ArgumentNode or
+      this instanceof ParameterNode or
+      this instanceof ReturnNode or
+      this = getAnOutNode(_, _) or
+      simpleLocalFlowStep(this, _) or
+      simpleLocalFlowStep(_, this) or
+      jumpStep(this, _) or
+      jumpStep(_, this) or
+      storeStep(this, _, _) or
+      storeStep(_, _, this) or
+      readStep(this, _, _) or
+      readStep(_, _, this) or
+      defaultAdditionalTaintStep(this, _) or
+      defaultAdditionalTaintStep(_, this)
+    }
+  }
+
+  query predicate uniqueEnclosingCallable(Node n, string msg) {
+    exists(int c |
+      n instanceof RelevantNode and
+      c = count(n.getEnclosingCallable()) and
+      c != 1 and
+      msg = "Node should have one enclosing callable but has " + c + "."
+    )
+  }
+
+  query predicate uniqueTypeBound(Node n, string msg) {
+    exists(int c |
+      n instanceof RelevantNode and
+      c = count(n.getTypeBound()) and
+      c != 1 and
+      msg = "Node should have one type bound but has " + c + "."
+    )
+  }
+
+  query predicate uniqueTypeRepr(Node n, string msg) {
+    exists(int c |
+      n instanceof RelevantNode and
+      c = count(getErasedRepr(n.getTypeBound())) and
+      c != 1 and
+      msg = "Node should have one type representation but has " + c + "."
+    )
+  }
+
+  query predicate parameterCallable(ParameterNode p, string msg) {
+    exists(DataFlowCallable c | p.isParameterOf(c, _) and c != p.getEnclosingCallable()) and
+    msg = "Callable mismatch for parameter."
+  }
+
+  query predicate localFlowIsLocal(Node n1, Node n2, string msg) {
+    simpleLocalFlowStep(n1, n2) and
+    n1.getEnclosingCallable() != n2.getEnclosingCallable() and
+    msg = "Local flow step does not preserve enclosing callable."
+  }
+
+  private DataFlowType typeRepr() { result = getErasedRepr(any(Node n).getTypeBound()) }
+
+  query predicate compatibleTypesReflexive(DataFlowType t, string msg) {
+    t = typeRepr() and
+    not compatibleTypes(t, t) and
+    msg = "Type compatibility predicate is not reflexive."
+  }
+
+  query predicate unreachableNodeCCtx(Node n, DataFlowCall call, string msg) {
+    isUnreachableInCall(n, call) and
+    exists(DataFlowCallable c |
+      c = n.getEnclosingCallable() and
+      not viableCallable(call) = c
+    ) and
+    msg = "Call context for isUnreachableInCall is inconsistent with call graph."
+  }
+
+  query predicate localCallNodes(DataFlowCall call, Node n, string msg) {
+    (
+      n = getAnOutNode(call, _) and
+      msg = "OutNode and call does not share enclosing callable."
+      or
+      n.(ArgumentNode).argumentOf(call, _) and
+      msg = "ArgumentNode and call does not share enclosing callable."
+    ) and
+    n.getEnclosingCallable() != call.getEnclosingCallable()
+  }
+
+  query predicate postIsNotPre(PostUpdateNode n, string msg) {
+    n.getPreUpdateNode() = n and msg = "PostUpdateNode should not equal its pre-update node."
+  }
+
+  query predicate postHasUniquePre(PostUpdateNode n, string msg) {
+    exists(int c |
+      c = count(n.getPreUpdateNode()) and
+      c != 1 and
+      msg = "PostUpdateNode should have one pre-update node but has " + c + "."
+    )
+  }
+
+  query predicate uniquePostUpdate(Node n, string msg) {
+    1 < strictcount(PostUpdateNode post | post.getPreUpdateNode() = n) and
+    msg = "Node has multiple PostUpdateNodes."
+  }
+
+  query predicate postIsInSameCallable(PostUpdateNode n, string msg) {
+    n.getEnclosingCallable() != n.getPreUpdateNode().getEnclosingCallable() and
+    msg = "PostUpdateNode does not share callable with its pre-update node."
+  }
+
+  private predicate hasPost(Node n) { exists(PostUpdateNode post | post.getPreUpdateNode() = n) }
+
+  query predicate reverseRead(Node n, string msg) {
+    exists(Node n2 | readStep(n, _, n2) and hasPost(n2) and not hasPost(n)) and
+    msg = "Origin of readStep is missing a PostUpdateNode."
+  }
+
+  query predicate storeIsPostUpdate(Node n, string msg) {
+    storeStep(_, _, n) and
+    not n instanceof PostUpdateNode and
+    msg = "Store targets should be PostUpdateNodes."
+  }
+
+  query predicate argHasPostUpdate(ArgumentNode n, string msg) {
+    not hasPost(n) and
+    not isImmutableOrUnobservable(n) and
+    msg = "ArgumentNode is missing PostUpdateNode."
+  }
+}

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplConsistency.qll
@@ -5,7 +5,8 @@
 
 private import DataFlowImplSpecific::Private
 private import DataFlowImplSpecific::Public
-private import TaintTrackingUtil
+private import tainttracking1.TaintTrackingParameter::Private
+private import tainttracking1.TaintTrackingParameter::Public
 
 module Consistency {
   private class RelevantNode extends Node {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplConsistency.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImplConsistency.qll
@@ -55,6 +55,44 @@ module Consistency {
     )
   }
 
+  query predicate uniqueNodeLocation(Node n, string msg) {
+    exists(int c |
+      c =
+        count(string filepath, int startline, int startcolumn, int endline, int endcolumn |
+          n.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+        ) and
+      c != 1 and
+      msg = "Node should have one location but has " + c + "."
+    )
+  }
+
+  query predicate missingLocation(string msg) {
+    exists(int c |
+      c =
+        strictcount(Node n |
+          not exists(string filepath, int startline, int startcolumn, int endline, int endcolumn |
+            n.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+          )
+        ) and
+      msg = "Nodes without location: " + c
+    )
+  }
+
+  query predicate uniqueNodeToString(Node n, string msg) {
+    exists(int c |
+      c = count(n.toString()) and
+      c != 1 and
+      msg = "Node should have one toString but has " + c + "."
+    )
+  }
+
+  query predicate missingToString(string msg) {
+    exists(int c |
+      c = strictcount(Node n | not exists(n.toString())) and
+      msg = "Nodes without toString: " + c
+    )
+  }
+
   query predicate parameterCallable(ParameterNode p, string msg) {
     exists(DataFlowCallable c | p.isParameterOf(c, _) and c != p.getEnclosingCallable()) and
     msg = "Callable mismatch for parameter."

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowPrivate.qll
@@ -1499,3 +1499,12 @@ private predicate viableConstantBooleanParamArg(
 }
 
 int accessPathLimit() { result = 3 }
+
+/**
+ * Holds if `n` does not require a `PostUpdateNode` as it either cannot be
+ * modified or its modification cannot be observed, for example if it is a
+ * freshly created object that is not saved in a variable.
+ *
+ * This predicate is only used for consistency checks.
+ */
+predicate isImmutableOrUnobservable(Node n) { none() }

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
@@ -1,0 +1,127 @@
+/**
+ * Provides consistency queries for checking invariants in the language-specific
+ * data-flow classes and predicates.
+ */
+
+private import DataFlowImplSpecific::Private
+private import DataFlowImplSpecific::Public
+private import TaintTrackingUtil
+
+module Consistency {
+  private predicate relevantNode(Node n) {
+    n instanceof ArgumentNode or
+    n instanceof ParameterNode or
+    n instanceof ReturnNode or
+    n = getAnOutNode(_, _) or
+    simpleLocalFlowStep(n, _) or
+    simpleLocalFlowStep(_, n) or
+    jumpStep(n, _) or
+    jumpStep(_, n) or
+    storeStep(n, _, _) or
+    storeStep(_, _, n) or
+    readStep(n, _, _) or
+    readStep(_, _, n) or
+    defaultAdditionalTaintStep(n, _) or
+    defaultAdditionalTaintStep(_, n)
+  }
+
+  query predicate uniqueEnclosingCallable(Node n, string msg) {
+    exists(int c |
+      relevantNode(n) and
+      c = count(n.getEnclosingCallable()) and
+      c != 1 and
+      if c > 1
+      then msg = "Node does not have unique enclosing callable."
+      else msg = "Node is missing an enclosing callable."
+    )
+  }
+
+  query predicate uniqueTypeBound(Node n, string msg) {
+    exists(int c |
+      relevantNode(n) and
+      c = count(n.getTypeBound()) and
+      c != 1 and
+      if c > 1
+      then msg = "Node does not have unique type bound."
+      else msg = "Node is missing a type bound."
+    )
+  }
+
+  query predicate uniqueTypeRepr(Node n, string msg) {
+    exists(int c |
+      relevantNode(n) and
+      c = count(getErasedRepr(n.getTypeBound())) and
+      c != 1 and
+      if c > 1
+      then msg = "Node does not have unique type representation."
+      else msg = "Node is missing a type representation."
+    )
+  }
+
+  query predicate parameterCallable(ParameterNode p, string msg) {
+    exists(DataFlowCallable c | p.isParameterOf(c, _) and c != p.getEnclosingCallable()) and
+    msg = "Callable mismatch for parameter."
+  }
+
+  query predicate localFlowIsLocal(Node n1, Node n2, string msg) {
+    simpleLocalFlowStep(n1, n2) and
+    n1.getEnclosingCallable() != n2.getEnclosingCallable() and
+    msg = "Local flow step does not preserve enclosing callable."
+  }
+
+  private DataFlowType typeRepr() { result = getErasedRepr(any(Node n).getTypeBound()) }
+
+  query predicate compatibleTypesReflexive(DataFlowType t, string msg) {
+    t = typeRepr() and
+    not compatibleTypes(t, t) and
+    msg = "Type compatibility predicate is not reflexive."
+  }
+
+  query predicate unreachableNodeCCtx(Node n, DataFlowCall call, string msg) {
+    isUnreachableInCall(n, call) and
+    exists(DataFlowCallable c |
+      c = n.getEnclosingCallable() and
+      not viableCallable(call) = c
+    ) and
+    msg = "Call context for isUnreachableInCall is inconsistent with call graph."
+  }
+
+  query predicate localCallNodes(DataFlowCall call, Node n, string msg) {
+    (
+      n = getAnOutNode(call, _) and
+      msg = "OutNode and call does not share enclosing callable."
+      or
+      n.(ArgumentNode).argumentOf(call, _) and
+      msg = "ArgumentNode and call does not share enclosing callable."
+    ) and
+    n.getEnclosingCallable() != call.getEnclosingCallable()
+  }
+
+  query predicate postIsNotPre(PostUpdateNode n, string msg) {
+    n.getPreUpdateNode() = n and msg = "PostUpdateNode should not equal its pre-update node."
+  }
+
+  query predicate postIsInSameCallable(PostUpdateNode n, string msg) {
+    n.getEnclosingCallable() != n.getPreUpdateNode().getEnclosingCallable() and
+    msg = "PostUpdateNode does not share callable with its pre-update node."
+  }
+
+  private predicate hasPost(Node n) { exists(PostUpdateNode post | post.getPreUpdateNode() = n) }
+
+  query predicate reverseRead(Node n, string msg) {
+    exists(Node n2 | readStep(n, _, n2) and hasPost(n2) and not hasPost(n)) and
+    msg = "Origin of readStep is missing a PostUpdateNode."
+  }
+
+  query predicate storeIsPostUpdate(Node n, string msg) {
+    storeStep(_, _, n) and
+    not n instanceof PostUpdateNode and
+    msg = "Store targets should be PostUpdateNodes."
+  }
+
+  query predicate argHasPostUpdate(ArgumentNode n, string msg) {
+    not hasPost(n) and
+    not isImmutableOrUnobservable(n) and
+    msg = "ArgumentNode is missing PostUpdateNode."
+  }
+}

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
@@ -5,7 +5,8 @@
 
 private import DataFlowImplSpecific::Private
 private import DataFlowImplSpecific::Public
-private import TaintTrackingUtil
+private import tainttracking1.TaintTrackingParameter::Private
+private import tainttracking1.TaintTrackingParameter::Public
 
 module Consistency {
   private class RelevantNode extends Node {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
@@ -32,9 +32,7 @@ module Consistency {
       n instanceof RelevantNode and
       c = count(n.getEnclosingCallable()) and
       c != 1 and
-      if c > 1
-      then msg = "Node does not have unique enclosing callable."
-      else msg = "Node is missing an enclosing callable."
+      msg = "Node should have one enclosing callable but has " + c + "."
     )
   }
 
@@ -43,9 +41,7 @@ module Consistency {
       n instanceof RelevantNode and
       c = count(n.getTypeBound()) and
       c != 1 and
-      if c > 1
-      then msg = "Node does not have unique type bound."
-      else msg = "Node is missing a type bound."
+      msg = "Node should have one type bound but has " + c + "."
     )
   }
 
@@ -54,9 +50,7 @@ module Consistency {
       n instanceof RelevantNode and
       c = count(getErasedRepr(n.getTypeBound())) and
       c != 1 and
-      if c > 1
-      then msg = "Node does not have unique type representation."
-      else msg = "Node is missing a type representation."
+      msg = "Node should have one type representation but has " + c + "."
     )
   }
 
@@ -107,9 +101,7 @@ module Consistency {
     exists(int c |
       c = count(n.getPreUpdateNode()) and
       c != 1 and
-      if c > 1
-      then msg = "PostUpdateNode does not have unique pre-update node."
-      else msg = "PostUpdateNode is missing a pre-update node."
+      msg = "PostUpdateNode should have one pre-update node but has " + c + "."
     )
   }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImplConsistency.qll
@@ -55,6 +55,44 @@ module Consistency {
     )
   }
 
+  query predicate uniqueNodeLocation(Node n, string msg) {
+    exists(int c |
+      c =
+        count(string filepath, int startline, int startcolumn, int endline, int endcolumn |
+          n.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+        ) and
+      c != 1 and
+      msg = "Node should have one location but has " + c + "."
+    )
+  }
+
+  query predicate missingLocation(string msg) {
+    exists(int c |
+      c =
+        strictcount(Node n |
+          not exists(string filepath, int startline, int startcolumn, int endline, int endcolumn |
+            n.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+          )
+        ) and
+      msg = "Nodes without location: " + c
+    )
+  }
+
+  query predicate uniqueNodeToString(Node n, string msg) {
+    exists(int c |
+      c = count(n.toString()) and
+      c != 1 and
+      msg = "Node should have one toString but has " + c + "."
+    )
+  }
+
+  query predicate missingToString(string msg) {
+    exists(int c |
+      c = strictcount(Node n | not exists(n.toString())) and
+      msg = "Nodes without toString: " + c
+    )
+  }
+
   query predicate parameterCallable(ParameterNode p, string msg) {
     exists(DataFlowCallable c | p.isParameterOf(c, _) and c != p.getEnclosingCallable()) and
     msg = "Callable mismatch for parameter."

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowPrivate.qll
@@ -326,3 +326,14 @@ predicate isUnreachableInCall(Node n, DataFlowCall call) {
 }
 
 int accessPathLimit() { result = 5 }
+
+/**
+ * Holds if `n` does not require a `PostUpdateNode` as it either cannot be
+ * modified or its modification cannot be observed, for example if it is a
+ * freshly created object that is not saved in a variable.
+ *
+ * This predicate is only used for consistency checks.
+ */
+predicate isImmutableOrUnobservable(Node n) {
+  n.getType() instanceof ImmutableType or n instanceof ImplicitVarargsArray
+}

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowUtil.qll
@@ -11,7 +11,10 @@ import semmle.code.java.dataflow.InstanceAccess
 
 cached
 private newtype TNode =
-  TExprNode(Expr e) or
+  TExprNode(Expr e) {
+    not e.getType() instanceof VoidType and
+    not e.getParent*() instanceof Annotation
+  } or
   TExplicitParameterNode(Parameter p) { exists(p.getCallable().getBody()) } or
   TImplicitVarargsArray(Call c) {
     c.getCallee().isVarargs() and


### PR DESCRIPTION
This adds a number of consistency queries (i.e. queries that ought to return zero results) for the shared data-flow implementation.  The main file is language-independent and can be synced across languages.  The idea is that this should help document expectations and invariants in the shared implementation.  For Java, these queries mostly give zero results, but extractor issues can result in nodes without callables, and the TypeFlow library can give multiple type bounds in some corner cases.

A few unresolved questions:
* One of the checks needs a tiny bit of customisation via the predicate `isImmutableOrUnobservable(Node n)` to disregard arguments without `PostUpdateNode`s when they have been consciously excluded.  Currently I've put this in `DataFlowPrivate.qll`, but perhaps this predicate ought to go in its own file?
* The checks currently reside next to the implementation, as this was the easiest way to access the language-specific imports.  Should this move to somewhere in `<lang>/ql/test/` instead?  A related question is how our plumming for consistency queries work at the moment and whether that gives some restrictions?

When we are happy with the structure, I can sync this to C# and C++.