### PR TITLE
Mention set literals in handbook

### DIFF
--- a/docs/language/ql-handbook/expressions.rst
+++ b/docs/language/ql-handbook/expressions.rst
@@ -107,7 +107,7 @@ For example, ``[2, 3, 5, 7, 11, 13, 17, 19, 23, 29]`` is a valid set literal exp
 Its values are the first ten prime numbers.
 
 The values of the contained expressions need to be of :ref:`compatible types <type-compatibility>` for a valid set literal expression.
-Specifically, at least one of the set elements has to be of a type that is a supertype of the types of all
+Furthermore, at least one of the set elements has to be of a type that is a supertype of the types of all
 the other contained expressions.
 
 Set literals are supported from release 2.1.0 of the CodeQL CLI, and release 1.24 of LGTM Enterprise.

--- a/docs/language/ql-handbook/expressions.rst
+++ b/docs/language/ql-handbook/expressions.rst
@@ -106,7 +106,7 @@ It consists of a comma-separated collection of expressions that are enclosed in 
 For example, ``[2, 3, 5, 7, 11, 13, 17, 19, 23, 29]`` is a valid set literal expression.
 Its values are the first ten prime numbers.
 
-The values of the contained expressions need to be of compatible types for a valid set literal expression.
+The values of the contained expressions need to be of :ref:`compatible types <type-compatibility>` for a valid set literal expression.
 Specifically, at least one of the set elements has to be of a type that is a supertype of the types of all
 the other contained expressions.
 

--- a/docs/language/ql-handbook/expressions.rst
+++ b/docs/language/ql-handbook/expressions.rst
@@ -115,7 +115,6 @@ Set literals are supported from release 2.1.0 of the CodeQL CLI, and release 1.2
 .. index:: super
 .. _super:
 
-
 Super expressions
 *****************
 

--- a/docs/language/ql-handbook/expressions.rst
+++ b/docs/language/ql-handbook/expressions.rst
@@ -95,8 +95,26 @@ In a valid range, the start and end expression are integers, floats, or dates. I
 is a date, then both must be dates. If one of them is an integer and the other a float, then
 both are treated as floats.
 
+.. index:: setliteral
+.. _setliteral:
+
+Set literal expressions
+***********************
+
+A set literal expression allows the explicit listing of a choice between several values.
+It consists of a comma-separated collection of expressions that are enclosed in brackets (``[`` and ``]``).
+For example, ``[2, 3, 5, 7, 11, 13, 17, 19, 23, 29]`` is a valid set literal expression.
+Its values are the first ten prime numbers.
+
+The values of the contained expressions need to be of compatible types for a valid set literal expression.
+Specifically, at least one of the set elements has to be of a type that is a supertype of the types of all
+the other contained expressions.
+
+Set literals are supported from release 2.1.0 of the CodeQL CLI, and release 1.24 of LGTM Enterprise.
+
 .. index:: super
 .. _super:
+
 
 Super expressions
 *****************


### PR DESCRIPTION
This updates the language handbook to explain the new [set literal](https://github.com/github/codeql-coreql-team/issues/331) language feature.