### PR TITLE
Java: Add test case to typeflow qltest.

### DIFF
--- a/java/ql/test/library-tests/typeflow/A.java
+++ b/java/ql/test/library-tests/typeflow/A.java
@@ -70,4 +70,19 @@ public class A extends ArrayList<Long> {
     int i2 = (Integer)x2;
     int j2 = i2;
   }
+
+  public static class C {
+    private Map<String, String> map;
+    public static C empty = new C(Collections.emptyMap());
+    private C(Map<String, String> map) {
+      this.map = map;
+    }
+    public C() {
+      this(new LinkedHashMap<>());
+    }
+    public void put(String k, String v) {
+      map.put(k, v);
+      empty.put(k, v);
+    }
+  }
 }


### PR DESCRIPTION
I encountered a minor shortcoming in TypeFlow, so this just adds it as a test case. Two things are missing for us to get proper type bounds here: support for disjunctive bounds and a bound for `Collections.emptyMap()`. The latter ought to be `java.util.Collections$EmptyMap`, but that type is not generally available without jdk extraction.