### PR TITLE
C++: Add a user defined swap function to taint tests.

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -512,3 +512,20 @@
 | taint.cpp:444:7:444:7 | d [post update] | taint.cpp:447:7:447:7 | d |  |
 | taint.cpp:445:2:445:2 | d [post update] | taint.cpp:446:7:446:7 | d |  |
 | taint.cpp:445:2:445:2 | d [post update] | taint.cpp:447:7:447:7 | d |  |
+| taint.cpp:452:16:452:16 | a | taint.cpp:454:10:454:10 | a |  |
+| taint.cpp:452:24:452:24 | b | taint.cpp:455:6:455:6 | b |  |
+| taint.cpp:454:10:454:10 | a | taint.cpp:456:6:456:6 | c |  |
+| taint.cpp:455:6:455:6 | b | taint.cpp:452:16:452:16 | a |  |
+| taint.cpp:455:6:455:6 | b | taint.cpp:455:2:455:6 | ... = ... |  |
+| taint.cpp:456:6:456:6 | c | taint.cpp:452:24:452:24 | b |  |
+| taint.cpp:456:6:456:6 | c | taint.cpp:456:2:456:6 | ... = ... |  |
+| taint.cpp:462:6:462:11 | call to source | taint.cpp:462:2:462:13 | ... = ... |  |
+| taint.cpp:462:6:462:11 | call to source | taint.cpp:465:7:465:7 | x |  |
+| taint.cpp:462:6:462:11 | call to source | taint.cpp:468:7:468:7 | x |  |
+| taint.cpp:462:6:462:11 | call to source | taint.cpp:470:7:470:7 | x |  |
+| taint.cpp:463:6:463:6 | 0 | taint.cpp:463:2:463:6 | ... = ... |  |
+| taint.cpp:463:6:463:6 | 0 | taint.cpp:466:7:466:7 | y |  |
+| taint.cpp:463:6:463:6 | 0 | taint.cpp:468:10:468:10 | y |  |
+| taint.cpp:463:6:463:6 | 0 | taint.cpp:471:7:471:7 | y |  |
+| taint.cpp:468:7:468:7 | ref arg x | taint.cpp:470:7:470:7 | x |  |
+| taint.cpp:468:10:468:10 | ref arg y | taint.cpp:471:7:471:7 | y |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.cpp
@@ -195,7 +195,7 @@ void test_memcpy(int *source) {
 	sink(x);
 }
 
-// --- swap ---
+// --- std::swap ---
 
 namespace std {
 	template<class T> constexpr void swap(T& a, T& b);
@@ -445,4 +445,28 @@ void test_qualifiers()
 	d.setString(strings::source());
 	sink(d); // tainted
 	sink(d.getString()); // tainted
+}
+
+// --- non-standard swap ---
+
+void swop(int &a, int &b)
+{
+	int c = a;
+	a = b;
+	b = c;
+}
+
+void test_swop() {
+	int x, y;
+
+	x = source();
+	y = 0;
+
+	sink(x); // tainted
+	sink(y); // clean
+
+	swop(x, y);
+
+	sink(x); // clean [FALSE POSITIVE]
+	sink(y); // tainted
 }

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -58,3 +58,6 @@
 | taint.cpp:439:10:439:18 | call to getMember | taint.cpp:437:15:437:20 | call to source |
 | taint.cpp:446:7:446:7 | d | taint.cpp:445:14:445:28 | call to source |
 | taint.cpp:447:9:447:17 | call to getString | taint.cpp:445:14:445:28 | call to source |
+| taint.cpp:465:7:465:7 | x | taint.cpp:462:6:462:11 | call to source |
+| taint.cpp:470:7:470:7 | x | taint.cpp:462:6:462:11 | call to source |
+| taint.cpp:471:7:471:7 | y | taint.cpp:462:6:462:11 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -42,3 +42,4 @@
 | taint.cpp:439:10:439:18 | taint.cpp:437:15:437:20 | AST only |
 | taint.cpp:446:7:446:7 | taint.cpp:445:14:445:28 | AST only |
 | taint.cpp:447:9:447:17 | taint.cpp:445:14:445:28 | AST only |
+| taint.cpp:471:7:471:7 | taint.cpp:462:6:462:11 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
@@ -20,3 +20,5 @@
 | taint.cpp:382:7:382:7 | a | taint.cpp:377:23:377:28 | source |
 | taint.cpp:429:7:429:7 | b | taint.cpp:428:13:428:18 | call to source |
 | taint.cpp:430:9:430:14 | member | taint.cpp:428:13:428:18 | call to source |
+| taint.cpp:465:7:465:7 | x | taint.cpp:462:6:462:11 | call to source |
+| taint.cpp:470:7:470:7 | x | taint.cpp:462:6:462:11 | call to source |


### PR DESCRIPTION
Trying to close https://jira.semmle.com/browse/CPP-406, I noticed that a proper test of taint through a _user defined_ swap function was missing.

We still get a false positive in the AST taint tracking (same as for the modelled `std::swap`) - which I think I can tolerate - and the IR taint tracking doesn't seem to follow data through the swap at all.  @rdmarsh2 can you comment on this perhaps?  (I'm not even sure what state the IR taint tracking is supposed to be in)