### PR TITLE
Docs: Bump supported Go version.

### DIFF
--- a/docs/language/support/versions-compilers.csv
+++ b/docs/language/support/versions-compilers.csv
@@ -9,7 +9,7 @@ Arm Compiler 5 [2]_","``.cpp``, ``.c++``, ``.cxx``, ``.hpp``, ``.hh``, ``.h++``,
 C#,C# up to 8.0. with .NET up to 4.8 [3]_,"Microsoft Visual Studio up to 2019, 
 
 .NET Core up to 3.0","``.sln``, ``.csproj``, ``.cs``, ``.cshtml``, ``.xaml``"
-Go (aka Golang), "Go up to 1.13", "Go 1.11 or more recent", ``.go``
+Go (aka Golang), "Go up to 1.14", "Go 1.11 or more recent", ``.go``
 Java,"Java 6 to 13 [4]_","javac (OpenJDK and Oracle JDK),
 
 Eclipse compiler for Java (ECJ) [5]_",``.java``


### PR DESCRIPTION
cf https://github.com/github/codeql-go/pull/39