### PR TITLE
Python: modernise remaining security files

### DIFF
--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -485,7 +485,8 @@ class ClassValue extends Value {
     /** Whether this class is a legal exception class. 
      *  What constitutes a legal exception class differs between major versions */
     predicate isLegalExceptionType() {
-        not this.isNewStyle() or
+        not this.isNewStyle()
+        or
         this.getASuperType() = ClassValue::baseException()
         or
         major_version() = 2 and this = ClassValue::tuple()

--- a/python/ql/src/semmle/python/security/ClearText.qll
+++ b/python/ql/src/semmle/python/security/ClearText.qll
@@ -43,7 +43,7 @@ module ClearTextLogging {
         PrintSink() {
             exists(CallNode call |
                 call.getAnArg() = this and
-                thePrintFunction().(FunctionObject).getACall() = call
+                call = Value::named("print").getACall()
             )
         }
     }

--- a/python/ql/src/semmle/python/security/Crypto.qll
+++ b/python/ql/src/semmle/python/security/Crypto.qll
@@ -16,8 +16,7 @@ abstract class WeakCryptoSink extends TaintSink {
 module Pycrypto {
 
     ModuleValue cipher(string name) {
-        result = Module::named("Crypto.Cipher").attr(name) and
-        result.isPackage()
+        result = Module::named("Crypto.Cipher").attr(name)
     }
 
     class CipherInstance extends TaintKind {

--- a/python/ql/src/semmle/python/security/Crypto.qll
+++ b/python/ql/src/semmle/python/security/Crypto.qll
@@ -12,7 +12,7 @@ abstract class WeakCryptoSink extends TaintSink {
     }
 }
 
-/** Modeling the 'pycrypto' pacakge https://github.com/dlitz/pycrypto (latest release 2013) */
+/** Modeling the 'pycrypto' package https://github.com/dlitz/pycrypto (latest release 2013) */
 module Pycrypto {
 
     ModuleValue cipher(string name) {

--- a/python/ql/src/semmle/python/security/Exceptions.qll
+++ b/python/ql/src/semmle/python/security/Exceptions.qll
@@ -27,7 +27,7 @@ class ExceptionInfo extends StringKind {
 
 }
 
-/** A class representing sources of information about 
+/** A class representing sources of information about
  * execution state exposed in tracebacks and the like.
  */
 abstract class ErrorInfoSource extends TaintSource {}
@@ -59,9 +59,9 @@ class ExceptionKind extends TaintKind {
 class ExceptionSource extends ErrorInfoSource {
 
     ExceptionSource() {
-        exists(ClassObject cls |
-            cls.isSubclassOf(theExceptionType()) and
-            this.(ControlFlowNode).refersTo(_, cls, _)
+        exists(ClassValue cls |
+            cls.getASuperType() = ClassValue::baseException() and
+            this.(ControlFlowNode).pointsTo().getClass() = cls
         )
         or
         this = any(ExceptStmt s).getName().getAFlowNode()
@@ -116,7 +116,7 @@ class CallToTracebackFunction extends ErrorInfoSource {
     }
 }
 
-/** 
+/**
  * Represents calls to functions in the `traceback` module that return a single
  * string of information about an exception.
  */

--- a/python/ql/src/semmle/python/security/SensitiveData.qll
+++ b/python/ql/src/semmle/python/security/SensitiveData.qll
@@ -166,9 +166,9 @@ module SensitiveData {
 
         SensitiveRequestParameter() {
             this.(CallNode).getFunction().(AttrNode).getName() = "get" and
-            exists(string sensitive |
-                this.(CallNode).getAnArg().refersTo(any(StringObject s | s.getText() = sensitive)) and
-                data = HeuristicNames::getSensitiveDataForName(sensitive)
+            exists(StringValue sensitive |
+                this.(CallNode).getAnArg().pointsTo(sensitive) and
+                data = HeuristicNames::getSensitiveDataForName(sensitive.getText())
             )
         }
 


### PR DESCRIPTION
I considered using `ClassValue.isLegalExceptionType` for the `ExceptionSource` char-pred, but since that included a good deal more things than before, I didn't dare to without exploring the impact. 

I did change it from checking if the class is a subclass of `Exception`, to if it's a subclass of `BaseException`, since that seems like an obvious improvement.