### PR TITLE
C++: Fix getValue in SimpleRangeAnalysis

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
@@ -93,24 +93,23 @@ private float wideningUpperBounds(ArithmeticType t) {
 
 /**
  * Gets the value of the expression `e`, if it is a constant.
- * This predicate also handles the case of constant variables initialized in compilation units,
- * which doesn't necessarily have a getValue() result from the extractor.
+ * This predicate also handles the case of constant variables initialized in different
+ * compilation units, which doesn't necessarily have a getValue() result from the extractor.
  */
 private string getValue(Expr e) {
   if exists(e.getValue())
   then result = e.getValue()
   else
-    exists(VariableAccess access, Variable v |
-      /*
-       * It should be safe to propagate the initialization value to a variable if:
-       * The type of v is const, and
-       * The type of v is not volatile, and
-       * Either:
-       *   v is a local/global variable, or
-       *   v is a static member variable
-       */
+    /*
+     * It should be safe to propagate the initialization value to a variable if:
+     * The type of v is const, and
+     * The type of v is not volatile, and
+     * Either:
+     *   v is a local/global variable, or
+     *   v is a static member variable
+     */
 
-      (v instanceof StaticStorageDurationVariable or v instanceof LocalVariable) and
+    exists(VariableAccess access, StaticStorageDurationVariable v |
       not v.getUnderlyingType().isVolatile() and
       v.getUnderlyingType().isConst() and
       e = access and

--- a/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/rangeanalysis/SimpleRangeAnalysis.qll
@@ -101,9 +101,20 @@ private string getValue(Expr e) {
   then result = e.getValue()
   else
     exists(VariableAccess access, Variable v |
+      /*
+       * It should be safe to propagate the initialization value to a variable if:
+       * The type of v is const, and
+       * The type of v is not volatile, and
+       * Either:
+       *   v is a local/global variable, or
+       *   v is a static member variable
+       */
+
+      (v instanceof StaticStorageDurationVariable or v instanceof LocalVariable) and
+      not v.getUnderlyingType().isVolatile() and
+      v.getUnderlyingType().isConst() and
       e = access and
       v = access.getTarget() and
-      v.getUnderlyingType().isConst() and
       result = getValue(v.getAnAssignedValue())
     )
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.cpp
@@ -1,0 +1,29 @@
+void func_with_default_arg(const int n = 0) {
+    if(n <= 10) {} // GOOD [FALSE POSITIVE]
+}
+
+struct A {
+    const int int_member = 0;
+    A(int n) : int_member(n) {
+        if(int_member <= 10) {
+                    
+        }
+    }
+};
+
+struct B {
+    B(const int n = 0) {
+        if(n <= 10) {} // GOOD [FALSE POSITIVE]
+    }
+};
+
+const volatile int volatile_const_global = 0;
+
+void test1() {
+    func_with_default_arg(100);
+
+    A a(100);
+    if(a.int_member <= 10) {}
+
+    if(volatile_const_global <= 10) {} // GOOD [FALSE POSITIVE]
+}

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.cpp
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.cpp
@@ -1,5 +1,5 @@
 void func_with_default_arg(const int n = 0) {
-    if(n <= 10) {} // GOOD [FALSE POSITIVE]
+    if(n <= 10) {}
 }
 
 struct A {
@@ -13,7 +13,7 @@ struct A {
 
 struct B {
     B(const int n = 0) {
-        if(n <= 10) {} // GOOD [FALSE POSITIVE]
+        if(n <= 10) {}
     }
 };
 
@@ -25,5 +25,5 @@ void test1() {
     A a(100);
     if(a.int_member <= 10) {}
 
-    if(volatile_const_global <= 10) {} // GOOD [FALSE POSITIVE]
+    if(volatile_const_global <= 10) {}
 }

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.expected
@@ -38,5 +38,8 @@
 | PointlessComparison.c:303:9:303:14 | ... >= ... | Comparison is always false because c <= 0. |
 | PointlessComparison.c:312:9:312:14 | ... >= ... | Comparison is always false because c <= 0. |
 | PointlessComparison.c:337:14:337:21 | ... >= ... | Comparison is always true because x >= 0. |
+| PointlessComparison.cpp:2:8:2:14 | ... <= ... | Comparison is always true because n <= 0. |
+| PointlessComparison.cpp:16:12:16:18 | ... <= ... | Comparison is always true because n <= 0. |
+| PointlessComparison.cpp:28:8:28:34 | ... <= ... | Comparison is always true because volatile_const_global <= 0. |
 | RegressionTests.cpp:57:7:57:22 | ... <= ... | Comparison is always true because * ... <= 4294967295. |
 | Templates.cpp:9:10:9:24 | ... <= ... | Comparison is always true because local <= 32767. |

--- a/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.expected
+++ b/cpp/ql/test/query-tests/Likely Bugs/Arithmetic/PointlessComparison/PointlessComparison.expected
@@ -38,8 +38,5 @@
 | PointlessComparison.c:303:9:303:14 | ... >= ... | Comparison is always false because c <= 0. |
 | PointlessComparison.c:312:9:312:14 | ... >= ... | Comparison is always false because c <= 0. |
 | PointlessComparison.c:337:14:337:21 | ... >= ... | Comparison is always true because x >= 0. |
-| PointlessComparison.cpp:2:8:2:14 | ... <= ... | Comparison is always true because n <= 0. |
-| PointlessComparison.cpp:16:12:16:18 | ... <= ... | Comparison is always true because n <= 0. |
-| PointlessComparison.cpp:28:8:28:34 | ... <= ... | Comparison is always true because volatile_const_global <= 0. |
 | RegressionTests.cpp:57:7:57:22 | ... <= ... | Comparison is always true because * ... <= 4294967295. |
 | Templates.cpp:9:10:9:24 | ... <= ... | Comparison is always true because local <= 32767. |


### PR DESCRIPTION
The fix in https://github.com/Semmle/ql/pull/3026 failed to consider initialization of `const` variables in parameter lists. Because of this some queries incorrectly concluded that some variables had constant values, even though that was not the case.

This PR fixes the problem by identifying the positive cases where we know it's safe to propagate the initialization value.