### PR TITLE
JS: infer `this` to be `module.exports` in node modules

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/InterProceduralTypeInference.qll
@@ -46,6 +46,19 @@ private class AnalyzedThisInBoundFunction extends AnalyzedThisExpr {
 }
 
 /**
+ * Flow analysis for `this` expressions in node modules.
+ *
+ * These expressions are assumed to refer to the `module.exports` object.
+ */
+private class AnalyzedThisAsModuleExports extends DataFlow::AnalyzedNode, DataFlow::ThisNode {
+  NodeModule m;
+
+  AnalyzedThisAsModuleExports() { m = getBindingContainer() }
+
+  override AbstractValue getALocalValue() { result = TAbstractExportsObject(m) }
+}
+
+/**
  * Flow analysis for `this` expressions inside a function that is instantiated.
  *
  * These expressions are assumed to refer to an instance of that function. Since

--- a/javascript/ql/test/library-tests/ThisExpr/ThisExpr_analyzed.expected
+++ b/javascript/ql/test/library-tests/ThisExpr/ThisExpr_analyzed.expected
@@ -1,4 +1,5 @@
 | module-exports.js:3:1:3:4 | this | file://:0:0:0:0 | indefinite value (call) |
+| module-exports.js:3:1:3:4 | this | module-exports.js:1:1:8:0 | exports object of module module-exports |
 | module-exports.js:4:28:4:31 | this | file://:0:0:0:0 | indefinite value (call) |
 | module-exports.js:4:28:4:31 | this | module-exports.js:1:1:8:0 | exports object of module module-exports |
 | module-exports.js:4:28:4:31 | this | module-exports.js:4:15:4:34 | instance of anonymous function |
@@ -7,7 +8,9 @@
 | module-exports.js:5:35:5:38 | this | module-exports.js:1:1:8:0 | exports object of module module-exports |
 | module-exports.js:5:35:5:38 | this | module-exports.js:5:22:5:41 | instance of anonymous function |
 | module-exports.js:6:21:6:24 | this | file://:0:0:0:0 | indefinite value (call) |
+| module-exports.js:6:21:6:24 | this | module-exports.js:1:1:8:0 | exports object of module module-exports |
 | module-exports.js:7:28:7:31 | this | file://:0:0:0:0 | indefinite value (call) |
+| module-exports.js:7:28:7:31 | this | module-exports.js:1:1:8:0 | exports object of module module-exports |
 | tst.js:4:9:4:12 | this | file://:0:0:0:0 | indefinite value (call) |
 | tst.js:4:9:4:12 | this | tst.js:1:1:11:1 | instance of class C_normal |
 | tst.js:8:15:8:18 | this | file://:0:0:0:0 | indefinite value (call) |

--- a/javascript/ql/test/library-tests/ThisExpr/ThisExpr_analyzed.expected
+++ b/javascript/ql/test/library-tests/ThisExpr/ThisExpr_analyzed.expected
@@ -1,3 +1,13 @@
+| module-exports.js:3:1:3:4 | this | file://:0:0:0:0 | indefinite value (call) |
+| module-exports.js:4:28:4:31 | this | file://:0:0:0:0 | indefinite value (call) |
+| module-exports.js:4:28:4:31 | this | module-exports.js:1:1:8:0 | exports object of module module-exports |
+| module-exports.js:4:28:4:31 | this | module-exports.js:4:15:4:34 | instance of anonymous function |
+| module-exports.js:5:35:5:38 | this | file://:0:0:0:0 | indefinite value (call) |
+| module-exports.js:5:35:5:38 | this | file://:0:0:0:0 | indefinite value (heap) |
+| module-exports.js:5:35:5:38 | this | module-exports.js:1:1:8:0 | exports object of module module-exports |
+| module-exports.js:5:35:5:38 | this | module-exports.js:5:22:5:41 | instance of anonymous function |
+| module-exports.js:6:21:6:24 | this | file://:0:0:0:0 | indefinite value (call) |
+| module-exports.js:7:28:7:31 | this | file://:0:0:0:0 | indefinite value (call) |
 | tst.js:4:9:4:12 | this | file://:0:0:0:0 | indefinite value (call) |
 | tst.js:4:9:4:12 | this | tst.js:1:1:11:1 | instance of class C_normal |
 | tst.js:8:15:8:18 | this | file://:0:0:0:0 | indefinite value (call) |

--- a/javascript/ql/test/library-tests/ThisExpr/getBasicBlock.expected
+++ b/javascript/ql/test/library-tests/ThisExpr/getBasicBlock.expected
@@ -1,5 +1,8 @@
 missingBasicBlock
 basicBlock
+| module-exports.js:1:1:1:0 | this | module-exports.js:1:1:1:0 | entry node of <toplevel> |
+| module-exports.js:4:15:4:14 | this | module-exports.js:4:15:4:14 | entry node of function() { this; } |
+| module-exports.js:5:22:5:21 | this | module-exports.js:5:22:5:21 | entry node of function() { this; } |
 | tst.js:1:1:1:0 | this | tst.js:1:1:1:0 | entry node of <toplevel> |
 | tst.js:1:16:1:15 | this | tst.js:1:16:1:15 | entry node of () {} |
 | tst.js:3:7:3:6 | this | tst.js:3:7:3:6 | entry node of () {\\n   ... ;\\n    } |

--- a/javascript/ql/test/library-tests/ThisExpr/getBinder.expected
+++ b/javascript/ql/test/library-tests/ThisExpr/getBinder.expected
@@ -1,3 +1,5 @@
+| module-exports.js:4:28:4:31 | this | module-exports.js:4:15:4:34 | function() { this; } |
+| module-exports.js:5:35:5:38 | this | module-exports.js:5:22:5:41 | function() { this; } |
 | tst.js:4:9:4:12 | this | tst.js:3:7:5:5 | () {\\n   ... ;\\n    } |
 | tst.js:8:15:8:18 | this | tst.js:7:7:9:5 | () {\\n   ... ;\\n    } |
 | tst.js:17:13:17:16 | this | tst.js:16:10:18:9 | functio ...       } |

--- a/javascript/ql/test/library-tests/ThisExpr/module-exports.js
+++ b/javascript/ql/test/library-tests/ThisExpr/module-exports.js
@@ -1,0 +1,7 @@
+var fs = require('fs');
+
+this;
+exports.foo = function() { this; };
+module.exports.bar = function() { this; };
+exports.baz = () => this;
+module.exports.qux = () => this;


### PR DESCRIPTION
It seems that we forgot to model this case.

```text
$ echo "console.log(this === exports)" > test.js
$ node test.js
true
```