### PR TITLE
C++: Manual magic in inStaticInitializer

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Variable.qll
+++ b/cpp/ql/src/semmle/code/cpp/Variable.qll
@@ -397,7 +397,7 @@ class StaticStorageDurationVariable extends Variable {
  */
 private predicate runtimeExprInStaticInitializer(Expr e) {
   inStaticInitializer(e) and
-  if e instanceof AggregateLiteral
+  if e instanceof AggregateLiteral // in sync with the cast in `inStaticInitializer`
   then runtimeExprInStaticInitializer(e.getAChild())
   else not e.getFullyConverted().isConstant()
 }
@@ -409,6 +409,8 @@ private predicate runtimeExprInStaticInitializer(Expr e) {
 private predicate inStaticInitializer(Expr e) {
   exists(StaticStorageDurationVariable var | e = var.getInitializer().getExpr())
   or
+  // The cast to `AggregateLiteral` ensures we only compute what'll later be
+  // needed by `runtimeExprInStaticInitializer`.
   inStaticInitializer(e.getParent().(AggregateLiteral))
 }
 

--- a/cpp/ql/src/semmle/code/cpp/Variable.qll
+++ b/cpp/ql/src/semmle/code/cpp/Variable.qll
@@ -402,11 +402,14 @@ private predicate runtimeExprInStaticInitializer(Expr e) {
   else not e.getFullyConverted().isConstant()
 }
 
-/** Holds if `e` is part of the initializer of a `StaticStorageDurationVariable`. */
+/**
+ * Holds if `e` is the initializer of a `StaticStorageDurationVariable`, either
+ * directly or below some top-level `AggregateLiteral`s.
+ */
 private predicate inStaticInitializer(Expr e) {
   exists(StaticStorageDurationVariable var | e = var.getInitializer().getExpr())
   or
-  inStaticInitializer(e.getParent())
+  inStaticInitializer(e.getParent().(AggregateLiteral))
 }
 
 /**


### PR DESCRIPTION
Since `runtimeExprInStaticInitializer` only looks at expressions at the top level of an initializer or directly below some number of top-level aggregate literals, there is no need for `inStaticInitializer` to include expressions strictly below those in the AST.

I tested this on Wireshark, which has very large static initializers, but found no measureable difference in run time. There are some differences in tuple counts and iteration counts, though:

- `inStaticInitializer` changes from 6,241,153 rows (86 iterations) to 5,031,617 rows (7 iterations).
- `runtimeExprInStaticInitializer` changes from 386,350 rows to 4,705 rows.
- `hasDynamicInitialization` has 410 rows both before and after, which suggests that this change does not affect results.

Even though there is no impact on this snapshot at this time, things might look different if/when the restriction on aggregate literals to 100 children is removed in the extractor.