### PR TITLE
JS: fix FP in js/superfluous-trailing-arguments related to Function.arguments

### DIFF
--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -80,6 +80,7 @@
 | Use of password hash with insufficient computational effort (`js/insufficient-password-hash`) | Fewer false positive results | This query now recognizes additional cases that do not require secure hashing. |
 | Useless regular-expression character escape (`js/useless-regexp-character-escape`) | Fewer false positive results | This query now distinguishes escapes in strings and regular expression literals. |
 | Identical operands (`js/redundant-operation`) | Fewer results | This query now recognizes cases where the operands change a value using ++/-- expressions. |
+| Superfluous trailing arguments (`js/superfluous-trailing-arguments`) | Fewer results | This query now recognizes cases where a function uses the `Function.arguments` value to process a variable number of parameters. |
 
 ## Changes to libraries
 

--- a/javascript/ql/src/semmle/javascript/Functions.qll
+++ b/javascript/ql/src/semmle/javascript/Functions.qll
@@ -117,7 +117,13 @@ class Function extends @function, Parameterized, TypeParameterized, StmtContaine
   ArgumentsVariable getArgumentsVariable() { result.getFunction() = this }
 
   /** Holds if the body of this function refers to the function's `arguments` variable. */
-  predicate usesArgumentsObject() { exists(getArgumentsVariable().getAnAccess()) }
+  predicate usesArgumentsObject() {
+    exists(getArgumentsVariable().getAnAccess()) or
+    exists(PropAccess read | 
+      read.getBase() = getVariable().getAnAccess() and
+      read.getPropertyName() = "arguments"
+    )
+  }
 
   /**
    * Holds if this function declares a parameter or local variable named `arguments`.

--- a/javascript/ql/src/semmle/javascript/Functions.qll
+++ b/javascript/ql/src/semmle/javascript/Functions.qll
@@ -118,8 +118,9 @@ class Function extends @function, Parameterized, TypeParameterized, StmtContaine
 
   /** Holds if the body of this function refers to the function's `arguments` variable. */
   predicate usesArgumentsObject() {
-    exists(getArgumentsVariable().getAnAccess()) or
-    exists(PropAccess read | 
+    exists(getArgumentsVariable().getAnAccess())
+    or
+    exists(PropAccess read |
       read.getBase() = getVariable().getAnAccess() and
       read.getPropertyName() = "arguments"
     )

--- a/javascript/ql/test/query-tests/LanguageFeatures/SpuriousArguments/tst.js
+++ b/javascript/ql/test/query-tests/LanguageFeatures/SpuriousArguments/tst.js
@@ -120,3 +120,13 @@ parseFloat("123", 10);
 	throwerWithParam(42, 87); // NOT OK
 	throwerIndirect(42); // OK, but still flagged due to complexity
 });
+
+function sum2() {
+	var result = 0;
+	for (var i=0,n=sum2.arguments.length; i<n; ++i)
+		result += sum2.arguments[i];
+	return result;
+}
+
+// OK
+sum2(1, 2, 3);


### PR DESCRIPTION
Fixes [these FPs](https://lgtm.com/projects/g/Adyen/adyen-magento/alerts?id=js%2Fsuperfluous-trailing-arguments&mode=list). 

I chose not to change the `getArgumentsVariable` predicate, as it looked like that would require a large refactoring.