### PR TITLE
JS: support sanitizers that remove all forward slashes

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPath.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPath.qll
@@ -197,6 +197,15 @@ module TaintedPath {
         srclabel = dstlabel
       )
       or
+      // foo.replace(/\./, "") and similar
+      exists(DotRemovingReplaceCall call |
+        src = call.getInput() and
+        dst = call.getOutput() and
+        srclabel.isAbsolute() and
+        dstlabel.isAbsolute() and
+        dstlabel.isNormalized()
+      )
+      or
       // path.join()
       exists(DataFlow::CallNode join, int n |
         join = NodeJSLib::Path::moduleMember("join").getACall()

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -227,9 +227,9 @@ module TaintedPath {
           seq.getNumChild() = 2
         )
         or
-        exists(RegExpCharacterClass choice | literal.getRoot() = choice |
-          choice.getAMatchedString() = "/" or
-          choice.getAMatchedString() = "."
+        exists(RegExpTerm term | literal.getRoot() = term |
+          term.getAMatchedString() = "/" or
+          term.getAMatchedString() = "."
         )
       )
     }

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -213,17 +213,24 @@ module TaintedPath {
         output = this
       )
       or
-      // non-global replace or replace of something other than /\.\./g
+      // non-global replace or replace of something other than /\.\./g, /[/]/g, or /[\.]/g.
       this.getCalleeName() = "replace" and
       input = getReceiver() and
       output = this and
-      not exists(RegExpLiteral literal, RegExpSequence seq |
+      not exists(RegExpLiteral literal |
         getArgument(0).getALocalSource().asExpr() = literal and
-        literal.isGlobal() and
-        literal.getRoot() = seq and
-        seq.getChild(0).(RegExpConstant).getValue() = "." and
-        seq.getChild(1).(RegExpConstant).getValue() = "." and
-        seq.getNumChild() = 2
+        literal.isGlobal()
+      |
+        exists(RegExpSequence seq | literal.getRoot() = seq |
+          seq.getChild(0).(RegExpConstant).getValue() = "." and
+          seq.getChild(1).(RegExpConstant).getValue() = "." and
+          seq.getNumChild() = 2
+        )
+        or
+        exists(RegExpCharacterClass choice | literal.getRoot() = choice |
+          choice.getAMatchedString() = "/" or
+          choice.getAMatchedString() = "."
+        )
       )
     }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -217,20 +217,14 @@ module TaintedPath {
       this.getCalleeName() = "replace" and
       input = getReceiver() and
       output = this and
-      not exists(RegExpLiteral literal |
+      not exists(RegExpLiteral literal, RegExpTerm term |
         getArgument(0).getALocalSource().asExpr() = literal and
-        literal.isGlobal()
+        literal.isGlobal() and
+        literal.getRoot() = term
       |
-        exists(RegExpSequence seq | literal.getRoot() = seq |
-          seq.getChild(0).(RegExpConstant).getValue() = "." and
-          seq.getChild(1).(RegExpConstant).getValue() = "." and
-          seq.getNumChild() = 2
-        )
-        or
-        exists(RegExpTerm term | literal.getRoot() = term |
-          term.getAMatchedString() = "/" or
-          term.getAMatchedString() = "."
-        )
+        term.getAMatchedString() = "/" or
+        term.getAMatchedString() = "." or
+        term.getAMatchedString() = ".."
       )
     }
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -240,6 +240,39 @@ module TaintedPath {
   }
 
   /**
+   * A call that removes all "." or ".." from a path, without also removing all forward slashes.
+   */
+  class DotRemovingReplaceCall extends DataFlow::CallNode {
+    DataFlow::Node input;
+    DataFlow::Node output;
+
+    DotRemovingReplaceCall() {
+      this.getCalleeName() = "replace" and
+      input = getReceiver() and
+      output = this and
+      exists(RegExpLiteral literal, RegExpTerm term |
+        getArgument(0).getALocalSource().asExpr() = literal and
+        literal.isGlobal() and
+        literal.getRoot() = term and
+        not term.getAMatchedString() = "/"
+      |
+        term.getAMatchedString() = "." or
+        term.getAMatchedString() = ".."
+      )
+    }
+
+    /**
+     * Gets the input path to be normalized.
+     */
+    DataFlow::Node getInput() { result = input }
+
+    /**
+     * Gets the normalized path.
+     */
+    DataFlow::Node getOutput() { result = output }
+  }
+
+  /**
    * Holds if `node` is a prefix of the string `../`.
    */
   private predicate isDotDotSlashPrefix(DataFlow::Node node) {

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -1225,6 +1225,58 @@ nodes
 | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
 | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
 | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
 | normalizedPaths.js:11:7:11:27 | path |
 | normalizedPaths.js:11:7:11:27 | path |
 | normalizedPaths.js:11:7:11:27 | path |
@@ -4069,6 +4121,38 @@ edges
 | TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
 | TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
 | TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:183:29:183:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:184:29:184:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:185:29:185:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:186:29:186:32 | path |
 | TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
 | TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
 | TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
@@ -4181,6 +4265,70 @@ edges
 | TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
 | TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
 | TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:183:29:183:32 | path | TaintedPath.js:183:29:183:52 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:184:29:184:32 | path | TaintedPath.js:184:29:184:53 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:185:29:185:32 | path | TaintedPath.js:185:29:185:51 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
 | normalizedPaths.js:11:7:11:27 | path | normalizedPaths.js:13:19:13:22 | path |
 | normalizedPaths.js:11:7:11:27 | path | normalizedPaths.js:13:19:13:22 | path |
 | normalizedPaths.js:11:7:11:27 | path | normalizedPaths.js:13:19:13:22 | path |
@@ -5640,6 +5788,10 @@ edges
 | TaintedPath.js:166:19:166:38 | concatted2.join("/") | TaintedPath.js:149:24:149:30 | req.url | TaintedPath.js:166:19:166:38 | concatted2.join("/") | This path depends on $@. | TaintedPath.js:149:24:149:30 | req.url | a user-provided value |
 | TaintedPath.js:168:19:168:29 | split.pop() | TaintedPath.js:149:24:149:30 | req.url | TaintedPath.js:168:19:168:29 | split.pop() | This path depends on $@. | TaintedPath.js:149:24:149:30 | req.url | a user-provided value |
 | TaintedPath.js:177:29:177:55 | path.re ... /g, '') | TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:177:29:177:55 | path.re ... /g, '') | This path depends on $@. | TaintedPath.js:173:24:173:30 | req.url | a user-provided value |
