### PR TITLE
Data flow: No magic in parameterThroughFlowCand

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -548,6 +548,7 @@ private predicate throughFlowNodeCand(Node node, Configuration config) {
 }
 
 /** Holds if flow may return from `callable`. */
+pragma[nomagic]
 private predicate returnFlowCallableCand(
   DataFlowCallable callable, ReturnKindExt kind, Configuration config
 ) {


### PR DESCRIPTION
Adding implementations of `PostUpdateNode` for IR field flow in C++ (https://github.com/Semmle/ql/pull/3118) revealed a bad join order in `DataFlowImpl::parameterThroughFlowCand` when running on `Wireshark/Wireshark`:

```
[2020-03-27 10:24:07] (4076s) Tuple counts for DataFlowImpl::parameterThroughFlowCand#ff#antijoin_rhs:
                      2981323763 ~0%     {3} r1 = JOIN DataFlowImpl::parameterThroughFlowCand#ff#shared AS L WITH DataFlowUtil::InstructionNode::getEnclosingCallable_dispred#ff_10#join_rhs AS R ON FIRST 1 OUTPUT L.<2>, L.<1>, R.<1>
                      2968445848 ~2%     {4} r2 = JOIN r1 WITH DataFlowImplCommon::Cached::TParamUpdate#2#ff_10#join_rhs AS R ON FIRST 1 OUTPUT r1.<2>, R.<1>, r1.<1>, r1.<0>
                      832264     ~0%     {3} r3 = JOIN r2 WITH project#DataFlowUtil::ParameterNode::isParameterOf_dispred#2#fff AS R ON FIRST 2 OUTPUT r2.<2>, r2.<3>, r2.<0>
                                         return r3
```

The fix is to avoid inlining `returnFlowCallableCand`. I couldn't reproduce the bad join order in C++ without the changes in https://github.com/Semmle/ql/pull/3118, but I figured it'd be good to test the impact of this change `master` in isolation.