### PR TITLE
JS: support optional options argument to MongoClient.connect

### DIFF
--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -31,6 +31,7 @@
   - [for-own](https://www.npmjs.com/package/for-own)
   - [http2](https://nodejs.org/api/http2.html)
   - [lazy-cache](https://www.npmjs.com/package/lazy-cache)
+  - [mongodb](https://www.npmjs.com/package/mongodb)
   - [react](https://www.npmjs.com/package/react)
   - [send](https://www.npmjs.com/package/send)
   - [typeahead.js](https://www.npmjs.com/package/typeahead.js)

--- a/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NoSQL.qll
@@ -44,7 +44,7 @@ private module MongoDB {
   /** Gets a data flow node that leads to a `connect` callback. */
   private DataFlow::SourceNode getAMongoDbCallback(DataFlow::TypeBackTracker t) {
     t.start() and
-    result = getAMongoClient().getAMemberCall("connect").getArgument(1).getALocalSource()
+    result = getAMongoClient().getAMemberCall("connect").getLastArgument().getALocalSource()
     or
     exists(DataFlow::TypeBackTracker t2 | result = getAMongoDbCallback(t2).backtrack(t2, t))
   }

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/SqlInjection.expected
@@ -20,6 +20,12 @@ nodes
 | mongodb.js:49:19:49:33 | req.query.title |
 | mongodb.js:54:16:54:20 | query |
 | mongodb.js:54:16:54:20 | query |
+| mongodb.js:59:8:59:17 | query |
+| mongodb.js:59:16:59:17 | {} |
+| mongodb.js:60:16:60:30 | req.query.title |
+| mongodb.js:60:16:60:30 | req.query.title |
+| mongodb.js:65:12:65:16 | query |
+| mongodb.js:65:12:65:16 | query |
 | mongodb_bodySafe.js:23:11:23:20 | query |
 | mongodb_bodySafe.js:23:19:23:20 | {} |
 | mongodb_bodySafe.js:24:19:24:33 | req.query.title |
@@ -129,6 +135,17 @@ edges
 | mongodb.js:49:19:49:33 | req.query.title | mongodb.js:54:16:54:20 | query |
 | mongodb.js:49:19:49:33 | req.query.title | mongodb.js:54:16:54:20 | query |
 | mongodb.js:49:19:49:33 | req.query.title | mongodb.js:54:16:54:20 | query |
+| mongodb.js:59:8:59:17 | query | mongodb.js:65:12:65:16 | query |
+| mongodb.js:59:8:59:17 | query | mongodb.js:65:12:65:16 | query |
+| mongodb.js:59:16:59:17 | {} | mongodb.js:59:8:59:17 | query |
+| mongodb.js:60:16:60:30 | req.query.title | mongodb.js:59:8:59:17 | query |
+| mongodb.js:60:16:60:30 | req.query.title | mongodb.js:59:8:59:17 | query |
+| mongodb.js:60:16:60:30 | req.query.title | mongodb.js:59:16:59:17 | {} |
+| mongodb.js:60:16:60:30 | req.query.title | mongodb.js:59:16:59:17 | {} |
+| mongodb.js:60:16:60:30 | req.query.title | mongodb.js:65:12:65:16 | query |
+| mongodb.js:60:16:60:30 | req.query.title | mongodb.js:65:12:65:16 | query |
+| mongodb.js:60:16:60:30 | req.query.title | mongodb.js:65:12:65:16 | query |
+| mongodb.js:60:16:60:30 | req.query.title | mongodb.js:65:12:65:16 | query |
 | mongodb_bodySafe.js:23:11:23:20 | query | mongodb_bodySafe.js:29:16:29:20 | query |
 | mongodb_bodySafe.js:23:11:23:20 | query | mongodb_bodySafe.js:29:16:29:20 | query |
 | mongodb_bodySafe.js:23:19:23:20 | {} | mongodb_bodySafe.js:23:11:23:20 | query |
@@ -243,6 +260,7 @@ edges
 | mongodb.js:18:16:18:20 | query | mongodb.js:13:19:13:26 | req.body | mongodb.js:18:16:18:20 | query | This query depends on $@. | mongodb.js:13:19:13:26 | req.body | a user-provided value |
 | mongodb.js:32:18:32:45 | { title ... itle) } | mongodb.js:26:19:26:26 | req.body | mongodb.js:32:18:32:45 | { title ... itle) } | This query depends on $@. | mongodb.js:26:19:26:26 | req.body | a user-provided value |
 | mongodb.js:54:16:54:20 | query | mongodb.js:49:19:49:33 | req.query.title | mongodb.js:54:16:54:20 | query | This query depends on $@. | mongodb.js:49:19:49:33 | req.query.title | a user-provided value |
+| mongodb.js:65:12:65:16 | query | mongodb.js:60:16:60:30 | req.query.title | mongodb.js:65:12:65:16 | query | This query depends on $@. | mongodb.js:60:16:60:30 | req.query.title | a user-provided value |
 | mongodb_bodySafe.js:29:16:29:20 | query | mongodb_bodySafe.js:24:19:24:33 | req.query.title | mongodb_bodySafe.js:29:16:29:20 | query | This query depends on $@. | mongodb_bodySafe.js:24:19:24:33 | req.query.title | a user-provided value |
 | mongoose.js:27:20:27:24 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:27:20:27:24 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |
 | mongoose.js:30:25:30:29 | query | mongoose.js:21:19:21:26 | req.body | mongoose.js:30:25:30:29 | query | This query depends on $@. | mongoose.js:21:19:21:26 | req.body | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/dbo.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/dbo.js
@@ -1,0 +1,13 @@
+let dbClient = require("mongodb").MongoClient,
+  db = null;
+module.exports = {
+  db: () => {
+    return db;
+  },
+  connect: fn => {
+    dbClient.connect(process.env.DB_URL, {}, (err, client) => {
+      db = client.db(process.env.DB_NAME);
+      return fn(err);
+    });
+  }
+};

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/mongodb.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/mongodb.js
@@ -65,3 +65,22 @@ app.post('/documents/find', (req, res) => {
 		doc.find(query);
 	});
 });
+
+app.post("/logs/count-by-tag", (req, res) => {
+  let tag = req.query.tag;
+
+  MongoClient.connect(process.env.DB_URL, {}, (err, client) => {
+    client
+      .db(process.env.DB_NAME)
+      .collection("logs")
+      // NOT OK: query is tainted by user-provided object value
+      .count({ tags: tag });
+  });
+
+  let importedDbo = require("./dbo.js");
+  importedDbo
+    .db()
+    .collection("logs")
+    // NOT OK: query is tainted by user-provided object value
+    .count({ tags: tag });
+});

--- a/javascript/ql/test/query-tests/Security/CWE-089/untyped/mongodb.js
+++ b/javascript/ql/test/query-tests/Security/CWE-089/untyped/mongodb.js
@@ -54,3 +54,14 @@ app.post('/documents/find', (req, res) => {
       doc.find(query);
     });
 });
+
+app.post('/documents/find', (req, res) => {
+	const query = {};
+	query.title = req.query.title;
+	MongoClient.connect('mongodb://localhost:27017/test', (err, client) => {
+		let doc = client.db("MASTER").collection('doc');
+
+		// NOT OK: query is tainted by user-provided object value
+		doc.find(query);
+	});
+});


### PR DESCRIPTION
A PR on top of #2980 (can be closed if we only want one merge). The diff should be self-explanatory, but here's some context:

https://mongodb.github.io/node-mongodb-native/api-generated/mongoclient.html#connect

![image](https://user-images.githubusercontent.com/1924993/75891117-9e44bc00-5e2f-11ea-9816-a1e45396979c.png)