+| TaintedPath.js:183:29:183:52 | path.re ... /g, '') | TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:183:29:183:52 | path.re ... /g, '') | This path depends on $@. | TaintedPath.js:173:24:173:30 | req.url | a user-provided value |
+| TaintedPath.js:184:29:184:53 | path.re ... /g, '') | TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:184:29:184:53 | path.re ... /g, '') | This path depends on $@. | TaintedPath.js:173:24:173:30 | req.url | a user-provided value |
+| TaintedPath.js:185:29:185:51 | path.re ... /g, '') | TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:185:29:185:51 | path.re ... /g, '') | This path depends on $@. | TaintedPath.js:173:24:173:30 | req.url | a user-provided value |
+| TaintedPath.js:186:29:186:57 | path.re ... /g, '') | TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:186:29:186:57 | path.re ... /g, '') | This path depends on $@. | TaintedPath.js:173:24:173:30 | req.url | a user-provided value |
 | normalizedPaths.js:13:19:13:22 | path | normalizedPaths.js:11:14:11:27 | req.query.path | normalizedPaths.js:13:19:13:22 | path | This path depends on $@. | normalizedPaths.js:11:14:11:27 | req.query.path | a user-provided value |
 | normalizedPaths.js:14:19:14:29 | './' + path | normalizedPaths.js:11:14:11:27 | req.query.path | normalizedPaths.js:14:19:14:29 | './' + path | This path depends on $@. | normalizedPaths.js:11:14:11:27 | req.query.path | a user-provided value |
 | normalizedPaths.js:15:19:15:38 | path + '/index.html' | normalizedPaths.js:11:14:11:27 | req.query.path | normalizedPaths.js:15:19:15:38 | path + '/index.html' | This path depends on $@. | normalizedPaths.js:11:14:11:27 | req.query.path | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -1123,6 +1123,108 @@ nodes
 | TaintedPath.js:168:19:168:29 | split.pop() |
 | TaintedPath.js:168:19:168:29 | split.pop() |
 | TaintedPath.js:168:19:168:29 | split.pop() |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:24:173:30 | req.url |
