### PR TITLE
JS: Don't report TypeScript diagnostics by default

### DIFF
--- a/javascript/extractor/lib/typescript/src/main.ts
+++ b/javascript/extractor/lib/typescript/src/main.ts
@@ -422,8 +422,10 @@ function handleOpenProjectCommand(command: OpenProjectCommand) {
     let program = project.program;
     let typeChecker = program.getTypeChecker();
 
-    let diagnostics = program.getSemanticDiagnostics()
-        .filter(d => d.category === ts.DiagnosticCategory.Error);
+    let shouldReportDiagnostics = getEnvironmentVariable("SEMMLE_TYPESCRIPT_REPORT_DIAGNOSTICS", Boolean, false);
+    let diagnostics = shouldReportDiagnostics
+        ? program.getSemanticDiagnostics().filter(d => d.category === ts.DiagnosticCategory.Error)
+        : [];
     if (diagnostics.length > 0) {
         console.warn('TypeScript: reported ' + diagnostics.length + ' semantic errors.');
     }


### PR DESCRIPTION
A while ago I made the TypeScript extractor report semantic errors found by the TypeScript compiler, wrongly assuming this would be cheap as the compiler had to compute type information anyway.

For vscode this increased extraction time by ~13% (from 838s to 947s), which I think is a bit much for some diagnostics information.

This hides it behind an internal flag as it's sometimes useful when diagnosing dependency installation.
(The flag name uses the old `SEMMLE_` prefix as it's internal anyway).