### PR TITLE
JS: recognize utility functions implementing a StartsWith check

### DIFF
--- a/javascript/ql/src/semmle/javascript/InclusionTests.qll
+++ b/javascript/ql/src/semmle/javascript/InclusionTests.qll
@@ -59,6 +59,40 @@ module InclusionTest {
   }
 
   /**
+   * A call to a utility function (`callee`) that performs an InclusionTest (`inner`).
+   */
+  private class IndirectInclusionTest extends Range, DataFlow::CallNode {
+    InclusionTest inner;
+    Function callee;
+
+    IndirectInclusionTest() {
+      inner.getEnclosingExpr() = callee.getAReturnedExpr() and
+      this.getACallee() = callee and
+      count(this.getACallee()) = 1 and
+      count(callee.getAReturnedExpr()) = 1 and
+      not this.isImprecise() and
+      inner.getContainerNode().getALocalSource().getEnclosingExpr() = callee.getAParameter() and
+      inner.getContainedNode().getALocalSource().getEnclosingExpr() = callee.getAParameter()
+    }
+
+    override DataFlow::Node getContainerNode() {
+      exists(int arg |
+        inner.getContainerNode().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and
+        result = this.getArgument(arg)
+      )
+    }
+
+    override DataFlow::Node getContainedNode() {
+      exists(int arg |
+        inner.getContainedNode().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and
+        result = this.getArgument(arg)
+      )
+    }
+
+    override boolean getPolarity() { result = inner.getPolarity() }
+  }
+
+  /**
    * A call to a method named `includes`, assumed to refer to `String.prototype.includes`
    * or `Array.prototype.includes`.
    */

