### PR TITLE
Python: ObjectAPI to ValueAPI: CallToSuperWrongClass

### DIFF
--- a/python/ql/src/Expressions/CallToSuperWrongClass.ql
+++ b/python/ql/src/Expressions/CallToSuperWrongClass.ql
@@ -17,13 +17,13 @@ import python
 from CallNode call_to_super, string name
 where
 exists(GlobalVariable gv, ControlFlowNode cn |
-    call_to_super = theSuperType().getACall() and
+    call_to_super = ClassValue::super_().getACall() and
     gv.getId() = "super" and
     cn = call_to_super.getArg(0) and
     name = call_to_super.getScope().getScope().(Class).getName() and
-    exists(ClassObject other | 
-        cn.refersTo(other) and
-        not other.getPyClass().getName() = name
+    exists(ClassValue other | 
+        cn.pointsTo(other) and
+        not other.getScope().getName() = name
     )
 )
 select call_to_super.getNode(), "First argument to super() should be " + name + "."


### PR DESCRIPTION
This PR is part of the Expressions modernization effort.