### PR TITLE
C++: Add Expr.getUnconverted predicate

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Expr.qll
@@ -443,6 +443,20 @@ class Expr extends StmtParent, @expr {
   }
 
   /**
+   * Gets the unique non-`Conversion` expression `e` for which
+   * `this = e.getConversion*()`.
+   *
+   * For example, if called on the expression `(int)(char)x`, this predicate
+   * gets the expression `x`.
+   */
+  Expr getUnconverted() {
+    not this instanceof Conversion and
+    result = this
+    or
+    result = this.(Conversion).getExpr().getUnconverted()
+  }
+
+  /**
    * Gets the type of this expression, after any implicit conversions and explicit casts, and after resolving typedefs.
    *
    * As an example, consider the AST fragment `(i64)(void*)0` in the context of `typedef long long i64;`. The fragment

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -131,10 +131,7 @@ class ExprNode extends InstructionNode {
    * `Conversion`, then the result is that `Conversion`'s non-`Conversion` base
    * expression.
    */
-  Expr getExpr() {
-    result.getConversion*() = instr.getConvertedResultExpression() and
-    not result instanceof Conversion
-  }
+  Expr getExpr() { result = instr.getUnconvertedResultExpression() }
 
   /**
    * Gets the expression corresponding to this node, if any. The returned

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
@@ -68,14 +68,7 @@ private module Cached {
 
   cached
   Expr getInstructionUnconvertedResultExpression(Instruction instruction) {
-    exists(Expr converted |
-      result = converted.(Conversion).getExpr+()
-      or
-      result = converted
-    |
-      not result instanceof Conversion and
-      converted = getInstructionConvertedResultExpression(instruction)
-    )
+    result = getInstructionConvertedResultExpression(instruction).getUnconverted()
   }
 
   cached


### PR DESCRIPTION
This gets rid of the expensive predicate `#Cast::Conversion::getExpr_dispred#ffPlus`, I've observed to cause memory pressure on large databases.