### PR TITLE
Data flow: Remove uses of `Node.getLocation()`.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -809,7 +809,7 @@ private class ReadStoreNodeExt extends CastingNodeExt, TReadStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -833,7 +833,7 @@ private class ReadTaintNode extends NodeExt, TReadTaintNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 
@@ -857,7 +857,7 @@ private class TaintStoreNode extends NodeExt, TTaintStoreNode {
   override predicate hasLocationInfo(
     string filepath, int startline, int startcolumn, int endline, int endcolumn
   ) {
-    arg.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
+    arg.hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
   }
 }
 


### PR DESCRIPTION
In the Go library, `Node` does not have a `getLocation()` predicate, only `hasLocationInfo`. It will be easier to keep the libraries in sync if we use the latter everywhere.