### PR TITLE
JS: Explore fewer spurious flow paths through properties

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -901,8 +901,14 @@ private predicate reachableFromStoreBase(
   string prop, DataFlow::Node rhs, DataFlow::Node nd, DataFlow::Configuration cfg,
   PathSummary summary
 ) {
-  isRelevant(rhs, cfg) and
-  storeStep(rhs, nd, prop, cfg, summary)
+  exists(PathSummary s1, PathSummary s2 |
+    reachableFromSource(rhs, cfg, s1)
+    or
+    reachableFromStoreBase(_, _, rhs, cfg, s1)
+  |
+    storeStep(rhs, nd, prop, cfg, s2) and
+    summary = MkPathSummary(false, s1.hasCall().booleanOr(s2.hasCall()), s2.getStartLabel(), s2.getEndLabel())
+  )
   or
   exists(DataFlow::Node mid, PathSummary oldSummary, PathSummary newSummary |
     reachableFromStoreBase(prop, rhs, mid, cfg, oldSummary) and

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -67,6 +67,12 @@ typeInferenceMismatch
 | exceptions.js:158:13:158:20 | source() | exceptions.js:161:10:161:10 | e |
 | importedReactComponent.jsx:4:40:4:47 | source() | exportedReactComponent.jsx:2:10:2:19 | props.text |
 | indexOf.js:4:11:4:18 | source() | indexOf.js:9:10:9:10 | x |
+| nested-props.js:4:13:4:20 | source() | nested-props.js:5:10:5:14 | obj.x |
+| nested-props.js:9:18:9:25 | source() | nested-props.js:10:10:10:16 | obj.x.y |
+| nested-props.js:35:13:35:20 | source() | nested-props.js:36:10:36:20 | doLoad(obj) |
+| nested-props.js:43:13:43:20 | source() | nested-props.js:44:10:44:18 | id(obj).x |
+| nested-props.js:67:31:67:38 | source() | nested-props.js:68:10:68:10 | x |
+| nested-props.js:77:36:77:43 | source() | nested-props.js:78:10:78:10 | x |
 | partialCalls.js:4:17:4:24 | source() | partialCalls.js:17:14:17:14 | x |
 | partialCalls.js:4:17:4:24 | source() | partialCalls.js:20:14:20:14 | y |
 | partialCalls.js:4:17:4:24 | source() | partialCalls.js:30:14:30:20 | x.value |

--- a/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/DataFlowTracking.expected
@@ -42,6 +42,11 @@
 | exceptions.js:158:13:158:20 | source() | exceptions.js:161:10:161:10 | e |
 | indexOf.js:4:11:4:18 | source() | indexOf.js:9:10:9:10 | x |
 | indexOf.js:4:11:4:18 | source() | indexOf.js:13:10:13:10 | x |
+| nested-props.js:4:13:4:20 | source() | nested-props.js:5:10:5:14 | obj.x |
+| nested-props.js:9:18:9:25 | source() | nested-props.js:10:10:10:16 | obj.x.y |
+| nested-props.js:35:13:35:20 | source() | nested-props.js:36:10:36:20 | doLoad(obj) |
+| nested-props.js:43:13:43:20 | source() | nested-props.js:44:10:44:18 | id(obj).x |
+| nested-props.js:67:31:67:38 | source() | nested-props.js:68:10:68:10 | x |
 | partialCalls.js:4:17:4:24 | source() | partialCalls.js:17:14:17:14 | x |
 | partialCalls.js:4:17:4:24 | source() | partialCalls.js:20:14:20:14 | y |
 | partialCalls.js:4:17:4:24 | source() | partialCalls.js:30:14:30:20 | x.value |

--- a/javascript/ql/test/library-tests/TaintTracking/nested-props.js
+++ b/javascript/ql/test/library-tests/TaintTracking/nested-props.js
@@ -1,0 +1,81 @@
+import * as dummy from 'dummy';
+
+function storeLoadFlow(obj) {
+    obj.x = source();
+    sink(obj.x); // NOT OK
+}
+
+function storeStoreLoadLoadFlow(obj) {
+    obj.x = { y: source() };
+    sink(obj.x.y); // NOT OK
+}
+
+function loadStoreFlow(obj) {
+    obj.x.y = source();
+    sink(obj.x.y); // NOT OK - but not found
+}
+
+function loadLoadStoreFlow(obj) {
+    obj.x.y.z = source();
+    sink(obj.x.y.z); // NOT OK - but not found
+}
+
+function doStore(obj, x) {
+    obj.x = x;
+}
+function callStoreBackcallFlow(obj) {
+    doStore(obj, source());
+    sink(obj.x); // NOT OK - but not found
+}
+
+function doLoad(obj) {
+    return obj.x
+}
+function storeCallLoadReturnFlow(obj) {
+    obj.x = source();
+    sink(doLoad(obj)); // NOT OK
+}
+
+function id(obj) {
+    return obj
+}
+function storeCallReturnLoadFlow(obj) {
+    obj.x = source();
+    sink(id(obj).x); // NOT OK
+}
+
+function doLoadStore(obj, val) {
+    obj.x.y = val;
+}
+function callStoreBackloadBackcallLoadLoad(obj) {
+    doLoadStore(obj, source());
+    sink(obj.x.y); // NOT OK - but not found
+}
+
+function doLoadLoad(obj) {
+    return obj.x.y
+}
+function storeBackloadCallLoadLoadReturn(obj) {
+    obj.x.y = source();
+    sink(doLoadStore(obj)); // NOT OK - but not found
+}
+
+function doStoreReturn(val) {
+    return { x: val }
+}
+function callStoreReturnLoad() {
+    let { x } = doStoreReturn(source());
+    sink(x); // NOT OK
+
+    doStoreReturn(null); // ensure multiple call sites exist
+}
+
+function doTaintStoreReturn(val) {
+    return { x: val + "!!" }
+}
+function callTaintStoreReturnLoadFlow() {
+    let { x } = doTaintStoreReturn(source());
+    sink(x); // NOT OK
+
+    doTaintStoreReturn(null); // ensure multiple call sites exist
+}


### PR DESCRIPTION
Fixes a scalability problem in how we track flow through properties.

It can be seen in the base case of `reachableFromStoreBase`:
```java
private predicate reachableFromStoreBase(
  string prop, DataFlow::Node rhs, DataFlow::Node nd, DataFlow::Configuration cfg,
  PathSummary summary
) {
  isRelevant(rhs, cfg) and
  storeStep(rhs, nd, prop, cfg, summary)
  or
  /* recursive case (propagate along flowStep) */
}
```

Note that `isRelevant` refers to the result of exploratory flow, which disregards both call/return matching and store/load matching.  So we're tracking forward from the base of any property write whose RHS is seen by exploratory flow, and this set can be quite large.

The tracking itself can also lead to more places than it needs to, for example:
```js
new C(taint())
class C {
  constructor(x) {
    this.foo = x;
    this.bar = new Blah(x);
  }
}
```
Here, we start forward-tracking from `foo` in the constructor. This forward-tracking spills into _all_ call sites of `C` as the initial path summary is level. Since the resulting path summary has a return, the spurious property-flow edges won't actually be usable, but we still pay for constructing them.

This PR makes two changes:
1. More accurately determine which prop writes are relevant for tracking. For this we use `reachableFromSource` and recursively `reachableFromStoreBase` to account for nested properties.
2. Include the `hasCall` part of the above "witness" to avoid constructing property-flow edges that can't be appended after the flow to the RHS.

[Initial evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/js/flow-through-prop_1583212465133) looks very promising, but I'm waiting for more evaluations.