### PR TITLE
JS: improve alert message for js/useless-assignment-to-local

### DIFF
--- a/javascript/ql/src/Declarations/DeadStoreOfLocal.ql
+++ b/javascript/ql/src/Declarations/DeadStoreOfLocal.ql
@@ -29,6 +29,23 @@ predicate deadStoreOfLocal(VarDef vd, PurelyLocalVariable v) {
   not exists(SsaExplicitDefinition ssa | ssa.defines(vd, v))
 }
 
+/**
+ * Holds if there exists another definition of the variable `v` that dominates `dead`. 
+ */ 
+predicate hasDominatingDef(VarDef dead, PurelyLocalVariable v) {
+  exists(VarDef otherDef | not otherDef = dead and otherDef.getAVariable() = v |
+    dead.getBasicBlock().getASuccessor+() = otherDef.getBasicBlock()
+    or
+    exists(ReachableBasicBlock bb, int i, int j |
+      bb = otherDef.getBasicBlock() and bb = dead.getBasicBlock()
+    |
+      bb.defAt(i, v, dead) and
+      bb.defAt(j, v, otherDef) and
+      j > i
+    )
+  )
+}
+
 from VarDef dead, PurelyLocalVariable v, string msg
 where
   deadStoreOfLocal(dead, v) and
@@ -63,7 +80,7 @@ where
   (
     // To avoid confusion about the meaning of "definition" and "declaration" we avoid
     // the term "definition" when the alert location is a variable declaration.
-    if dead instanceof VariableDeclarator
+    if dead instanceof VariableDeclarator and hasDominatingDef(dead, v)
     then msg = "The initial value of " + v.getName() + " is unused, since it is always overwritten."
     else msg = "This definition of " + v.getName() + " is useless, since its value is never read."
   )

--- a/javascript/ql/src/Declarations/DeadStoreOfLocal.ql
+++ b/javascript/ql/src/Declarations/DeadStoreOfLocal.ql
@@ -30,8 +30,8 @@ predicate deadStoreOfLocal(VarDef vd, PurelyLocalVariable v) {
 }
 
 /**
- * Holds if there exists another definition of the variable `v` that dominates `dead`. 
- */ 
+ * Holds if there exists another definition of the variable `v` that dominates `dead`.
+ */
 predicate hasDominatingDef(VarDef dead, PurelyLocalVariable v) {
   exists(VarDef otherDef | not otherDef = dead and otherDef.getAVariable() = v |
     dead.getBasicBlock().getASuccessor+() = otherDef.getBasicBlock()

--- a/javascript/ql/src/Declarations/DeadStoreOfLocal.ql
+++ b/javascript/ql/src/Declarations/DeadStoreOfLocal.ql
@@ -65,7 +65,7 @@ where
     // the term "definition" when the alert location is a variable declaration.
     if
       dead instanceof VariableDeclarator and
-      not exists(SsaImplicitInit init | init.getVariable().getSourceVariable() = v) // the variable is dead at the hoisted implicit initialization. 
+      not exists(SsaImplicitInit init | init.getVariable().getSourceVariable() = v) // the variable is dead at the hoisted implicit initialization.
     then msg = "The initial value of " + v.getName() + " is unused, since it is always overwritten."
     else msg = "The value assigned to " + v.getName() + " here is unused."
   )

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/DeadStoreOfLocal.expected
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/DeadStoreOfLocal.expected
@@ -1,13 +1,13 @@
-| overload.ts:10:12:10:14 | baz | This definition of baz is useless, since its value is never read. |
+| overload.ts:10:12:10:14 | baz | The value assigned to baz here is unused. |
 | tst2.js:26:9:26:14 | x = 23 | The initial value of x is unused, since it is always overwritten. |
-| tst2.js:28:9:28:14 | x = 42 | This definition of x is useless, since its value is never read. |
-| tst3.js:2:1:2:36 | exports ... a: 23 } | This definition of exports is useless, since its value is never read. |
-| tst3b.js:2:18:2:36 | exports = { a: 23 } | This definition of exports is useless, since its value is never read. |
-| tst.js:6:2:6:7 | y = 23 | This definition of y is useless, since its value is never read. |
+| tst2.js:28:9:28:14 | x = 42 | The value assigned to x here is unused. |
+| tst3.js:2:1:2:36 | exports ... a: 23 } | The value assigned to exports here is unused. |
+| tst3b.js:2:18:2:36 | exports = { a: 23 } | The value assigned to exports here is unused. |
+| tst.js:6:2:6:7 | y = 23 | The value assigned to y here is unused. |
 | tst.js:13:6:13:11 | a = 23 | The initial value of a is unused, since it is always overwritten. |
-| tst.js:13:14:13:19 | a = 42 | This definition of a is useless, since its value is never read. |
+| tst.js:13:14:13:19 | a = 42 | The value assigned to a here is unused. |
 | tst.js:45:6:45:11 | x = 23 | The initial value of x is unused, since it is always overwritten. |
 | tst.js:51:6:51:11 | x = 23 | The initial value of x is unused, since it is always overwritten. |
 | tst.js:132:7:132:13 | {x} = o | The initial value of x is unused, since it is always overwritten. |
 | tst.js:162:6:162:14 | [x] = [0] | The initial value of x is unused, since it is always overwritten. |
-| tst.js:172:7:172:17 | nSign = foo | This definition of nSign is useless, since its value is never read. |
+| tst.js:172:7:172:17 | nSign = foo | The value assigned to nSign here is unused. |

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/DeadStoreOfLocal.expected
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/DeadStoreOfLocal.expected
@@ -10,3 +10,4 @@
 | tst.js:51:6:51:11 | x = 23 | The initial value of x is unused, since it is always overwritten. |
 | tst.js:132:7:132:13 | {x} = o | The initial value of x is unused, since it is always overwritten. |
 | tst.js:162:6:162:14 | [x] = [0] | The initial value of x is unused, since it is always overwritten. |
+| tst.js:172:7:172:17 | nSign = foo | This definition of nSign is useless, since its value is never read. |

--- a/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/tst.js
+++ b/javascript/ql/test/query-tests/Declarations/DeadStoreOfLocal/tst.js
@@ -166,3 +166,11 @@ function v() {
 	x;
 	y;
 });
+
+(function() {
+	if (something()) {
+		var nSign = foo;
+	} else {
+		console.log(nSign);
+	}
+})()


### PR DESCRIPTION
Fixes #3165. 

For the below example we would previously report: `The initial value of nSign is unused, since it is always overwritten.`.  
However, the definition of `nSign` is never actually overwritten, and thus the error message is confusing. 

```JavaScript 
(function() {
   if (something()) {
      var nSign = foo(); // the value assigned here is never read
   } else {
      console.log(nSign); // nSign is always undefined here.
   }
})()
```

With this PR a dominating definition must exist for the error message to mention `"overwritten"`.   
The error message defaults to `This definition of nSign is useless, since its value is never read.`, which will now be reported for the above example. 