### PR TITLE
JS: Context sensitive exploratory flow

### DIFF
--- a/javascript/ql/src/semmle/javascript/AST.qll
+++ b/javascript/ql/src/semmle/javascript/AST.qll
@@ -390,6 +390,16 @@ class StmtContainer extends @stmt_container, ASTNode {
    * See Annex C of the ECMAScript language specification.
    */
   predicate isStrict() { getEnclosingContainer().isStrict() }
+
+  /**
+   * Gets the number of enclosing containers.
+   */
+  cached
+  int getContainerDepth() {
+    this instanceof TopLevel and result = 0
+    or
+    result = 1 + getEnclosingContainer().getContainerDepth()
+  }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Configuration.qll
@@ -754,15 +754,20 @@ private int getContainerDepthFromInputNode(DataFlow::Node nd) {
 
 /**
  * Holds if `nd` is an assignment to a captured variable declared
- * in the function `scope`.
+ * in the given `scope`.
  */
 cached
 private predicate capturedVariableScope(DataFlow::Node nd, DataFlow::Node scope) {
-  exists(SsaExplicitDefinition ssa, LocalVariable v |
+  exists(SsaExplicitDefinition ssa, LocalVariable v, StmtContainer container |
     nd = DataFlow::ssaDefinitionNode(ssa) and
     v = ssa.getSourceVariable() and
     v.isCaptured() and
-    scope = DataFlow::valueNode(v.getADeclaration().getContainer().getFunctionBoundary())
+    container = v.getADeclaration().getContainer().getFunctionBoundary()
+  |
+    scope = DataFlow::valueNode(container)
+    or
+    container instanceof TopLevel and
+    scope = DataFlow::globalAccessPathRootPseudoNode()
   )
 }
 

--- a/javascript/ql/test/library-tests/InterProceduralFlow/TaintTracking.expected
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/TaintTracking.expected
@@ -4,6 +4,8 @@
 | callback.js:16:14:16:21 | "source" | callback.js:13:14:13:14 | x |
 | callback.js:17:15:17:23 | "source2" | callback.js:13:14:13:14 | x |
 | callback.js:27:15:27:23 | "source3" | callback.js:13:14:13:14 | x |
+| captureflow2.js:3:14:3:19 | "src1" | captureflow2.js:13:16:13:18 | b() |
+| captureflow.js:15:14:15:19 | "src1" | captureflow.js:16:12:16:24 | outer(source) |
 | destructuring.js:2:16:2:24 | "tainted" | destructuring.js:5:14:5:20 | tainted |
 | destructuring.js:2:16:2:24 | "tainted" | destructuring.js:9:15:9:22 | tainted2 |
 | destructuring.js:19:15:19:23 | "tainted" | destructuring.js:14:15:14:15 | p |

--- a/javascript/ql/test/library-tests/InterProceduralFlow/captureflow.js
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/captureflow.js
@@ -1,0 +1,18 @@
+import * as dummy from 'dummy';
+
+function outer(x) {
+  var shared;
+  function a() {
+    shared = x;
+  }
+  function b() {
+    return shared + 'blah';
+  }
+  b(null);
+  a();
+  return b();
+}
+var source = "src1";
+var sink = outer(source);
+
+outer(null);

--- a/javascript/ql/test/library-tests/InterProceduralFlow/captureflow2.js
+++ b/javascript/ql/test/library-tests/InterProceduralFlow/captureflow2.js
@@ -1,0 +1,14 @@
+import * as dummy from 'dummy';
+
+var source = "src1";
+var shared;
+a(source);
+function a(x) {
+    shared = x;
+}
+function b() {
+    return shared + 'blah';
+}
+function c() {
+    var sink = b(); // free to return out of b() because context is 'outer'
+}


### PR DESCRIPTION
This changes exploratory flow to respect call/return matching (in practice), but still disregard store/load and flow labels. The call/return matching is slightly more overapproximate in the handling of captured variables than the full flow version, but for performance purposes that's fine.

The forward phase constantly keeps track of a "context", which is either
1. The most recently used parameter, meaning we may not use return steps, but may be used to construct summaries;
2. A function `f`, meaning we may use return steps out of any function nested within `f` (used to model captured variables);
3. A pseudo-node, meaning no call has been entered

We can freely step out of a return if the function we're returning from is more deeply nested than the context. For example:
```js
outer(taint())
function outer(x) { // 'x' has depth 1
  function inner() {
    return x;      // returning from depth 2
  }
  return inner();  // reachable with 'x' as the most recently used parameter
}
```

When we step into a captured variable, the context becomes the enclosing function, allowing flow like:
```js
function outer() {
  var shared;
  function a() {
    shared = taint();
  }
  function b() {
    return shared + 'blah';
  }
  function c() {
    sink(b()); // free to return out of b() because context is 'outer'
  }
}
```

The [evaluation](https://git.semmle.com/asger/dist-compare-reports/tree/js/context-sensitive-pruning-merge_1585061801784) (sorted by tuples [here](https://git.semmle.com/gist/asger/5e6a3bf766a30996b076b47914130378)) is a bit hard to read. I'm a little uncertain about whether it's worth landing this.