### PR TITLE
JS: add isRelevant(succ) to flowStep predicate

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -1106,6 +1106,7 @@ private predicate flowStep(
     // Flow into higher-order call
     flowIntoHigherOrderCall(pred, succ, cfg, summary)
   ) and
+  isRelevant(succ, cfg) and
   not cfg.isBarrier(succ) and
   not isBarrierEdge(cfg, pred, succ) and
   not isLabeledBarrierEdge(cfg, pred, succ, summary.getEndLabel()) and


### PR DESCRIPTION
While evaluating https://github.com/Semmle/ql/pull/3019 I found a weird performance regression in the `sqlteaching` benchmark that was most notable with the `js/insecure-randomness` query.  
It ran about 3 times slower than on master. 

Turns out that all I needed to trigger the performance regression was to add 3 edges to the exploratory flow (the `exploratoryFlowStep` predicate), corresponding to 3 calls to `array.filter()`.  
Adding those 3 edges caused the exploratory flow to find ~200.000 data-flow nodes, instead of 44, which caused the query to run 3 times slower.  
I only needed to add the edges in the exploratory flow to trigger the regression, and nowhere else.

But most of the extra time was not spend in the exploratory flow, so it seemed there was room for improvement. 

With this one line change most, but not all, of the performance was regained. 
(Performance went from about 245 seconds to about 95 seconds)


And the change seems to improve performance across all benchmarks (big evaluation pending). 

Here are two small evaluations on some benchmarks: 
https://git.semmle.com/erik/dist-compare-reports/tree/profiling-js-max.northeurope.cloudapp.azure.com_1584361183161
https://git.semmle.com/erik/dist-compare-reports/tree/profiling-js-asger.northeurope.cloudapp.azure.com_1584356931002