### PR TITLE
Add execve to CommandExecution

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/security/CommandExecution.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/CommandExecution.qll
@@ -99,6 +99,8 @@ class ArrayExecFunctionCall extends FunctionCall {
     getTarget().hasGlobalName("execv") or
     getTarget().hasGlobalName("execvp") or
     getTarget().hasGlobalName("execvpe") or
+    getTarget().hasGlobalName("execve") or
+    getTarget().hasGlobalName("fexecve") or
     // Windows variants
     getTarget().hasGlobalName("_execv") or
     getTarget().hasGlobalName("_execve") or


### PR DESCRIPTION
Not sure why this was left out initially, perhaps there is something I am overlooking? I think `posix_spawn` could be added for more coverage too. But it has a slightly different argument pattern than exists already, nevertheless easy to implement.