### PR TITLE
JS: more precise charpreds in taint steps

### DIFF
--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -8,7 +8,8 @@ module ArrayTaintTracking {
   /**
    * A taint propagating data flow edge caused by the builtin array functions.
    */
-  private class ArrayFunctionTaintStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
+  private class ArrayFunctionTaintStep extends TaintTracking::AdditionalTaintStep,
+    DataFlow::CallNode {
     ArrayFunctionTaintStep() { arrayFunctionTaintStep(_, _, this) }
 
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {

--- a/javascript/ql/src/semmle/javascript/Arrays.qll
+++ b/javascript/ql/src/semmle/javascript/Arrays.qll
@@ -8,13 +8,11 @@ module ArrayTaintTracking {
   /**
    * A taint propagating data flow edge caused by the builtin array functions.
    */
-  private class ArrayFunctionTaintStep extends TaintTracking::AdditionalTaintStep {
-    DataFlow::CallNode call;
-
-    ArrayFunctionTaintStep() { this = call }
+  private class ArrayFunctionTaintStep extends TaintTracking::AdditionalTaintStep, DataFlow::CallNode {
+    ArrayFunctionTaintStep() { arrayFunctionTaintStep(_, _, this) }
 
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
-      arrayFunctionTaintStep(pred, succ, call)
+      arrayFunctionTaintStep(pred, succ, this)
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/TaintTracking.qll
@@ -229,18 +229,16 @@ module TaintTracking {
    * promises.
    */
   private class HeapTaintStep extends AdditionalTaintStep {
-    HeapTaintStep() {
-      heapStep(_, this)
-    }
+    HeapTaintStep() { heapStep(_, this) }
 
     override predicate step(DataFlow::Node pred, DataFlow::Node succ) {
       heapStep(pred, succ) and succ = this
     }
   }
 
-  /** 
-   * Holds if there is taint propagation through the heap from `pred` to `succ`. 
-   */ 
+  /**
+   * Holds if there is taint propagation through the heap from `pred` to `succ`.
+   */
   private predicate heapStep(DataFlow::Node pred, DataFlow::Node succ) {
     exists(Expr e, Expr f | e = succ.asExpr() and f = pred.asExpr() |
       // arrays with tainted elements and objects with tainted property names are tainted
@@ -398,9 +396,9 @@ module TaintTracking {
     }
   }
 
-  /** 
-   * Holds if taint can propagate from `pred` to `succ` with a step related to string manipulation. 
-   */ 
+  /**
+   * Holds if taint can propagate from `pred` to `succ` with a step related to string manipulation.
+   */
   private predicate stringManipulationStep(DataFlow::Node pred, DataFlow::ValueNode succ) {
     // string operations that propagate taint
     exists(string name | name = succ.getAstNode().(MethodCallExpr).getMethodName() |


### PR DESCRIPTION
I was looking at an output of `.getAQlClass()`, and I got annoyed at the amount of irrelevant classes it returned.

So I decided to make some of the characteristic predicates of taint steps more precise. 

There is the added benefit of a [slight performance increase](https://git.semmle.com/erik/dist-compare-reports/tree/erik-laptop_1585228075504). (Ignore wallclock on the bottom two, I was running it on my laptop). 