### PR TITLE
C++: Handle constant variable accesses in SimpleRangeAnalysis.qll

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
@@ -96,16 +96,21 @@ private float wideningUpperBounds(ArithmeticType t) {
  * This predicate also handles the case of constant variables initialized in compilation units,
  * which doesn't necessarily have a getValue() result from the extractor.
  */
-private string getValue(Expr e) {
+private string getValue0(Expr e) {
   if exists(e.getValue())
   then result = e.getValue()
   else
     exists(VariableAccess access, Variable v |
       e = access and
       v = access.getTarget() and
-      v.getType().isConst() and
-      result = getValue(v.getAnAssignedValue())
+      v.getUnderlyingType().isConst() and
+      result = getValue0(v.getAnAssignedValue())
     )
+}
+
+private string getValue(Expr e) {
+  result = min(getValue0(e)) and
+  result = max(getValue0(e))
 }
 
 /** Set of expressions which we know how to analyze. */
@@ -382,8 +387,8 @@ private float getTruncatedLowerBounds(Expr expr) {
   then
     // If the expression evaluates to a constant, then there is no
     // need to call getLowerBoundsImpl.
-    if exists(expr.getValue().toFloat())
-    then result = expr.getValue().toFloat()
+    if exists(getValue(expr).toFloat())
+    then result = getValue(expr).toFloat()
     else (
       // Some of the bounds computed by getLowerBoundsImpl might
       // overflow, so we replace invalid bounds with exprMinVal.
@@ -435,8 +440,8 @@ private float getTruncatedUpperBounds(Expr expr) {
   then
     // If the expression evaluates to a constant, then there is no
     // need to call getUpperBoundsImpl.
-    if exists(expr.getValue().toFloat())
-    then result = expr.getValue().toFloat()
+    if exists(getValue(expr).toFloat())
+    then result = getValue(expr).toFloat()
     else (
       // Some of the bounds computed by `getUpperBoundsImpl`
       // might overflow, so we replace invalid bounds with

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
@@ -91,13 +91,30 @@ private float wideningUpperBounds(ArithmeticType t) {
   result = 1.0 / 0.0 // +Inf
 }
 
+/**
+ * Gets the value of the expression `e`, if it is a constant.
+ * This predicate also handles the case of constant variables initialized in compilation units,
+ * which doesn't necessarily have a getValue() result from the extractor.
+ */
+private string getValue(Expr e) {
+  if exists(e.getValue())
+  then result = e.getValue()
+  else
+    exists(VariableAccess access, Variable v |
+      e = access and
+      v = access.getTarget() and
+      v.getType().isConst() and
+      result = getValue(v.getAnAssignedValue())
+    )
+}
+
 /** Set of expressions which we know how to analyze. */
 private predicate analyzableExpr(Expr e) {
   // The type of the expression must be arithmetic. We reuse the logic in
   // `exprMinVal` to check this.
   exists(exprMinVal(e)) and
   (
-    exists(e.getValue().toFloat()) or
+    exists(getValue(e).toFloat()) or
     e instanceof UnaryPlusExpr or
     e instanceof UnaryMinusExpr or
     e instanceof MinExpr or

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
@@ -96,7 +96,7 @@ private float wideningUpperBounds(ArithmeticType t) {
  * This predicate also handles the case of constant variables initialized in compilation units,
  * which doesn't necessarily have a getValue() result from the extractor.
  */
-private string getValue0(Expr e) {
+private string getValue(Expr e) {
   if exists(e.getValue())
   then result = e.getValue()
   else
@@ -104,13 +104,8 @@ private string getValue0(Expr e) {
       e = access and
       v = access.getTarget() and
       v.getUnderlyingType().isConst() and
-      result = getValue0(v.getAnAssignedValue())
+      result = getValue(v.getAnAssignedValue())
     )
-}
-
-private string getValue(Expr e) {
-  result = min(getValue0(e)) and
-  result = max(getValue0(e))
 }
 
 /** Set of expressions which we know how to analyze. */

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/wider_type/test.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/wider_type/test.c
@@ -69,3 +69,10 @@ void test10(int x) {
 		} while (0);
 	}
 }
+
+extern const int const256;
+
+void test11() {
+	short s;
+	for(s = 0; s < const256; ++s) {}
+}

--- a/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/wider_type/test2.c
+++ b/cpp/ql/test/query-tests/Security/CWE/CWE-190/semmle/wider_type/test2.c
@@ -1,0 +1,1 @@
+const int const256 = 256;


### PR DESCRIPTION
The PR fixes #3009. The problem was that a `VariableAccess` to a static const member variable does not have a `getValue()` result, and this meant that `analyzableExpr` in `SimpleRangeAnalysis.qll` wasn't matched for that variable access.

I couldn't verify this problem with a simple qltest, so I assume that this only happens when the initialization happens in a different compilation unit.

Another fix for this problem might be to override `getValue()` in `Access.qll`, but that feels like quite an intrusive change.