### PR TITLE
JS: Fix perf issue in mayReceiveArgument

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/internal/VariableTypeInference.qll
@@ -697,14 +697,14 @@ abstract private class CallWithAnalyzedParameters extends FunctionWithAnalyzedPa
   }
 
   override predicate mayReceiveArgument(Parameter p) {
-    exists(DataFlow::InvokeNode invk, int argIdx |
-      invk = getAnInvocation() and
-      p = getParameter(argIdx)
-    |
-      exists(invk.getArgument(argIdx))
-      or
-      invk.asExpr().(InvokeExpr).isSpreadArgument([0 .. argIdx])
+    exists(int argIdx |
+      p = getParameter(argIdx) and
+      getAnInvocation().getNumArgument() > argIdx
     )
+    or
+    // All parameters may receive an argument if invoked with a spread argument
+    p = getAParameter() and
+    getAnInvocation().asExpr().(InvokeExpr).isSpreadArgument(_)
   }
 }
 


### PR DESCRIPTION
`mayReceiveArgument` contained a bad join ordering.

Evaluations are spread out a bit:
- [Gecko failing on master](https://git.semmle.com/asger/dist-compare-reports/tree/js/expr-has-no-effect-regression_1584038374619) (compared to an unrelated commit)
- [Gecko succeeding with this commit](https://git.semmle.com/asger/dist-compare-reports/tree/js/expr-has-no-effect-regression_1584038374619)
- [Smoke-test](https://git.semmle.com/asger/dist-compare-reports/tree/js/may-receive-argument-fix_1584073367284)