### PR TITLE
Replace remaining links to semmle.com in 'docs' directory

### DIFF
--- a/docs/language/global-sphinx-files/_templates/layout.html
+++ b/docs/language/global-sphinx-files/_templates/layout.html
@@ -34,7 +34,7 @@
 <div id="siteBanner">
         <div class="textContainer">
             <div class="logocontainer">
-            <a href="https://semmle.com/" id="Header-logo" class="">
+            <a href="https://help.semmle.com/" id="Header-logo" class="">
                 <svg class="Header-logo-white" width="98" height="20" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                     <defs>
                         <path id="a" d="M0 .149h12.872v18.814H0z"></path>
@@ -102,7 +102,7 @@
         {{super()}}
     </div>
     <div class="privacy">
-            <a target="_blank" href="https://semmle.com/privacy-policy" alt="Privacy policy and tracking preferences" title="Privacy policy and tracking preferences">Privacy policy</a>
+            <a target="_blank" href="https://help.semmle.com/privacy-policy.html" alt="Privacy policy and tracking preferences" title="Privacy policy and tracking preferences">Privacy policy</a>
     </div>
     
 </div>

--- a/docs/language/learn-ql/about-ql.rst
+++ b/docs/language/learn-ql/about-ql.rst
@@ -61,7 +61,7 @@ These topics are discussed in detail in the `QL language handbook <https://help.
 References
 ----------
 
-Academic references available from the `Semmle website <https://semmle.com/publications>`__ also provide an overview of QL and its semantics. Other useful references on database query languages and Datalog:
+Academic references available from the `Semmle website <https://help.semmle.com/publications.html>`__ also provide an overview of QL and its semantics. Other useful references on database query languages and Datalog:
 
 -  `Database theory: Query languages <http://www.lsv.ens-cachan.fr/~segoufin/Papers/Mypapers/DB-chapter.pdf>`__
 -  `Logic Programming and Databases book - Amazon page <http://www.amazon.co.uk/Programming-Databases-Surveys-Computer-Science/dp/3642839541>`__


### PR DESCRIPTION
This pull request is the last part of the changes required in this repository to make help.semmle.com an independent site.

It replaces the remaining links to semmle.com.

For more information, see https://github.com/github/product-documentation/issues/2209 and https://github.com/github/product-documentation/issues/2212