### PR TITLE
C++: pragma[noinline] on GVN charpred

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/internal/ASTValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/ASTValueNumbering.qll
@@ -51,6 +51,7 @@ private import semmle.code.cpp.ir.IR
  * methods.
  */
 class GVN extends TValueNumber {
+  pragma[noinline]
   GVN() {
     exists(Instruction instr |
       this = tvalueNumber(instr) and exists(instr.getUnconvertedResultExpression())


### PR DESCRIPTION
The charpred of class `GVN` in `ASTValueNumbering.qll` got inlined into the member predicate `getAnInstruction` and caused a tuple explosion on Wireshark in the query `StrncpyFlippedArgs.ql`.

I interrupted the predicate after 10 minutes and got these intermediate tuple counts:

    (5208s) Tuple counts for ASTValueNumbering::GVN::getAnInstruction_dispred#ff:
    8754900909 ~5%          {3} r1 = JOIN ValueNumberingInternal::tvalueNumber#ff_10#join_rhs AS L WITH ValueNumberingInternal::tvalueNumber#ff_10#join_rhs AS R ON FIRST 1 OUTPUT R.<1>, L.<1>, L.<0>
    4390274632 ~150085%     {2} r2 = JOIN r1 WITH project#SSAConstruction::Cached::getInstructionUnconvertedResultExpression AS R ON FIRST 1 OUTPUT r1.<2>, r1.<1>
                            return r2

After this change, the `getAnInstruction` predicate is itself inlined, like it should be. The new non-inlined charpred takes 2.1s and has these tuple counts:

    (2s) Tuple counts for ASTValueNumbering::GVN#f:
    9158442  ~117%     {1} r1 = JOIN project#SSAConstruction::Cached::getInstructionUnconvertedResultExpression AS L WITH ValueNumberingInternal::tvalueNumber#ff@staged_ext AS R ON FIRST 1 OUTPUT R.<1>
                       return r1