### PR TITLE
1.23: Update or remove unwanted links

### DIFF
--- a/docs/language/learn-ql/index.rst
+++ b/docs/language/learn-ql/index.rst
@@ -1,7 +1,7 @@
 Learning CodeQL
 ###############
 
-CodeQL is the code analysis platform used by security researchers to automate `variant analysis <https://semmle.com/variant-analysis>`__. 
+CodeQL is the code analysis platform used by security researchers to automate variant analysis. 
 You can use CodeQL queries to explore code and quickly find variants of security vulnerabilities and bugs. 
 These queries are easy to write and share–visit the topics below and `our open source repository on GitHub <https://github.com/Semmle/ql>`__ to learn more. 
 You can also try out CodeQL in the `query console <https://lgtm.com/query>`__ on `LGTM.com <https://lgtm.com>`__. 

--- a/docs/language/learn-ql/ql-training.rst
+++ b/docs/language/learn-ql/ql-training.rst
@@ -4,9 +4,9 @@ CodeQL training and variant analysis examples
 CodeQL and variant analysis
 ---------------------------
 
-`Variant analysis <https://semmle.com/variant-analysis>`__ is the process of using a known vulnerability as a seed to find similar problems in your code. Security engineers typically perform variant analysis to identify possible vulnerabilities and to ensure that these threats are properly fixed across multiple code bases.
+Variant analysis is the process of using a known vulnerability as a seed to find similar problems in your code. Security engineers typically perform variant analysis to identify possible vulnerabilities and to ensure that these threats are properly fixed across multiple code bases.
 
-`CodeQL <https://semmle.com/ql>`__ is the code analysis engine that underpins LGTM, Semmle's community driven security analysis platform. Together, CodeQL and LGTM provide continuous monitoring and scalable variant analysis for your projects, even if you don’t have your own team of dedicated security engineers. You can read more about using CodeQL and LGTM in variant analysis on the `Security Lab research page <https://securitylab.github.com/research>`__.
+CodeQL is the code analysis engine that underpins LGTM, the community driven security analysis platform. Together, CodeQL and LGTM provide continuous monitoring and scalable variant analysis for your projects, even if you don’t have your own team of dedicated security engineers. You can read more about using CodeQL and LGTM in variant analysis on the `Security Lab research page <https://securitylab.github.com/research>`__.
 
 CodeQL is easy to learn, and exploring code using CodeQL is the most efficient way to perform variant analysis. 
 

--- a/docs/language/ql-training/cpp/bad-overflow-guard.rst
+++ b/docs/language/ql-training/cpp/bad-overflow-guard.rst
@@ -141,7 +141,7 @@ Let’s look for overflow guards of the form ``v + b < v``, using the classes
 
 .. note::
 
-  - When performing `variant analysis <https://semmle.com/variant-analysis>`__, it is usually helpful to write a simple query that finds the simple syntactic pattern, before trying to go on to describe the cases where it goes wrong.
+  - When performing variant analysis, it is usually helpful to write a simple query that finds the simple syntactic pattern, before trying to go on to describe the cases where it goes wrong.
   - In this case, we start by looking for all the *overflow* checks, before trying to refine the query to find all *bad overflow* checks.
   - The ``select`` clause defines what this query is looking for:
 

--- a/docs/language/ql-training/java/query-injection-java.rst
+++ b/docs/language/ql-training/java/query-injection-java.rst
@@ -77,7 +77,7 @@ Let’s start by looking for calls to methods with names of the form ``sparql*Qu
 
 .. note::
 
-  - When performing `variant analysis <https://semmle.com/variant-analysis>`__, it is usually helpful to write a simple query that finds the simple syntactic pattern, before trying to go on to describe the cases where it goes wrong.
+  - When performing variant analysis, it is usually helpful to write a simple query that finds the simple syntactic pattern, before trying to go on to describe the cases where it goes wrong.
   - In this case, we start by looking for all the method calls that appear to run, before trying to refine the query to find cases which are vulnerable to query injection.
   - The ``select`` clause defines what this query is looking for:
   

--- a/docs/language/ql-training/slide-snippets/intro-ql-general.rst
+++ b/docs/language/ql-training/slide-snippets/intro-ql-general.rst
@@ -81,8 +81,6 @@ Find all instances!
 
 - All were fixed with a mid-flight patch.
 
-- For more detail on the collaboration between Semmle and NASA, see our case study: `Semmle at NASA: Landing Curiosity safely on Mars <https://semmle.com/case-studies/semmle-nasa-landing-curiosity-safely-mars>`__.
-
 .. note::
 
   The JPL team ran the query across the full Curiosity control software–it identified the original problem, and more than 30 other variants, of which three were in the critical Entry, Descent, and Landing module. 
@@ -107,7 +105,7 @@ Analysis overview
 
   Once the extraction finishes, all this information is collected into a single `CodeQL database <https://help.semmle.com/QL/learn-ql/database.html>`__, which is then ready to query, possibly on a different machine. A copy of the source files, made at the time the database was created, is also included in the CodeQL database so analysis results can be displayed at the correct location in the code. The database schema is (source) language specific.
 
-  Queries are written in `QL <https://semmle.com/ql>`__ and usually depend on one or more of the `standard CodeQL libraries <https://github.com/semmle/ql>`__ (and of course you can write your own custom libraries). They are compiled into an efficiently executable format by the QL compiler and then run on a CodeQL database by the QL evaluator, either on a remote worker machine or locally on a developer’s machine.
+  Queries are written in QL and usually depend on one or more of the `standard CodeQL libraries <https://github.com/semmle/ql>`__ (and of course you can write your own custom libraries). They are compiled into an efficiently executable format by the QL compiler and then run on a CodeQL database by the QL evaluator, either on a remote worker machine or locally on a developer’s machine.
 
   Query results can be interpreted and presented in a variety of ways, including displaying them in an `IDE extension <https://lgtm.com/help/lgtm/running-queries-ide>`__ such as CodeQL for Visual Studio Code, or in a web dashboard as on `LGTM <https://lgtm.com/help/lgtm/about-lgtm>`__.
 


### PR DESCRIPTION
This relates to product-documentation issue 2210 and removes unwanted links from the CodeQL documentation.

* [Learning CodeQL](https://jenkins.internal.semmle.com/job/Docs/job/Generate-Sphinx/1373/artifact/target/sphinx/learn-ql/index.html)
* [CodeQL training and variant analysis examples](https://jenkins.internal.semmle.com/job/Docs/job/Generate-Sphinx/1373/artifact/target/sphinx/learn-ql/ql-training.html)
* [Example: Bad overflow guard](http://docteam.internal.semmle.com/felicity/2210/2210-slides/cpp/bad-overflow-guard.html#8) - press `p` to see the notes.
* [Example: Query injection](http://docteam.internal.semmle.com/felicity/2210/2210-slides/java/query-injection-java.html#6) - press `p` to see the notes.
* [Introduction to variant analysis](http://docteam.internal.semmle.com/felicity/2210/2210-slides/cpp/intro-ql-cpp.html#6) - uses the snippet `intro-ql-general.rst`