### PR TITLE
Python: ObjectAPI to ValueAPI: DeprecatedSliceMethod

### DIFF
--- a/python/ql/src/Functions/DeprecatedSliceMethod.ql
+++ b/python/ql/src/Functions/DeprecatedSliceMethod.ql
@@ -15,9 +15,9 @@ predicate slice_method_name(string name) {
   name = "__getslice__" or name = "__setslice__" or name = "__delslice__"
 }
 
-from PyFunctionObject f, string meth
+from PythonFunctionValue f, string meth
 
-where f.getFunction().isMethod() and not f.isOverridingMethod() and
+where f.getScope().isMethod() and not f.isOverridingMethod() and
       slice_method_name(meth) and f.getName() = meth
   
       

--- a/python/ql/test/query-tests/Functions/general/DeprecatedSliceMethod.expected
+++ b/python/ql/test/query-tests/Functions/general/DeprecatedSliceMethod.expected
@@ -1,3 +1,3 @@
-| functions_test.py:99:5:99:40 | Function __getslice__ | __getslice__ method has been deprecated since Python 2.0 |
-| functions_test.py:102:5:102:47 | Function __setslice__ | __setslice__ method has been deprecated since Python 2.0 |
-| functions_test.py:105:5:105:40 | Function __delslice__ | __delslice__ method has been deprecated since Python 2.0 |
+| functions_test.py:99:5:99:40 | Function DeprecatedSliceMethods.__getslice__ | __getslice__ method has been deprecated since Python 2.0 |
+| functions_test.py:102:5:102:47 | Function DeprecatedSliceMethods.__setslice__ | __setslice__ method has been deprecated since Python 2.0 |
+| functions_test.py:105:5:105:40 | Function DeprecatedSliceMethods.__delslice__ | __delslice__ method has been deprecated since Python 2.0 |


### PR DESCRIPTION
This PR is part of the Functions modernization effort.