### PR TITLE
Add code-scanning suites

### DIFF
--- a/cpp/ql/src/codeql-suites/cpp-code-scanning.qls
+++ b/cpp/ql/src/codeql-suites/cpp-code-scanning.qls
@@ -1,0 +1,4 @@
+- description: Standard Code Scanning queries for C and C++
+- qlpack: codeql-cpp
+- apply: code-scanning-selectors.yml
+  from: codeql-suite-helpers

--- a/csharp/ql/src/codeql-suites/csharp-code-scanning.qls
+++ b/csharp/ql/src/codeql-suites/csharp-code-scanning.qls
@@ -1,0 +1,4 @@
+- description: Standard Code Scanning queries for C#
+- qlpack: codeql-csharp
+- apply: code-scanning-selectors.yml
+  from: codeql-suite-helpers

--- a/java/ql/src/codeql-suites/java-code-scanning.qls
+++ b/java/ql/src/codeql-suites/java-code-scanning.qls
@@ -1,0 +1,4 @@
+- description: Standard Code Scanning queries for Java
+- qlpack: codeql-java
+- apply: code-scanning-selectors.yml
+  from: codeql-suite-helpers

--- a/javascript/ql/src/codeql-suites/javascript-code-scanning.qls
+++ b/javascript/ql/src/codeql-suites/javascript-code-scanning.qls
@@ -1,0 +1,4 @@
+- description: Standard Code Scanning queries for JavaScript
+- qlpack: codeql-javascript
+- apply: code-scanning-selectors.yml
+  from: codeql-suite-helpers

--- a/misc/suite-helpers/code-scanning-selectors.yml
+++ b/misc/suite-helpers/code-scanning-selectors.yml
@@ -1,0 +1,16 @@
+- description: Selectors for selecting the Code-Scanning-relevant queries for a language
+- include:
+    kind:
+    - problem
+    - path-problem
+    precision:
+    - high
+    - very-high
+    problem.severity:
+    - error
+    - warning
+    tags contain:
+    - security
+- exclude:
+    deprecated: //
+

--- a/python/ql/src/codeql-suites/python-code-scanning.qls
+++ b/python/ql/src/codeql-suites/python-code-scanning.qls
@@ -1,0 +1,4 @@
+- description: Standard Code Scanning queries for Python
+- qlpack: codeql-python
+- apply: code-scanning-selectors.yml
+  from: codeql-suite-helpers


### PR DESCRIPTION
These are the suites that'll be run by default for the code-scanning feature.
Also see https://github.com/github/codeql-go/pull/77 which depends on this.