### PR TITLE
Python: Mitigate CP in `nested_sequence_assign`.

### DIFF
--- a/python/ql/src/semmle/python/Flow.qll
+++ b/python/ql/src/semmle/python/Flow.qll
@@ -910,6 +910,10 @@ private AstNode assigned_value(Expr lhs) {
 
 predicate nested_sequence_assign(Expr left_parent, Expr right_parent,
         Expr left_result, Expr right_result) {
+    exists(Assign a |
+        a.getATarget().getASubExpression*() = left_parent and
+        a.getValue().getASubExpression*() = right_parent
+    ) and
     exists(int i, Expr left_elem, Expr right_elem
     |
         (


### PR DESCRIPTION
The problem here was that in the base case, there was no relationship between
`left_parent` and `right_parent`. These could be any two tuples or lists, even
if they were not part of an assignment statement.

To fix this, we add a bit of manual "magic", requiring that both of these
arguments must belong to the left and right-hand sides of the same assignment
statement.

(Note that this is in principle _still_ a gross overapproximation, but since
assignment statements are usually quite restricted in size, I don't expect this
to be a major problem.)