### PR TITLE
C++: Only return functions that match arguments in DataFlowDispatch::viableCallable

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
@@ -22,7 +22,13 @@ Function viableCallable(CallInstruction call) {
   )
   or
   // Virtual dispatch
-  result = call.(VirtualDispatch::DataSensitiveCall).resolve()
+  result = call.(VirtualDispatch::DataSensitiveCall).resolve() and
+  (
+    call.getNumberOfArguments() <= result.getEffectiveNumberOfParameters() and
+    call.getNumberOfArguments() >= result.getEffectiveNumberOfParameters()
+    or
+    result.isVarargs()
+  )
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowDispatch.qll
@@ -22,13 +22,7 @@ Function viableCallable(CallInstruction call) {
   )
   or
   // Virtual dispatch
-  result = call.(VirtualDispatch::DataSensitiveCall).resolve() and
-  (
-    call.getNumberOfArguments() <= result.getEffectiveNumberOfParameters() and
-    call.getNumberOfArguments() >= result.getEffectiveNumberOfParameters()
-    or
-    result.isVarargs()
-  )
+  result = call.(VirtualDispatch::DataSensitiveCall).resolve()
 }
 
 /**
@@ -141,6 +135,12 @@ private module VirtualDispatch {
       exists(FunctionInstruction fi |
         this.flowsFrom(DataFlow::instructionNode(fi), _) and
         result = fi.getFunctionSymbol()
+      ) and
+      (
+        this.getNumberOfArguments() <= result.getEffectiveNumberOfParameters() and
+        this.getNumberOfArguments() >= result.getEffectiveNumberOfParameters()
+        or
+        result.isVarargs()
       )
     }
   }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -1202,6 +1202,11 @@ class CallInstruction extends Instruction {
   final Instruction getPositionalArgument(int index) {
     result = getPositionalArgumentOperand(index).getDef()
   }
+
+  /**
+   * Gets the number of arguments of the call, including the `this` pointer, if any.
+   */
+  final int getNumberOfArguments() { result = count(this.getAnArgumentOperand()) }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -1202,6 +1202,11 @@ class CallInstruction extends Instruction {
   final Instruction getPositionalArgument(int index) {
     result = getPositionalArgumentOperand(index).getDef()
   }
+
+  /**
+   * Gets the number of arguments of the call, including the `this` pointer, if any.
+   */
+  final int getNumberOfArguments() { result = count(this.getAnArgumentOperand()) }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -1202,6 +1202,11 @@ class CallInstruction extends Instruction {
   final Instruction getPositionalArgument(int index) {
     result = getPositionalArgumentOperand(index).getDef()
   }
+
+  /**
+   * Gets the number of arguments of the call, including the `this` pointer, if any.
+   */
+  final int getNumberOfArguments() { result = count(this.getAnArgumentOperand()) }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
@@ -1202,6 +1202,11 @@ class CallInstruction extends Instruction {
   final Instruction getPositionalArgument(int index) {
     result = getPositionalArgumentOperand(index).getDef()
   }
+
+  /**
+   * Gets the number of arguments of the call, including the `this` pointer, if any.
+   */
+  final int getNumberOfArguments() { result = count(this.getAnArgumentOperand()) }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -1202,6 +1202,11 @@ class CallInstruction extends Instruction {
   final Instruction getPositionalArgument(int index) {
     result = getPositionalArgumentOperand(index).getDef()
   }
+
+  /**
+   * Gets the number of arguments of the call, including the `this` pointer, if any.
+   */
+  final int getNumberOfArguments() { result = count(this.getAnArgumentOperand()) }
 }
 
 /**


### PR DESCRIPTION
This PR applies the same trick for reducing the number of spurious results for `viableCallable` in the new IR-based `DataFlowDispatch` library as was present in the old AST-based library.

This removes about 25 false positives from `cpp/uncontrolled-allocation-size` on `php/php-src` compared to `master`.