### PR TITLE
Dataflow: Exclude param-param flow through with identical params.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -2088,6 +2088,8 @@ private class SummaryCtxSome extends SummaryCtx, TSummaryCtxSome {
 
   SummaryCtxSome() { this = TSummaryCtxSome(p, ap) }
 
+  int getParameterPos() { p.isParameterOf(_, result) }
+
   override string toString() { result = p + ": " + ap }
 
   predicate hasLocationInfo(
@@ -2481,13 +2483,15 @@ pragma[nomagic]
 private predicate paramFlowsThrough(
   ReturnKindExt kind, CallContextCall cc, SummaryCtxSome sc, AccessPath ap, Configuration config
 ) {
-  exists(PathNodeMid mid, ReturnNodeExt ret |
+  exists(PathNodeMid mid, ReturnNodeExt ret, int pos |
     mid.getNode() = ret and
     kind = ret.getKind() and
     cc = mid.getCallContext() and
     sc = mid.getSummaryCtx() and
     config = mid.getConfiguration() and
-    ap = mid.getAp()
+    ap = mid.getAp() and
+    pos = sc.getParameterPos() and
+    not kind.(ParamUpdateReturnKind).getPosition() = pos
   )
 }
 


### PR DESCRIPTION
This is a heuristic that we have been generally enforcing (and still enforce elsewhere in the lib), but it was accidentally dropped here in #2631.  (Detecting something as a setter that writes a particular argument to a field of itself is unlikely to be real flow).