### PR TITLE
JS: Lower severity of js/syntax-error

### DIFF
--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -62,6 +62,7 @@
 | Missing CSRF middleware (`js/missing-token-validation`) | Fewer false positive results | The query reports fewer duplicates and only flags handlers that explicitly access cookie data. |
 | Uncontrolled data used in path expression (`js/path-injection`) | More results | This query now recognizes additional ways dangerous paths can be constructed and used. |
 | Uncontrolled command line (`js/command-line-injection`) | More results | This query now recognizes additional ways of constructing arguments to `cmd.exe` and `/bin/sh`. |
+| Syntax error (`js/syntax-error`) | Lower severity | This results of this query are now displayed with lower severity. |
 
 ## Changes to libraries
 

--- a/javascript/ql/src/LanguageFeatures/SyntaxError.ql
+++ b/javascript/ql/src/LanguageFeatures/SyntaxError.ql
@@ -7,7 +7,7 @@
  * @tags reliability
  *       correctness
  *       language-features
- * @precision high
+ * @precision very-high
  */
 
 import javascript

--- a/javascript/ql/src/LanguageFeatures/SyntaxError.ql
+++ b/javascript/ql/src/LanguageFeatures/SyntaxError.ql
@@ -2,7 +2,7 @@
  * @name Syntax error
  * @description A piece of code could not be parsed due to syntax errors.
  * @kind problem
- * @problem.severity error
+ * @problem.severity recommendation
  * @id js/syntax-error
  * @tags reliability
  *       correctness


### PR DESCRIPTION
These are usually the fault of our analysis rather than the codebase, so it doesn't make sense to display them with the highest severity.