### PR TITLE
Java: Sharpen return type of LambdaExpr.getStmtBody().

### DIFF
--- a/java/ql/src/semmle/code/java/Expr.qll
+++ b/java/ql/src/semmle/code/java/Expr.qll
@@ -1016,7 +1016,7 @@ class LambdaExpr extends FunctionalExpr, @lambdaexpr {
   }
 
   /** Gets the body of this lambda expression, if it is a statement. */
-  Stmt getStmtBody() { hasStmtBody() and result = asMethod().getBody() }
+  Block getStmtBody() { hasStmtBody() and result = asMethod().getBody() }
 
   /** Gets a printable representation of this expression. */
   override string toString() { result = "...->..." }


### PR DESCRIPTION
Fixes https://github.com/Semmle/ql/issues/3104.