### PR TITLE
Python: Make two tests not depend on minor Python version.

### DIFF
--- a/python/ql/src/Imports/SyntaxError.ql
+++ b/python/ql/src/Imports/SyntaxError.ql
@@ -14,4 +14,4 @@ import python
 
 from SyntaxError error
 where not error instanceof EncodingError
-select error, error.getMessage() + " (in Python " +  major_version() + "." + minor_version() + ")."
+select error, error.getMessage() + " (in Python " +  major_version() + ")."

--- a/python/ql/test/2/query-tests/Imports/syntax_error/SyntaxError.expected
+++ b/python/ql/test/2/query-tests/Imports/syntax_error/SyntaxError.expected
@@ -1,1 +1,1 @@
-| nonsense.py:1:14:1:14 | Syntax Error | Syntax Error (in Python 2.7). |
+| nonsense.py:1:14:1:14 | Syntax Error | Syntax Error (in Python 2). |

--- a/python/ql/test/3/query-tests/Imports/syntax_error/SyntaxError.expected
+++ b/python/ql/test/3/query-tests/Imports/syntax_error/SyntaxError.expected
@@ -1,1 +1,1 @@
-| nonsense.py:1:2:1:2 | Syntax Error | Syntax Error (in Python 3.5). |
+| nonsense.py:1:2:1:2 | Syntax Error | Syntax Error (in Python 3). |

--- a/python/ql/test/query-tests/Imports/unused/options
+++ b/python/ql/test/query-tests/Imports/unused/options
@@ -1,0 +1,1 @@
+semmle-extractor-options: --max-import-depth=0


### PR DESCRIPTION
For syntax errors, we simply report the major version.

For unused imports, we were getting a result for `typing.py` when run under
Python 3.7.3. To prevent this import from being considered, I've set the maximum
import depth to `0`.