### PR TITLE
JS: Improve TypeScript memory management and error reporting

### DIFF
--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -163,6 +163,7 @@ function extractFile(filename: string): string {
 function prepareNextFile() {
     if (state.pendingResponse != null) return;
     if (state.pendingFileIndex < state.pendingFiles.length) {
+        checkMemoryUsage();
         let nextFilename = state.pendingFiles[state.pendingFileIndex];
         state.pendingResponse = extractFile(nextFilename);
     }
@@ -538,6 +539,8 @@ let isAboveReloadThreshold = false;
 
 /**
  * If memory usage has moved above a the threshold, reboot the TypeScript compiler instance.
+ *
+ * Make sure to call this only when stdout has been flushed.
  */
 function checkMemoryUsage() {
     let bytesUsed = process.memoryUsage().heapUsed;
@@ -560,7 +563,6 @@ function runReadLineInterface() {
         switch (req.command) {
         case "parse":
             handleParseCommand(req);
-            checkMemoryUsage();
             break;
         case "open-project":
             handleOpenProjectCommand(req);

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -534,8 +534,11 @@ function getEnvironmentVariable<T>(name: string, parse: (x: string) => T, defaul
 
 /**
  * Whether the memory usage was last observed to be above the threshold for restarting the TypeScript compiler.
+ *
+ * This is to prevent repeatedly restarting the compiler if the GC does not immediately bring us below the
+ * threshold again.
  */
-let isAboveReloadThreshold = false;
+let hasReloadedSinceExceedingThreshold = false;
 
 /**
  * If memory usage has moved above a the threshold, reboot the TypeScript compiler instance.
@@ -545,13 +548,13 @@ let isAboveReloadThreshold = false;
 function checkMemoryUsage() {
     let bytesUsed = process.memoryUsage().heapUsed;
     let megabytesUsed = bytesUsed / 1000000;
-    if (!isAboveReloadThreshold && megabytesUsed > reloadMemoryThresholdMb && state.project != null) {
+    if (!hasReloadedSinceExceedingThreshold && megabytesUsed > reloadMemoryThresholdMb && state.project != null) {
         console.warn('Restarting TypeScript compiler due to memory usage');
         state.project.reload();
-        isAboveReloadThreshold = true;
+        hasReloadedSinceExceedingThreshold = true;
     }
-    else if (isAboveReloadThreshold && megabytesUsed < reloadMemoryThresholdMb) {
-        isAboveReloadThreshold = false;
+    else if (hasReloadedSinceExceedingThreshold && megabytesUsed < reloadMemoryThresholdMb) {
+        hasReloadedSinceExceedingThreshold = false;
     }
 }
 

--- a/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
+++ b/javascript/extractor/src/com/semmle/js/parser/TypeScriptParser.java
@@ -262,7 +262,7 @@ public class TypeScriptParser {
     int mainMemoryMb =
         typescriptRam != 0
             ? typescriptRam
-            : getMegabyteCountFromPrefixedEnv(TYPESCRIPT_RAM_SUFFIX, 1000);
+            : getMegabyteCountFromPrefixedEnv(TYPESCRIPT_RAM_SUFFIX, 2000);
     int reserveMemoryMb = getMegabyteCountFromPrefixedEnv(TYPESCRIPT_RAM_RESERVE_SUFFIX, 400);
 
     File parserWrapper = getParserWrapper();


### PR DESCRIPTION
The Node.js process monitors its own memory usage and reboots the TypeScript compiler instance when it runs low on memory (<400 MB left). Previously this could happen while writing to stdout; now we only do it after flushing stdout. This alleviates two problems:
- More memory is available when we reboot the compiler instance.
- If the rebooting fails for some reason, the Java process won't receive an incomplete JSON string.

Also improves the corresponding error handling on the Java side. The log generally contains the information needed to diagnose the problem, but it doesn't hurt for the Java exception to be a bit more descriptive.

Lastly, the default main memory limit is raised to 2 GB to ensure vscode can be extracted with the default memory limit.