### PR TITLE
CodeQL docs: tidy up a few links

### DIFF
--- a/docs/language/learn-ql/csharp/introduce-libraries-csharp.rst
+++ b/docs/language/learn-ql/csharp/introduce-libraries-csharp.rst
@@ -1122,6 +1122,6 @@ Here is the fixed version:
 Further reading
 ---------------
 
--  Visit :doc:`Tutorial: Analyzing data flow in C# <dataflow>` to learn more about writing queries using the standard data flow and taint tracking libraries.
+-  Visit :doc:`Analyzing data flow in C# <dataflow>` to learn more about writing queries using the standard data flow and taint tracking libraries.
 -  Find out more about QL in the `QL language handbook <https://help.semmle.com/QL/ql-handbook/index.html>`__ and `QL language specification <https://help.semmle.com/QL/ql-spec/language.html>`__.
 -  Learn more about the query console in `Using the query console <https://lgtm.com/help/lgtm/using-query-console>`__.

--- a/docs/language/learn-ql/csharp/ql-for-csharp.rst
+++ b/docs/language/learn-ql/csharp/ql-for-csharp.rst
@@ -20,7 +20,7 @@ These topics provide an overview of the CodeQL libraries for C# and show example
 
    <!-- Working with generic types and methods(generics) - how to query generic types and methods. -->
 
--  :doc:`Tutorial: Analyzing data flow in C# <dataflow>` demonstrates how to write queries using the standard data flow and taint tracking libraries for C#.
+-  :doc:`Analyzing data flow in C# <dataflow>` demonstrates how to write queries using the standard data flow and taint tracking libraries for C#.
 
 
 Other resources

--- a/docs/language/learn-ql/java/ql-for-java.rst
+++ b/docs/language/learn-ql/java/ql-for-java.rst
@@ -21,21 +21,21 @@ These topics provide an overview of the CodeQL libraries for Java and show examp
 
 -  `Basic Java query <https://lgtm.com/help/lgtm/console/ql-java-basic-example>`__ describes how to write and run queries using LGTM.
 
--  :doc:`Introducing the CodeQL libraries for Java <introduce-libraries-java>` introduces the standard libraries used to write queries for Java code.
+-  :doc:`CodeQL libraries for Java <introduce-libraries-java>` introduces the standard libraries used to write queries for Java code.
 
--  :doc:`Tutorial: Analyzing data flow in Java <dataflow>` demonstrates how to write queries using the standard data flow and taint tracking libraries for Java.
+-  :doc:`Analyzing data flow in Java <dataflow>` demonstrates how to write queries using the standard data flow and taint tracking libraries for Java.
 
--  :doc:`Tutorial: Types and the class hierarchy <types-class-hierarchy>` introduces the classes for representing a program's class hierarchy by means of examples.
+-  :doc:`Types in Java <types-class-hierarchy>` introduces the classes for representing a program's class hierarchy by means of examples.
 
--  :doc:`Tutorial: Expressions and statements <expressions-statements>` introduces the classes for representing a program's syntactic structure by means of examples.
+-  :doc:`Expressions and statements in Java <expressions-statements>` introduces the classes for representing a program's syntactic structure by means of examples.
 
--  :doc:`Tutorial: Navigating the call graph <call-graph>` is a worked example of how to write a query that navigates a program's call graph to find unused methods.
+-  :doc:`Navigating the call graph <call-graph>` is a worked example of how to write a query that navigates a program's call graph to find unused methods.
 
--  :doc:`Tutorial: Annotations <annotations>` introduces the classes for representing annotations by means of examples.
+-  :doc:`Annotations in Java <annotations>` introduces the classes for representing annotations by means of examples.
 
--  :doc:`Tutorial: Javadoc <javadoc>` introduces the classes for representing Javadoc comments by means of examples.
+-  :doc:`Javadoc <javadoc>` introduces the classes for representing Javadoc comments by means of examples.
 
--  :doc:`Tutorial: Working with source locations <source-locations>` is a worked example of how to write a query that uses the location information provided in the database for finding likely bugs.
+-  :doc:`Working with source locations <source-locations>` is a worked example of how to write a query that uses the location information provided in the database for finding likely bugs.
 
 -  :doc:`AST class reference <ast-class-reference>` gives an overview of all AST classes in the standard CodeQL library for Java.
 


### PR DESCRIPTION
Partially fixes https://github.com/github/product-documentation/issues/2280 by updating the last few links to reflect the new article names. Most of the links were in 'CodeQL for X' landing page topics---these pages won't be directly migrated, but I updated the links anyway for completeness.