### PR TITLE
JS: model `process` as an EventEmitter

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -936,6 +936,15 @@ module NodeJSLib {
   }
 
   /**
+   * The NodeJS `process` object as an EventEmitter subclass.
+   */
+  private class ProcessAsNodeJSEventEmitter extends NodeJSEventEmitter {
+    ProcessAsNodeJSEventEmitter() {
+      this = process()
+    }
+  }
+
+  /**
    * A class that extends EventEmitter.
    */
   private class EventEmitterSubClass extends DataFlow::ClassNode {

--- a/javascript/ql/test/library-tests/frameworks/EventEmitter/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/EventEmitter/test.expected
@@ -12,3 +12,5 @@
 | tst.js:28:17:28:22 | "blab" | tst.js:25:16:25:20 | event |
 | tst.js:34:18:34:22 | "BOH" | tst.js:33:17:33:17 | x |
 | tst.js:40:20:40:27 | "yabity" | tst.js:39:19:39:19 | x |
+| tst.js:46:28:46:38 | 'FirstData' | tst.js:43:45:43:49 | first |
+| tst.js:47:29:47:40 | 'SecondData' | tst.js:44:37:44:42 | second |

--- a/javascript/ql/test/library-tests/frameworks/EventEmitter/tst.js
+++ b/javascript/ql/test/library-tests/frameworks/EventEmitter/tst.js
@@ -38,3 +38,10 @@ class ExtendsMyCustomEmitter extends MyEventEmitter{}
 var em5 = new ExtendsMyCustomEmitter();
 em5.on("yibity", (x) => {});
 em5.emit("yibity", "yabity");
+
+var process = require('process');
+process.addListener('FirstEvent', function (first) {});
+process.on('SecondEvent', function (second) {});
+
+process.emit('FirstEvent', 'FirstData');
+process.emit('SecondEvent', 'SecondData');


### PR DESCRIPTION
I stumbled upon this hole in our models:

```
$ node
> process.__proto__.__proto__
EventEmitter { ... }
```