### PR TITLE
JS: Fix cyclic JSON error during TypeScript extraction

### DIFF
--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -107,6 +107,7 @@ function checkCycle(root: any) {
         obj.$cycle_visiting = true;
         for (let k in obj) {
             if (!obj.hasOwnProperty(k)) continue;
+            // Ignore numeric and whitelisted properties.
             if (+k !== +k && !astPropertySet.has(k)) continue;
             if (k === "$cycle_visiting") continue;
             let cycle = visit(obj[k]);

--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -134,7 +134,8 @@ function isBlacklistedProperty(k: string) {
         || k === "symbol" || k === "localSymbol"
         || k === "flowNode" || k === "returnFlowNode" || k === "endFlowNode" || k === "fallthroughFlowNode"
         || k === "nextContainer" || k === "locals"
-        || k === "bindDiagnostics" || k === "bindSuggestionDiagnostics";
+        || k === "bindDiagnostics" || k === "bindSuggestionDiagnostics"
+        || k === "relatedInformation";
 }
 
 /**

--- a/javascript/extractor/src/com/semmle/js/parser/TypeScriptASTConverter.java
+++ b/javascript/extractor/src/com/semmle/js/parser/TypeScriptASTConverter.java
@@ -2,9 +2,7 @@ package com.semmle.js.parser;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -163,10 +161,7 @@ import com.semmle.util.data.IntList;
  */
 public class TypeScriptASTConverter {
   private String source;
-  private final JsonObject nodeFlags;
-  private final JsonObject syntaxKinds;
-  private final Map<Integer, String> nodeFlagMap = new LinkedHashMap<>();
-  private final Map<Integer, String> syntaxKindMap = new LinkedHashMap<>();
+  private final TypeScriptParserMetadata metadata;
   private int[] lineStarts;
 
   private int syntaxKindExtends;
@@ -180,22 +175,9 @@ public class TypeScriptASTConverter {
   private static final Pattern WHITESPACE_END_PAREN =
       Pattern.compile("^" + WHITESPACE_CHAR + "*\\)");
 
-  TypeScriptASTConverter(JsonObject nodeFlags, JsonObject syntaxKinds) {
-    this.nodeFlags = nodeFlags;
-    this.syntaxKinds = syntaxKinds;
-    makeEnumIdMap(nodeFlags, nodeFlagMap);
-    makeEnumIdMap(syntaxKinds, syntaxKindMap);
+  TypeScriptASTConverter(TypeScriptParserMetadata metadata) {
+    this.metadata = metadata;
     this.syntaxKindExtends = getSyntaxKind("ExtendsKeyword");
-  }
-
-  /** Builds a mapping from ID to name given a TypeScript enum object. */
-  private void makeEnumIdMap(JsonObject enumObject, Map<Integer, String> idToName) {
-    for (Map.Entry<String, JsonElement> entry : enumObject.entrySet()) {
-      JsonPrimitive prim = entry.getValue().getAsJsonPrimitive();
-      if (prim.isNumber() && !idToName.containsKey(prim.getAsInt())) {
-        idToName.put(prim.getAsInt(), entry.getKey());
-      }
-    }
   }
 
   /**
@@ -1617,7 +1599,7 @@ public class TypeScriptASTConverter {
   private Node convertMetaProperty(JsonObject node, SourceLocation loc) throws ParseError {
     Position metaStart = loc.getStart();
     String keywordKind =
-        syntaxKinds.get(node.getAsJsonPrimitive("keywordToken").getAsInt() + "").getAsString();
+        metadata.getSyntaxKinds().get(node.getAsJsonPrimitive("keywordToken").getAsInt() + "").getAsString();
     String identifier = keywordKind.equals("ImportKeyword") ? "import" : "new";
     Position metaEnd =
         new Position(
@@ -1995,7 +1977,7 @@ public class TypeScriptASTConverter {
 
   private String getOperator(JsonObject node) throws ParseError {
     int operatorId = node.get("operator").getAsInt();
-    switch (syntaxKindMap.get(operatorId)) {
+    switch (metadata.getSyntaxKindMap().get(operatorId)) {
       case "PlusPlusToken":
         return "++";
       case "MinusMinusToken":
@@ -2219,7 +2201,7 @@ public class TypeScriptASTConverter {
   }
 
   private Node convertTypeOperator(JsonObject node, SourceLocation loc) throws ParseError {
-    String operator = syntaxKinds.get("" + node.get("operator").getAsInt()).getAsString();
+    String operator = metadata.getSyntaxKinds().get("" + node.get("operator").getAsInt()).getAsString();
     if (operator.equals("KeyOfKeyword")) {
       return new UnaryTypeExpr(loc, UnaryTypeExpr.Kind.Keyof, convertChildAsType(node, "type"));
     }
@@ -2537,7 +2519,7 @@ public class TypeScriptASTConverter {
    * <tt>ts.NodeFlags</tt> in enum.
    */
   private boolean hasFlag(JsonObject node, String flagName) {
-    JsonElement flagDescriptor = this.nodeFlags.get(flagName);
+    JsonElement flagDescriptor = this.metadata.getNodeFlags().get(flagName);
     if (flagDescriptor == null) {
       throw new RuntimeException(
           "Incompatible version of TypeScript installed. Missing node flag " + flagName);
@@ -2552,7 +2534,7 @@ public class TypeScriptASTConverter {
 
   /** Gets the numeric value of the syntax kind enum with the given name. */
   private int getSyntaxKind(String syntaxKind) {
-    JsonElement descriptor = this.syntaxKinds.get(syntaxKind);
+    JsonElement descriptor = this.metadata.getSyntaxKinds().get(syntaxKind);
     if (descriptor == null) {
       throw new RuntimeException(
           "Incompatible version of TypeScript installed. Missing syntax kind " + syntaxKind);
@@ -2581,7 +2563,7 @@ public class TypeScriptASTConverter {
     if (node instanceof JsonObject) {
       JsonElement kind = ((JsonObject) node).get("kind");
       if (kind instanceof JsonPrimitive && ((JsonPrimitive) kind).isNumber())
-        return syntaxKindMap.get(kind.getAsInt());
+        return metadata.getSyntaxKindMap().get(kind.getAsInt());
     }
     return null;
   }

--- a/javascript/extractor/src/com/semmle/js/parser/TypeScriptASTConverter.java
+++ b/javascript/extractor/src/com/semmle/js/parser/TypeScriptASTConverter.java
@@ -1599,7 +1599,7 @@ public class TypeScriptASTConverter {
   private Node convertMetaProperty(JsonObject node, SourceLocation loc) throws ParseError {
     Position metaStart = loc.getStart();
     String keywordKind =
-        metadata.getSyntaxKinds().get(node.getAsJsonPrimitive("keywordToken").getAsInt() + "").getAsString();
+        metadata.getSyntaxKindName(node.getAsJsonPrimitive("keywordToken").getAsInt());
     String identifier = keywordKind.equals("ImportKeyword") ? "import" : "new";
     Position metaEnd =
         new Position(
@@ -1977,7 +1977,7 @@ public class TypeScriptASTConverter {
 
   private String getOperator(JsonObject node) throws ParseError {
     int operatorId = node.get("operator").getAsInt();
-    switch (metadata.getSyntaxKindMap().get(operatorId)) {
+    switch (metadata.getSyntaxKindName(operatorId)) {
       case "PlusPlusToken":
         return "++";
       case "MinusMinusToken":
@@ -2201,7 +2201,7 @@ public class TypeScriptASTConverter {
   }
 
   private Node convertTypeOperator(JsonObject node, SourceLocation loc) throws ParseError {
-    String operator = metadata.getSyntaxKinds().get("" + node.get("operator").getAsInt()).getAsString();
+    String operator = metadata.getSyntaxKindName(node.get("operator").getAsInt());
     if (operator.equals("KeyOfKeyword")) {
       return new UnaryTypeExpr(loc, UnaryTypeExpr.Kind.Keyof, convertChildAsType(node, "type"));
     }
@@ -2519,12 +2519,7 @@ public class TypeScriptASTConverter {
    * <tt>ts.NodeFlags</tt> in enum.
    */
   private boolean hasFlag(JsonObject node, String flagName) {
-    JsonElement flagDescriptor = this.metadata.getNodeFlags().get(flagName);
-    if (flagDescriptor == null) {
-      throw new RuntimeException(
-          "Incompatible version of TypeScript installed. Missing node flag " + flagName);
-    }
-    int flagId = flagDescriptor.getAsInt();
+    int flagId = metadata.getNodeFlagId(flagName);
     JsonElement flags = node.get("flags");
     if (flags instanceof JsonPrimitive) {
       return (flags.getAsInt() & flagId) != 0;
@@ -2534,12 +2529,7 @@ public class TypeScriptASTConverter {
 
   /** Gets the numeric value of the syntax kind enum with the given name. */
   private int getSyntaxKind(String syntaxKind) {
-    JsonElement descriptor = this.metadata.getSyntaxKinds().get(syntaxKind);
-    if (descriptor == null) {
-      throw new RuntimeException(
-          "Incompatible version of TypeScript installed. Missing syntax kind " + syntaxKind);
-    }
-    return descriptor.getAsInt();
+    return metadata.getSyntaxKindId(syntaxKind);
   }
 
   /** Check whether a node has a child with a given name. */
@@ -2563,7 +2553,7 @@ public class TypeScriptASTConverter {
     if (node instanceof JsonObject) {
       JsonElement kind = ((JsonObject) node).get("kind");
       if (kind instanceof JsonPrimitive && ((JsonPrimitive) kind).isNumber())
-        return metadata.getSyntaxKindMap().get(kind.getAsInt());
+        return metadata.getSyntaxKindName(kind.getAsInt());
     }
     return null;
   }

--- a/javascript/extractor/src/com/semmle/js/parser/TypeScriptASTConverter.java
+++ b/javascript/extractor/src/com/semmle/js/parser/TypeScriptASTConverter.java
@@ -177,7 +177,7 @@ public class TypeScriptASTConverter {
 
   TypeScriptASTConverter(TypeScriptParserMetadata metadata) {
     this.metadata = metadata;
-    this.syntaxKindExtends = getSyntaxKind("ExtendsKeyword");
+    this.syntaxKindExtends = metadata.getSyntaxKindId("ExtendsKeyword");
   }
 
   /**
@@ -2525,11 +2525,6 @@ public class TypeScriptASTConverter {
       return (flags.getAsInt() & flagId) != 0;
     }
     return false;
-  }
-
-  /** Gets the numeric value of the syntax kind enum with the given name. */
-  private int getSyntaxKind(String syntaxKind) {
-    return metadata.getSyntaxKindId(syntaxKind);
   }
 
   /** Check whether a node has a child with a given name. */

--- a/javascript/extractor/src/com/semmle/js/parser/TypeScriptParserMetadata.java
+++ b/javascript/extractor/src/com/semmle/js/parser/TypeScriptParserMetadata.java
@@ -1,0 +1,67 @@
+package com.semmle.js.parser;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+
+/**
+ * Static data from the TypeScript compiler needed for decoding ASTs.
+ * <p>
+ * AST nodes store their kind and flags as integers, but the meaning of this integer changes
+ * between compiler versions. The metadata contains mappings from integers to logical names
+ * which are stable across versions.
+ */
+public class TypeScriptParserMetadata {
+  private final JsonObject nodeFlags;
+  private final JsonObject syntaxKinds;
+  private final Map<Integer, String> nodeFlagMap = new LinkedHashMap<>();
+  private final Map<Integer, String> syntaxKindMap = new LinkedHashMap<>();
+
+  public TypeScriptParserMetadata(JsonObject metadata) {
+    this.nodeFlags = metadata.get("nodeFlags").getAsJsonObject();
+    this.syntaxKinds = metadata.get("syntaxKinds").getAsJsonObject();
+    makeEnumIdMap(getNodeFlags(), getNodeFlagMap());
+    makeEnumIdMap(getSyntaxKinds(), getSyntaxKindMap());
+  }
+
+  /** Builds a mapping from ID to name given a TypeScript enum object. */
+  private void makeEnumIdMap(JsonObject enumObject, Map<Integer, String> idToName) {
+    for (Map.Entry<String, JsonElement> entry : enumObject.entrySet()) {
+      JsonPrimitive prim = entry.getValue().getAsJsonPrimitive();
+      if (prim.isNumber() && !idToName.containsKey(prim.getAsInt())) {
+        idToName.put(prim.getAsInt(), entry.getKey());
+      }
+    }
+  }
+
+  /**
+   * Returns the <code>NodeFlags</code> enum object from the TypeScript API.
+   */
+  public JsonObject getNodeFlags() {
+    return nodeFlags;
+  }
+
+  /**
+   * Returns the <code>SyntaxKind</code> enum object from the TypeScript API.
+   */
+  public JsonObject getSyntaxKinds() {
+    return syntaxKinds;
+  }
+
+  /**
+   * Returns the mapping from node flag bit to its name.
+   */
+  public Map<Integer, String> getNodeFlagMap() {
+    return nodeFlagMap;
+  }
+
+  /**
+   * Returns the mapping from syntax kind ID to its name.
+   */
+  public Map<Integer, String> getSyntaxKindMap() {
+    return syntaxKindMap;
+  }
+}

--- a/javascript/extractor/src/com/semmle/js/parser/TypeScriptParserMetadata.java
+++ b/javascript/extractor/src/com/semmle/js/parser/TypeScriptParserMetadata.java
@@ -17,14 +17,12 @@ import com.google.gson.JsonPrimitive;
 public class TypeScriptParserMetadata {
   private final JsonObject nodeFlags;
   private final JsonObject syntaxKinds;
-  private final Map<Integer, String> nodeFlagMap = new LinkedHashMap<>();
   private final Map<Integer, String> syntaxKindMap = new LinkedHashMap<>();
 
   public TypeScriptParserMetadata(JsonObject metadata) {
     this.nodeFlags = metadata.get("nodeFlags").getAsJsonObject();
     this.syntaxKinds = metadata.get("syntaxKinds").getAsJsonObject();
-    makeEnumIdMap(getNodeFlags(), getNodeFlagMap());
-    makeEnumIdMap(getSyntaxKinds(), getSyntaxKindMap());
+    makeEnumIdMap(syntaxKinds, syntaxKindMap);
   }
 
   /** Builds a mapping from ID to name given a TypeScript enum object. */
@@ -38,30 +36,41 @@ public class TypeScriptParserMetadata {
   }
 
   /**
-   * Returns the <code>NodeFlags</code> enum object from the TypeScript API.
+   * Returns the logical name associated with syntax kind ID <code>id</code>,
+   * or throws an exception if it does not exist.
    */
-  public JsonObject getNodeFlags() {
-    return nodeFlags;
+  String getSyntaxKindName(int id) {
+    String name = syntaxKindMap.get(id);
+    if (name == null) {
+      throw new RuntimeException(
+          "Incompatible version of TypeScript installed. Missing syntax kind ID " + id);
+    }
+    return name;
   }
 
   /**
-   * Returns the <code>SyntaxKind</code> enum object from the TypeScript API.
+   * Returns the syntax kind ID corresponding to the logical name <code>name</code>,
+   * or throws an exception if it does not exist.
    */
-  public JsonObject getSyntaxKinds() {
-    return syntaxKinds;
+  int getSyntaxKindId(String name) {
+    JsonElement elm = syntaxKinds.get(name);
+    if (elm == null) {
+      throw new RuntimeException(
+          "Incompatible version of TypeScript installed. Missing syntax kind " + name);
+    }
+    return elm.getAsInt();
   }
 
   /**
-   * Returns the mapping from node flag bit to its name.
+   * Returns the NodeFlag ID from the logical name <code>name</code>
+   * or throws an exception if it does not exist.
    */
-  public Map<Integer, String> getNodeFlagMap() {
-    return nodeFlagMap;
-  }
-
-  /**
-   * Returns the mapping from syntax kind ID to its name.
-   */
-  public Map<Integer, String> getSyntaxKindMap() {
-    return syntaxKindMap;
+  int getNodeFlagId(String name) {
+    JsonElement elm = nodeFlags.get(name);
+    if (elm == null) {
+      throw new RuntimeException(
+          "Incompatible version of TypeScript installed. Missing node flag " + name);
+    }
+    return elm.getAsInt();
   }
 }

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/ArrowReturn/options
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/ArrowReturn/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --tolerate-parse-errors

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/ArrowReturn/test.expected
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/ArrowReturn/test.expected
@@ -1,0 +1,2 @@
+| tst.ts:1:1:1:1 | Error: '}' expected. |
+| tst.ts:1:25:1:25 | Error: '{' expected. |

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/ArrowReturn/test.ql
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/ArrowReturn/test.ql
@@ -1,0 +1,4 @@
+import javascript
+
+from JSParseError err
+select err

--- a/javascript/ql/test/library-tests/TypeScript/RegressionTests/ArrowReturn/tst.ts
+++ b/javascript/ql/test/library-tests/TypeScript/RegressionTests/ArrowReturn/tst.ts
@@ -1,0 +1,1 @@
+var fn = (x: number) => return x * 2;


### PR DESCRIPTION
Fixes an extractor crash due to a new cyclic property in the AST.

The first commit just blacklists a new property and adds a test for it.

The second replaces the troublesome blacklist with a whitelist. The whitelist should be easier to maintain as we only need to add new names when we add support for new features.

We also send the `SyntaxKind` and `NodeFlag` enums in a separate command now. Sending it with each parse request was redundant, and it means we don't have to whitelist all their members.