--- a/javascript/ql/src/semmle/javascript/StringOps.qll
+++ b/javascript/ql/src/semmle/javascript/StringOps.qll
@@ -57,6 +57,38 @@ module StringOps {
     }
 
     /**
+     * A call to a utility function (`callee`) that performs a StartsWith check (`inner`).
+     */
+    private class IndirectStartsWith extends Range, DataFlow::CallNode {
+      StartsWith inner;
+      Function callee;
+
+      IndirectStartsWith() {
+        inner.getEnclosingExpr() = callee.getAReturnedExpr() and
+        this.getACallee() = callee and
+        count(this.getACallee()) = 1 and
+        count(callee.getAReturnedExpr()) = 1 and 
+        not this.isImprecise() and
+        inner.getBaseString().getALocalSource().getEnclosingExpr() = callee.getAParameter() and
+        inner.getSubstring().getALocalSource().getEnclosingExpr() = callee.getAParameter()
+      }
+
+      override DataFlow::Node getBaseString() {
+        exists(int arg |
+          inner.getBaseString().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and
+          result = this.getArgument(arg)
+        )
+      }
+
+      override DataFlow::Node getSubstring() {
+        exists(int arg |
+          inner.getSubstring().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and
+          result = this.getArgument(arg)
+        )
+      }
+    }
+
+    /**
      * An expression of form `A.startsWith(B)`.
      */
     private class StartsWith_Native extends Range, DataFlow::MethodCallNode {

--- a/javascript/ql/src/semmle/javascript/StringOps.qll
+++ b/javascript/ql/src/semmle/javascript/StringOps.qll
@@ -288,6 +288,41 @@ module StringOps {
     }
 
     /**
+     * A call to a utility function (`callee`) that performs an EndsWith check (`inner`).
+     */
+    private class IndirectEndsWith extends Range, DataFlow::CallNode {
+      EndsWith inner;
+      Function callee;
+
+      IndirectEndsWith() {
+        inner.getEnclosingExpr() = callee.getAReturnedExpr() and
+        this.getACallee() = callee and
+        count(this.getACallee()) = 1 and
+        count(callee.getAReturnedExpr()) = 1 and 
+        not this.isImprecise() and
+        inner.getBaseString().getALocalSource().getEnclosingExpr() = callee.getAParameter() and
+        inner.getSubstring().getALocalSource().getEnclosingExpr() = callee.getAParameter()
+      }
+
+      override DataFlow::Node getBaseString() {
+        exists(int arg |
+          inner.getBaseString().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and
+          result = this.getArgument(arg)
+        )
+      }
+
+      override DataFlow::Node getSubstring() {
+        exists(int arg |
+          inner.getSubstring().getALocalSource().getEnclosingExpr() = callee.getParameter(arg) and
+          result = this.getArgument(arg)
+        )
+      }
+
+      override boolean getPolarity() { result = inner.getPolarity() }
+    }
+
+
+    /**
      * A call of form `A.endsWith(B)`.
      */
     private class EndsWith_Native extends Range, DataFlow::MethodCallNode {

--- a/javascript/ql/src/semmle/javascript/StringOps.qll
+++ b/javascript/ql/src/semmle/javascript/StringOps.qll
@@ -86,6 +86,8 @@ module StringOps {
           result = this.getArgument(arg)
         )
       }
+
+      override boolean getPolarity() { result = inner.getPolarity() }
     }
 
     /**

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -1654,6 +1654,33 @@ nodes
 | normalizedPaths.js:346:19:346:22 | path |
 | normalizedPaths.js:346:19:346:22 | path |
 | normalizedPaths.js:346:19:346:22 | path |
+| normalizedPaths.js:354:7:354:27 | path |
+| normalizedPaths.js:354:7:354:27 | path |
+| normalizedPaths.js:354:7:354:27 | path |
+| normalizedPaths.js:354:7:354:27 | path |
+| normalizedPaths.js:354:14:354:27 | req.query.path |
+| normalizedPaths.js:354:14:354:27 | req.query.path |
+| normalizedPaths.js:354:14:354:27 | req.query.path |
+| normalizedPaths.js:354:14:354:27 | req.query.path |
+| normalizedPaths.js:354:14:354:27 | req.query.path |
+| normalizedPaths.js:356:19:356:22 | path |
+| normalizedPaths.js:356:19:356:22 | path |
+| normalizedPaths.js:356:19:356:22 | path |
+| normalizedPaths.js:356:19:356:22 | path |
+| normalizedPaths.js:356:19:356:22 | path |
+| normalizedPaths.js:358:7:358:51 | requestPath |
+| normalizedPaths.js:358:7:358:51 | requestPath |
+| normalizedPaths.js:358:7:358:51 | requestPath |
+| normalizedPaths.js:358:21:358:51 | pathMod ... , path) |
+| normalizedPaths.js:358:21:358:51 | pathMod ... , path) |
+| normalizedPaths.js:358:21:358:51 | pathMod ... , path) |
+| normalizedPaths.js:358:47:358:50 | path |
+| normalizedPaths.js:358:47:358:50 | path |
+| normalizedPaths.js:358:47:358:50 | path |
+| normalizedPaths.js:363:21:363:31 | requestPath |
+| normalizedPaths.js:363:21:363:31 | requestPath |
+| normalizedPaths.js:363:21:363:31 | requestPath |
+| normalizedPaths.js:363:21:363:31 | requestPath |
 | tainted-require.js:7:19:7:37 | req.param("module") |
 | tainted-require.js:7:19:7:37 | req.param("module") |
 | tainted-require.js:7:19:7:37 | req.param("module") |
@@ -4582,6 +4609,37 @@ edges
 | normalizedPaths.js:339:32:339:45 | req.query.path | normalizedPaths.js:339:13:339:46 | pathMod ... y.path) |
 | normalizedPaths.js:339:32:339:45 | req.query.path | normalizedPaths.js:339:13:339:46 | pathMod ... y.path) |
 | normalizedPaths.js:339:32:339:45 | req.query.path | normalizedPaths.js:339:13:339:46 | pathMod ... y.path) |
+| normalizedPaths.js:354:7:354:27 | path | normalizedPaths.js:356:19:356:22 | path |
+| normalizedPaths.js:354:7:354:27 | path | normalizedPaths.js:356:19:356:22 | path |
+| normalizedPaths.js:354:7:354:27 | path | normalizedPaths.js:356:19:356:22 | path |
+| normalizedPaths.js:354:7:354:27 | path | normalizedPaths.js:356:19:356:22 | path |
+| normalizedPaths.js:354:7:354:27 | path | normalizedPaths.js:356:19:356:22 | path |
+| normalizedPaths.js:354:7:354:27 | path | normalizedPaths.js:356:19:356:22 | path |
+| normalizedPaths.js:354:7:354:27 | path | normalizedPaths.js:356:19:356:22 | path |
+| normalizedPaths.js:354:7:354:27 | path | normalizedPaths.js:356:19:356:22 | path |
+| normalizedPaths.js:354:7:354:27 | path | normalizedPaths.js:358:47:358:50 | path |
+| normalizedPaths.js:354:7:354:27 | path | normalizedPaths.js:358:47:358:50 | path |
+| normalizedPaths.js:354:7:354:27 | path | normalizedPaths.js:358:47:358:50 | path |
+| normalizedPaths.js:354:14:354:27 | req.query.path | normalizedPaths.js:354:7:354:27 | path |
+| normalizedPaths.js:354:14:354:27 | req.query.path | normalizedPaths.js:354:7:354:27 | path |
+| normalizedPaths.js:354:14:354:27 | req.query.path | normalizedPaths.js:354:7:354:27 | path |
+| normalizedPaths.js:354:14:354:27 | req.query.path | normalizedPaths.js:354:7:354:27 | path |
+| normalizedPaths.js:354:14:354:27 | req.query.path | normalizedPaths.js:354:7:354:27 | path |
+| normalizedPaths.js:354:14:354:27 | req.query.path | normalizedPaths.js:354:7:354:27 | path |
+| normalizedPaths.js:354:14:354:27 | req.query.path | normalizedPaths.js:354:7:354:27 | path |
+| normalizedPaths.js:354:14:354:27 | req.query.path | normalizedPaths.js:354:7:354:27 | path |
+| normalizedPaths.js:358:7:358:51 | requestPath | normalizedPaths.js:363:21:363:31 | requestPath |
+| normalizedPaths.js:358:7:358:51 | requestPath | normalizedPaths.js:363:21:363:31 | requestPath |
+| normalizedPaths.js:358:7:358:51 | requestPath | normalizedPaths.js:363:21:363:31 | requestPath |
+| normalizedPaths.js:358:7:358:51 | requestPath | normalizedPaths.js:363:21:363:31 | requestPath |
+| normalizedPaths.js:358:7:358:51 | requestPath | normalizedPaths.js:363:21:363:31 | requestPath |
+| normalizedPaths.js:358:7:358:51 | requestPath | normalizedPaths.js:363:21:363:31 | requestPath |
+| normalizedPaths.js:358:21:358:51 | pathMod ... , path) | normalizedPaths.js:358:7:358:51 | requestPath |
+| normalizedPaths.js:358:21:358:51 | pathMod ... , path) | normalizedPaths.js:358:7:358:51 | requestPath |
+| normalizedPaths.js:358:21:358:51 | pathMod ... , path) | normalizedPaths.js:358:7:358:51 | requestPath |
+| normalizedPaths.js:358:47:358:50 | path | normalizedPaths.js:358:21:358:51 | pathMod ... , path) |
+| normalizedPaths.js:358:47:358:50 | path | normalizedPaths.js:358:21:358:51 | pathMod ... , path) |
+| normalizedPaths.js:358:47:358:50 | path | normalizedPaths.js:358:21:358:51 | pathMod ... , path) |
 | tainted-require.js:7:19:7:37 | req.param("module") | tainted-require.js:7:19:7:37 | req.param("module") |
 | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | tainted-sendFile.js:8:16:8:33 | req.param("gimme") |
 | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | tainted-sendFile.js:10:16:10:33 | req.param("gimme") |
@@ -5464,6 +5522,8 @@ edges
 | normalizedPaths.js:332:19:332:32 | normalizedPath | normalizedPaths.js:303:13:303:26 | req.query.path | normalizedPaths.js:332:19:332:32 | normalizedPath | This path depends on $@. | normalizedPaths.js:303:13:303:26 | req.query.path | a user-provided value |
 | normalizedPaths.js:341:18:341:21 | path | normalizedPaths.js:339:32:339:45 | req.query.path | normalizedPaths.js:341:18:341:21 | path | This path depends on $@. | normalizedPaths.js:339:32:339:45 | req.query.path | a user-provided value |
 | normalizedPaths.js:346:19:346:22 | path | normalizedPaths.js:339:32:339:45 | req.query.path | normalizedPaths.js:346:19:346:22 | path | This path depends on $@. | normalizedPaths.js:339:32:339:45 | req.query.path | a user-provided value |
+| normalizedPaths.js:356:19:356:22 | path | normalizedPaths.js:354:14:354:27 | req.query.path | normalizedPaths.js:356:19:356:22 | path | This path depends on $@. | normalizedPaths.js:354:14:354:27 | req.query.path | a user-provided value |
+| normalizedPaths.js:363:21:363:31 | requestPath | normalizedPaths.js:354:14:354:27 | req.query.path | normalizedPaths.js:363:21:363:31 | requestPath | This path depends on $@. | normalizedPaths.js:354:14:354:27 | req.query.path | a user-provided value |
 | tainted-require.js:7:19:7:37 | req.param("module") | tainted-require.js:7:19:7:37 | req.param("module") | tainted-require.js:7:19:7:37 | req.param("module") | This path depends on $@. | tainted-require.js:7:19:7:37 | req.param("module") | a user-provided value |
 | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | This path depends on $@. | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | a user-provided value |
 | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | This path depends on $@. | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/normalizedPaths.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/normalizedPaths.js
@@ -348,3 +348,26 @@ app.get('/yet-another-prefix', (req, res) => {
     }
 	fs.readFileSync(path); // OK
 });
+
+var rootPath = process.cwd();
+app.get('/yet-another-prefix2', (req, res) => {
+  let path = req.query.path;
+
+  fs.readFileSync(path); // NOT OK
+
+  var requestPath = pathModule.join(rootPath, path);
+
+  var targetPath;
+  if (!allowPath(requestPath, rootPath)) {
+    targetPath = rootPath;
+    fs.readFileSync(requestPath); // NOT OK
+  } else {
+    targetPath = requestPath;
+    fs.readFileSync(requestPath); // OK
+  }
+  fs.readFileSync(targetPath); // OK
+
+  function allowPath(requestPath, rootPath) {
+    return requestPath.indexOf(rootPath) === 0;
+  }
+});


### PR DESCRIPTION
Example: 

```JavaScript
function goodPath(requestPath, rootPath) {
  return requestPath.indexOf(rootPath) === 0;
}

var rootPath = process.cwd();
app.get('/foo', (req, res) => {
  let taintedPath = req.query.path;
  var requestPath = path.join(rootPath, taintedPath);

  if (!goodPath(requestPath, rootPath)) { // <- Not previously recognized as a StartsWith. 
    return;
  }
  fs.readFileSync(requestPath); // OK - was previously a FP
});
```

This gets us a TN in CVE-2018-16485. 