### PR TITLE
Docs: Remove some Semmle references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ Before we accept your pull request, we require that you have agreed to our Contr
 
 ## Adding a new query
 
-If you have an idea for a query that you would like to share with other Semmle users, please open a pull request to add it to this repository. 
-Follow the steps below to help other users understand what your query does, and to ensure that your query is consistent with the other Semmle queries.
+If you have an idea for a query that you would like to share with other CodeQL users, please open a pull request to add it to this repository.
+Follow the steps below to help other users understand what your query does, and to ensure that your query is consistent with the other CodeQL queries.
 
 1. **Consult the documentation for query writers**
 
@@ -15,13 +15,13 @@ Follow the steps below to help other users understand what your query does, and 
 
 2. **Format your code correctly**
 
-   All of Semmle's standard queries and libraries are uniformly formatted for clarity and consistency, so we strongly recommend that all contributions follow the same formatting guidelines. If you use CodeQL for VS Code, you can autoformat your query in the [Editor](https://help.semmle.com/codeql/codeql-for-vscode/reference/editor.html#autoformatting). For more information, see the [CodeQL style guide](https://github.com/Semmle/ql/blob/master/docs/ql-style-guide.md).
+   All CodeQL standard queries and libraries are uniformly formatted for clarity and consistency, so we strongly recommend that all contributions follow the same formatting guidelines. If you use CodeQL for VS Code, you can autoformat your query in the [Editor](https://help.semmle.com/codeql/codeql-for-vscode/reference/editor.html#autoformatting). For more information, see the [CodeQL style guide](https://github.com/Semmle/ql/blob/master/docs/ql-style-guide.md).
 
 3. **Make sure your query has the correct metadata**
 
-   Query metadata is used by Semmle's analysis to identify your query and make sure the query results are displayed properly. 
+   Query metadata is used to identify your query and make sure the query results are displayed properly.
    The most important metadata to include are the `@name`, `@description`, and the `@kind`.
-   Other metadata properties (`@precision`, `@severity`, and `@tags`) are usually added after the query has been reviewed by Semmle staff.
+   Other metadata properties (`@precision`, `@severity`, and `@tags`) are usually added after the query has been reviewed by GitHub staff.
    For more information on writing query metadata, see the [Query metadata style guide](https://github.com/Semmle/ql/blob/master/docs/query-metadata-style-guide.md).
 
 4. **Make sure the `select` statement is compatible with the query type**
@@ -39,11 +39,11 @@ Follow the steps below to help other users understand what your query does, and 
      * JavaScript: `ql/javascript/ql/src`
      * Python: `ql/python/ql/src`
 
-   Each language-specific directory contains further subdirectories that group queries based on their `@tags` properties or purpose. Select the appropriate subdirectory for your new query, or create a new one if necessary. 
+   Each language-specific directory contains further subdirectories that group queries based on their `@tags` properties or purpose. Select the appropriate subdirectory for your new query, or create a new one if necessary.
 
 6. **Write a query help file**
 
-   Query help files explain the purpose of your query to other users. Write your query help in a `.qhelp` file and save it in the same directory as your new query. 
+   Query help files explain the purpose of your query to other users. Write your query help in a `.qhelp` file and save it in the same directory as your new query.
    For more information on writing query help, see the [Query help style guide](https://github.com/Semmle/ql/blob/master/docs/query-help-style-guide.md).
 
 7. **Maintain backwards compatibility**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CodeQL
 
-This open source repository contains the standard CodeQL libraries and queries that power [LGTM](https://lgtm.com), and the other products that [Semmle](https://semmle.com) makes available to its customers worldwide.
+This open source repository contains the standard CodeQL libraries and queries that power [LGTM](https://lgtm.com) and the other CodeQL products that [GitHub](https://github.com) makes available to its customers worldwide.
 
 ## How do I learn CodeQL and run queries?
 
@@ -13,4 +13,4 @@ We welcome contributions to our standard library and standard checks. Do you hav
 
 ## License
 
-The code in this repository is licensed under [Apache License 2.0](LICENSE) by [Semmle](https://semmle.com).
+The code in this repository is licensed under [Apache License 2.0](LICENSE) by [GitHub](https://github.com).

--- a/docs/query-metadata-style-guide.md
+++ b/docs/query-metadata-style-guide.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This document outlines the structure of Semmle query files. You should adopt this structure when contributing custom queries to this repository, in order to ensure that new queries are consistent with the standard Semmle queries.
+This document outlines the structure of CodeQL query files. You should adopt this structure when contributing custom queries to this repository, in order to ensure that new queries are consistent with the standard CodeQL queries.
 
 ## Query files (.ql extension)
 
@@ -67,7 +67,7 @@ You must define an `@description` property for your query. This property defines
 
 ### Query ID `@id`
 
-You must specify an `@id` property for your query. It must be unique in the Semmle namespace and should follow the standard Semmle convention. That is, it should begin with the 'language code' for the language that the query analyzes followed by a forward slash. The following language codes are supported:
+You must specify an `@id` property for your query. It must be unique and should follow the standard CodeQL convention. That is, it should begin with the 'language code' for the language that the query analyzes followed by a forward slash. The following language codes are supported:
 
 *   C and C++: `cpp`
 *   C#: `cs`
@@ -105,7 +105,7 @@ Note, `@id` properties should be consistent for queries that highlight the same 
 *   alerts (`@kind problem`)
 *   alerts containing path information (`@kind path-problem`)
 
-Alert queries (`@kind problem` or `path-problem`) support two further properties. These are added by Semmle after the query has been tested, prior to deployment to LGTM. The following information is for reference:
+Alert queries (`@kind problem` or `path-problem`) support two further properties. These are added by GitHub staff after the query has been tested, prior to deployment to LGTM. The following information is for reference:
 
 
 

--- a/javascript/extractor/README.md
+++ b/javascript/extractor/README.md
@@ -6,4 +6,4 @@ The extractor consists of a parser for the latest version of ECMAScript, includi
 
 ## License
 
-Like the LGTM queries, the JavaScript extractor is licensed under [Apache License 2.0](LICENSE) by [Semmle](https://semmle.com). Some code is derived from other projects, whose licenses are noted in other `LICENSE-*.md` files in this folder.
+Like the LGTM queries, the JavaScript extractor is licensed under [Apache License 2.0](LICENSE) by [GitHub](https://github.com). Some code is derived from other projects, whose licenses are noted in other `LICENSE-*.md` files in this folder.


### PR DESCRIPTION
The only Semmle references now left in the public Markdown files are in URLs and in legal text. There are also two Semmle references left in `docs/language/vale-styles/README.md` because I didn't understand them well enough to change them.

@p0 Please let me know if I'm stepping on any legal landmines here. I changed to copyright notices from Semmle to GitHub, but I didn't touch the CLA.