### PR TITLE
JS: handle this parameters when finding unreachable overloads

### DIFF
--- a/javascript/ql/src/Declarations/UnreachableMethodOverloads.ql
+++ b/javascript/ql/src/Declarations/UnreachableMethodOverloads.ql
@@ -100,6 +100,13 @@ predicate signaturesMatch(MethodSignature method, MethodSignature other) {
   method.getName() = other.getName() and
   // same number of parameters.
   method.getBody().getNumParameter() = other.getBody().getNumParameter() and
+  // same this parameter (if exists)
+  (
+    not exists(method.getBody().getThisTypeAnnotation()) and
+    not exists(other.getBody().getThisTypeAnnotation())
+    or
+    method.getBody().getThisTypeAnnotation() = other.getBody().getThisTypeAnnotation()
+  ) and
   // The types are compared in matchingCallSignature. This is sanity-check that the textual representation of the type-annotations are somewhat similar.
   forall(int i | i in [0 .. -1 + method.getBody().getNumParameter()] |
     getParameterTypeAnnotation(method, i) = getParameterTypeAnnotation(other, i)

--- a/javascript/ql/src/Declarations/UnreachableMethodOverloads.ql
+++ b/javascript/ql/src/Declarations/UnreachableMethodOverloads.ql
@@ -105,7 +105,7 @@ predicate signaturesMatch(MethodSignature method, MethodSignature other) {
     not exists(method.getBody().getThisTypeAnnotation()) and
     not exists(other.getBody().getThisTypeAnnotation())
     or
-    method.getBody().getThisTypeAnnotation() = other.getBody().getThisTypeAnnotation()
+    method.getBody().getThisTypeAnnotation().getType() = other.getBody().getThisTypeAnnotation().getType()
   ) and
   // The types are compared in matchingCallSignature. This is sanity-check that the textual representation of the type-annotations are somewhat similar.
   forall(int i | i in [0 .. -1 + method.getBody().getNumParameter()] |

--- a/javascript/ql/test/query-tests/Declarations/UnreachableOverloads/UnreachableMethodOverloads.expected
+++ b/javascript/ql/test/query-tests/Declarations/UnreachableOverloads/UnreachableMethodOverloads.expected
@@ -1,4 +1,4 @@
 | tst.ts:3:3:3:30 | method( ... number; | This overload of method() is unreachable, the $@ overload will always be selected. | tst.ts:2:3:2:30 | method( ... string; | previous |
 | tst.ts:6:3:6:17 | types1(): any[] | This overload of types1() is unreachable, the $@ overload will always be selected. | tst.ts:5:3:5:18 | types1<T>(): T[] | previous |
 | tst.ts:15:3:15:74 | on(even ... nction; | This overload of on() is unreachable, the $@ overload will always be selected. | tst.ts:14:3:14:74 | on(even ... nction; | previous |
-| tst.ts:21:3:21:30 | method( ... number; | This overload of method() is unreachable, the $@ overload will always be selected. | tst.ts:20:3:20:30 | method( ... string; | previous |
+| tst.ts:24:3:24:30 | method( ... number; | This overload of method() is unreachable, the $@ overload will always be selected. | tst.ts:23:3:23:30 | method( ... string; | previous |

--- a/javascript/ql/test/query-tests/Declarations/UnreachableOverloads/UnreachableMethodOverloads.expected
+++ b/javascript/ql/test/query-tests/Declarations/UnreachableOverloads/UnreachableMethodOverloads.expected
@@ -1,4 +1,5 @@
 | tst.ts:3:3:3:30 | method( ... number; | This overload of method() is unreachable, the $@ overload will always be selected. | tst.ts:2:3:2:30 | method( ... string; | previous |
 | tst.ts:6:3:6:17 | types1(): any[] | This overload of types1() is unreachable, the $@ overload will always be selected. | tst.ts:5:3:5:18 | types1<T>(): T[] | previous |
 | tst.ts:15:3:15:74 | on(even ... nction; | This overload of on() is unreachable, the $@ overload will always be selected. | tst.ts:14:3:14:74 | on(even ... nction; | previous |
-| tst.ts:24:3:24:30 | method( ... number; | This overload of method() is unreachable, the $@ overload will always be selected. | tst.ts:23:3:23:30 | method( ... string; | previous |
+| tst.ts:21:3:21:28 | bar(thi ... number; | This overload of bar() is unreachable, the $@ overload will always be selected. | tst.ts:20:3:20:28 | bar(thi ... string; | previous |
+| tst.ts:27:3:27:30 | method( ... number; | This overload of method() is unreachable, the $@ overload will always be selected. | tst.ts:26:3:26:30 | method( ... string; | previous |

--- a/javascript/ql/test/query-tests/Declarations/UnreachableOverloads/tst.ts
+++ b/javascript/ql/test/query-tests/Declarations/UnreachableOverloads/tst.ts
@@ -14,6 +14,9 @@ declare class Foobar {
   on(event: string, fn?: (event?: any, ...args: any[]) => void): Function;
   on(event: string, fn?: (event?: any, ...args: any[]) => void): Function; // NOT OK.
 
+  foo(this: string): string;
+  foo(this: number): number; // OK
+
 }
 
 declare class Base {

--- a/javascript/ql/test/query-tests/Declarations/UnreachableOverloads/tst.ts
+++ b/javascript/ql/test/query-tests/Declarations/UnreachableOverloads/tst.ts
@@ -17,6 +17,9 @@ declare class Foobar {
   foo(this: string): string;
   foo(this: number): number; // OK
 
+  bar(this: number): string;
+  bar(this: number): number; // NOT OK
+
 }
 
 declare class Base {


### PR DESCRIPTION
The unreachable overloads query did not check for the `this`-parameter, which lead to FPs. 