+| TaintedPath.js:173:24:173:30 | req.url |
+| TaintedPath.js:173:24:173:30 | req.url |
+| TaintedPath.js:173:24:173:30 | req.url |
+| TaintedPath.js:173:24:173:30 | req.url |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
 | normalizedPaths.js:11:7:11:27 | path |
 | normalizedPaths.js:11:7:11:27 | path |
 | normalizedPaths.js:11:7:11:27 | path |
@@ -3951,6 +4053,134 @@ edges
 | TaintedPath.js:168:19:168:23 | split | TaintedPath.js:168:19:168:29 | split.pop() |
 | TaintedPath.js:168:19:168:23 | split | TaintedPath.js:168:19:168:29 | split.pop() |
 | TaintedPath.js:168:19:168:23 | split | TaintedPath.js:168:19:168:29 | split.pop() |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:177:29:177:32 | path |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:43 | url.par ... ).query | TaintedPath.js:173:14:173:48 | url.par ... ry.path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:14:173:48 | url.par ... ry.path | TaintedPath.js:173:7:173:48 | path |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:173:14:173:37 | url.par ... , true) |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
+| TaintedPath.js:177:29:177:32 | path | TaintedPath.js:177:29:177:55 | path.re ... /g, '') |
 | normalizedPaths.js:11:7:11:27 | path | normalizedPaths.js:13:19:13:22 | path |
 | normalizedPaths.js:11:7:11:27 | path | normalizedPaths.js:13:19:13:22 | path |
 | normalizedPaths.js:11:7:11:27 | path | normalizedPaths.js:13:19:13:22 | path |
@@ -5409,6 +5639,7 @@ edges
 | TaintedPath.js:163:19:163:37 | concatted.join("/") | TaintedPath.js:149:24:149:30 | req.url | TaintedPath.js:163:19:163:37 | concatted.join("/") | This path depends on $@. | TaintedPath.js:149:24:149:30 | req.url | a user-provided value |
 | TaintedPath.js:166:19:166:38 | concatted2.join("/") | TaintedPath.js:149:24:149:30 | req.url | TaintedPath.js:166:19:166:38 | concatted2.join("/") | This path depends on $@. | TaintedPath.js:149:24:149:30 | req.url | a user-provided value |
 | TaintedPath.js:168:19:168:29 | split.pop() | TaintedPath.js:149:24:149:30 | req.url | TaintedPath.js:168:19:168:29 | split.pop() | This path depends on $@. | TaintedPath.js:149:24:149:30 | req.url | a user-provided value |
+| TaintedPath.js:177:29:177:55 | path.re ... /g, '') | TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:177:29:177:55 | path.re ... /g, '') | This path depends on $@. | TaintedPath.js:173:24:173:30 | req.url | a user-provided value |
 | normalizedPaths.js:13:19:13:22 | path | normalizedPaths.js:11:14:11:27 | req.query.path | normalizedPaths.js:13:19:13:22 | path | This path depends on $@. | normalizedPaths.js:11:14:11:27 | req.query.path | a user-provided value |
 | normalizedPaths.js:14:19:14:29 | './' + path | normalizedPaths.js:11:14:11:27 | req.query.path | normalizedPaths.js:14:19:14:29 | './' + path | This path depends on $@. | normalizedPaths.js:11:14:11:27 | req.query.path | a user-provided value |
 | normalizedPaths.js:15:19:15:38 | path + '/index.html' | normalizedPaths.js:11:14:11:27 | req.query.path | normalizedPaths.js:15:19:15:38 | path + '/index.html' | This path depends on $@. | normalizedPaths.js:11:14:11:27 | req.query.path | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.js
