### PR TITLE
docs: Remove GitHub variable

### DIFF
--- a/docs/language/learn-ql/csharp/introduce-libraries-csharp.rst
+++ b/docs/language/learn-ql/csharp/introduce-libraries-csharp.rst
@@ -1,7 +1,7 @@
 CodeQL libraries for C#
 =======================
 
-When you're analyzing a C# program in {{ site.data.variables.product.prodname_dotcom }}, you can make use of the large collection of classes in the CodeQL libraries for C#.
+When you're analyzing a C# program, you can make use of the large collection of classes in the CodeQL libraries for C#.
 
 About the CodeQL libraries for C#
 ---------------------------------


### PR DESCRIPTION
This just corrects an error spotted by @jf205 in a previous pre-migration PR (https://github.com/Semmle/ql/pull/2879#discussion_r390197933)

Note: the diff spuriously indicates I've made a change to the Further reading. I haven't. The only change is removing the GH variable. 