### PR TITLE
Update link text for remaining links to Python topics

### DIFF
--- a/docs/language/learn-ql/intro-to-data-flow.rst
+++ b/docs/language/learn-ql/intro-to-data-flow.rst
@@ -17,7 +17,7 @@ See the following tutorials for more information about analyzing data flow in sp
 - :doc:`Analyzing data flow in C# <csharp/dataflow>`
 - :doc:`Analyzing data flow in Java <java/dataflow>`
 - :doc:`Analyzing data flow in JavaScript/TypeScript <javascript/dataflow>`
-- :doc:`Taint tracking and data flow analysis in Python <python/taint-tracking>`
+- :doc:`Analyzing data flow and tracking tainted data in Python <python/taint-tracking>`
 
 .. pull-quote::
 

--- a/docs/language/learn-ql/writing-queries/path-queries.rst
+++ b/docs/language/learn-ql/writing-queries/path-queries.rst
@@ -24,7 +24,7 @@ For more language-specific information on analyzing data flow, see:
 - :doc:`Analyzing data flow in C# <../csharp/dataflow>`
 - :doc:`Analyzing data flow in Java <../java/dataflow>` 
 - :doc:`Analyzing data flow in JavaScript/TypeScript <../javascript/dataflow>`
-- :doc:`Taint tracking and data flow analysis in Python <../python/taint-tracking>`
+- :doc:`Analyzing data flow and tracking tainted data in Python <../python/taint-tracking>`
 
 Path query examples
 *******************


### PR DESCRIPTION
This updates the link text for links from other topics to the Python topics that were renamed in https://github.com/Semmle/ql/pull/2823. These appear to be the only two links in this repository.