@@ -175,12 +175,20 @@ var server = http.createServer(function(req, res) {
   // Removal of forward-slash or dots.
   res.write(fs.readFileSync(path.replace(/[\]\[*,;'"`<>\\?\/]/g, ''))); // OK.
   res.write(fs.readFileSync(path.replace(/[abcd]/g, ''))); // NOT OK
-  res.write(fs.readFileSync(path.replace(/[.]/g, ''))); // OK (can still be absolute)
-  res.write(fs.readFileSync(path.replace(/[..]/g, ''))); // OK
   res.write(fs.readFileSync(path.replace(/[./]/g, ''))); // OK
   res.write(fs.readFileSync(path.replace(/[foobar/foobar]/g, ''))); // OK
   res.write(fs.readFileSync(path.replace(/\//g, ''))); // OK
-  res.write(fs.readFileSync(path.replace(/\./g, ''))); // OK
   res.write(fs.readFileSync(path.replace(/\.|\//g, ''))); // OK
-  res.write(fs.readFileSync(path.replace(/\.\.|BLA/g, ''))); // OK
+
+  res.write(fs.readFileSync(path.replace(/[.]/g, ''))); // NOT OK (can be absolute)
+  res.write(fs.readFileSync(path.replace(/[..]/g, ''))); // NOT OK (can be absolute)
+  res.write(fs.readFileSync(path.replace(/\./g, ''))); // NOT OK (can be absolute)
+  res.write(fs.readFileSync(path.replace(/\.\.|BLA/g, ''))); // NOT OK (can be absolute)
+
+  if (!pathModule.isAbsolute(path)) {
+    res.write(fs.readFileSync(path.replace(/[.]/g, ''))); // OK
+  	res.write(fs.readFileSync(path.replace(/[..]/g, ''))); // OK
+    res.write(fs.readFileSync(path.replace(/\./g, ''))); // OK
+  	res.write(fs.readFileSync(path.replace(/\.\.|BLA/g, ''))); // OK
+  }
 });

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.js
@@ -179,4 +179,6 @@ var server = http.createServer(function(req, res) {
   res.write(fs.readFileSync(path.replace(/[..]/g, ''))); // OK
   res.write(fs.readFileSync(path.replace(/[./]/g, ''))); // OK
   res.write(fs.readFileSync(path.replace(/[foobar/foobar]/g, ''))); // OK
+  res.write(fs.readFileSync(path.replace(/\//g, ''))); // OK
+  res.write(fs.readFileSync(path.replace(/\./g, ''))); // OK
 });

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.js
@@ -168,3 +168,15 @@ var server = http.createServer(function(req, res) {
   fs.readFileSync(split.pop()); // NOT OK 
 
 });
+
+var server = http.createServer(function(req, res) {
+  let path = url.parse(req.url, true).query.path;
+  
+  // Removal of forward-slash.
+  res.write(fs.readFileSync(path.replace(/[\]\[*,;'"`<>\\?\/]/g, ''))); // OK.
+  res.write(fs.readFileSync(path.replace(/[abcd]/g, ''))); // NOT OK
+  res.write(fs.readFileSync(path.replace(/[.]/g, ''))); // OK (can still be absolute)
+  res.write(fs.readFileSync(path.replace(/[..]/g, ''))); // OK
+  res.write(fs.readFileSync(path.replace(/[./]/g, ''))); // OK
+  res.write(fs.readFileSync(path.replace(/[foobar/foobar]/g, ''))); // OK
+});

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.js
@@ -172,7 +172,7 @@ var server = http.createServer(function(req, res) {
 var server = http.createServer(function(req, res) {
   let path = url.parse(req.url, true).query.path;
   
-  // Removal of forward-slash.
+  // Removal of forward-slash or dots.
   res.write(fs.readFileSync(path.replace(/[\]\[*,;'"`<>\\?\/]/g, ''))); // OK.
   res.write(fs.readFileSync(path.replace(/[abcd]/g, ''))); // NOT OK
   res.write(fs.readFileSync(path.replace(/[.]/g, ''))); // OK (can still be absolute)
@@ -181,4 +181,6 @@ var server = http.createServer(function(req, res) {
   res.write(fs.readFileSync(path.replace(/[foobar/foobar]/g, ''))); // OK
   res.write(fs.readFileSync(path.replace(/\//g, ''))); // OK
   res.write(fs.readFileSync(path.replace(/\./g, ''))); // OK
+  res.write(fs.readFileSync(path.replace(/\.|\//g, ''))); // OK
+  res.write(fs.readFileSync(path.replace(/\.\.|BLA/g, ''))); // OK
 });


### PR DESCRIPTION
Flow for `js/tainted-path` no longer flow though replace calls that replace all forward slahes or dots.

Gets us a TN for CVE-2019-10767. 

[This kind of regexp](https://lgtm.com/query/6424952412923521795/) seems quite common. 

No evaluation yet.