### PR TITLE
JavaScript: Avoid a few bad join orders

### DIFF
--- a/javascript/ql/src/semmle/javascript/Promises.qll
+++ b/javascript/ql/src/semmle/javascript/Promises.qll
@@ -184,6 +184,7 @@ module PromiseTypeTracking {
    * Gets the result from a single step through a promise, from `pred` with tracker `t2` to `result` with tracker `t`.
    * This can be loading a resolved value from a promise, storing a value in a promise, or copying a resolved value from one promise to another.
    */
+  pragma[inline]
   DataFlow::SourceNode promiseStep(
     DataFlow::SourceNode pred, DataFlow::TypeTracker t, DataFlow::TypeTracker t2
   ) {

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -157,10 +157,12 @@ class InvokeNode extends DataFlow::SourceNode {
    * `name` is set to `result`.
    */
   DataFlow::ValueNode getOptionArgument(int i, string name) {
-    exists(ObjectLiteralNode obj |
-      obj.flowsTo(getArgument(i)) and
-      obj.hasPropertyWrite(name, result)
-    )
+    getOptionsArgument(i).hasPropertyWrite(name, result)
+  }
+
+  pragma[noinline]
+  private ObjectLiteralNode getOptionsArgument(int i) {
+    result.flowsTo(getArgument(i))
   }
 
   /** Gets an abstract value representing possible callees of this call site. */

--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -161,9 +161,7 @@ class InvokeNode extends DataFlow::SourceNode {
   }
 
   pragma[noinline]
-  private ObjectLiteralNode getOptionsArgument(int i) {
-    result.flowsTo(getArgument(i))
-  }
+  private ObjectLiteralNode getOptionsArgument(int i) { result.flowsTo(getArgument(i)) }
 
   /** Gets an abstract value representing possible callees of this call site. */
   final AbstractValue getACalleeValue() { result = getCalleeNode().analyze().getAValue() }


### PR DESCRIPTION
These only seem to matter on very large snapshots (for the flow-summary projects where I encountered them I'm working with a roughly gecko-sized one).

Consequently, the [evaluation](https://git.semmle.com/max/dist-compare-reports/blob/master/js/performance-fixes/report.md) on big-apps is not particularly compelling. I had hopes for `gecko-dev`, but that still timed out on `master`; I suspect memory pressure, so I'm trying one last rerun with 16G of heap.