### PR TITLE
Python: Fix outdated link in `ImportFailure.qhelp`.

### DIFF
--- a/python/ql/src/analysis/ImportFailure.qhelp
+++ b/python/ql/src/analysis/ImportFailure.qhelp
@@ -21,7 +21,7 @@ Ensure that all required modules and packages can be found when running the extr
 </recommendation>
 <references>
 
-<li>Semmle Tutorial: <a href="https://semmle.com/wiki/pages/viewpage.action?pageId=9493108">Basic project creation (Python)</a>.</li>
+<li>Semmle Tutorial: <a href="https://help.semmle.com/codeql/codeql-cli/procedures/create-codeql-database.html">Creating a CodeQL database</a>.</li>
 
 
 </references>


### PR DESCRIPTION
(@felicitymay)

I've updated the link to point to our resources for creating CodeQL databases, as you suggested. 
