### PR TITLE
JS: add a "../" removing taint-step for js/path-injection

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPath.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPath.qll
@@ -206,6 +206,14 @@ module TaintedPath {
         dstlabel.isNormalized()
       )
       or
+      // foo.replace(/(\.\.\/)*/, "") and similar
+      exists(DotDotSlashPrefixRemovingReplace call |
+        src = call.getInput() and
+        dst = call.getOutput() and
+        dstlabel.isAbsolute() and // result can be absolute
+        dstlabel.toAbsolute() = srclabel.toAbsolute() // preserves normalization status
+      )
+      or
       // path.join()
       exists(DataFlow::CallNode join, int n |
         join = NodeJSLib::Path::moduleMember("join").getACall()

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPath.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPath.qll
@@ -210,7 +210,7 @@ module TaintedPath {
       exists(DotDotSlashPrefixRemovingReplace call |
         src = call.getInput() and
         dst = call.getOutput() and
-        dstlabel.isAbsolute() and // result can be absolute
+        (srclabel.isNonNormalized() or dstlabel.isAbsolute()) and // if src is normalized, then dst must be absolute (if dst is relative, then dst is sanitized)
         dstlabel.toAbsolute() = srclabel.toAbsolute() // preserves normalization status
       )
       or

--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPath.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPath.qll
@@ -209,9 +209,15 @@ module TaintedPath {
       // foo.replace(/(\.\.\/)*/, "") and similar
       exists(DotDotSlashPrefixRemovingReplace call |
         src = call.getInput() and
-        dst = call.getOutput() and
-        (srclabel.isNonNormalized() or dstlabel.isAbsolute()) and // if src is normalized, then dst must be absolute (if dst is relative, then dst is sanitized)
-        dstlabel.toAbsolute() = srclabel.toAbsolute() // preserves normalization status
+        dst = call.getOutput()
+      |
+        // the 4 possible combinations of normalized + relative for `srclabel`, and the possible values for `dstlabel` in each case.
+        srclabel.isNonNormalized() and srclabel.isRelative() // raw + relative -> any()
+        or
+        srclabel.isNormalized() and srclabel.isAbsolute() and srclabel = dstlabel // normalized + absolute -> normalized + absolute
+        or
+        srclabel.isNonNormalized() and srclabel.isAbsolute() and dstlabel.isAbsolute() // raw + absolute -> raw/normalized + absolute
+        // normalized + relative -> none()
       )
       or
       // path.join()

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -1277,6 +1277,52 @@ nodes
 | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
 | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
 | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:202:50:202:53 | path |
 | normalizedPaths.js:11:7:11:27 | path |
 | normalizedPaths.js:11:7:11:27 | path |
 | normalizedPaths.js:11:7:11:27 | path |
@@ -4385,6 +4431,30 @@ edges
 | TaintedPath.js:173:7:173:48 | path | TaintedPath.js:186:29:186:32 | path |
 | TaintedPath.js:173:7:173:48 | path | TaintedPath.js:186:29:186:32 | path |
 | TaintedPath.js:173:7:173:48 | path | TaintedPath.js:186:29:186:32 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:201:40:201:43 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
+| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
 | TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
 | TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
 | TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
@@ -4561,6 +4631,54 @@ edges
 | TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
 | TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
 | TaintedPath.js:186:29:186:32 | path | TaintedPath.js:186:29:186:57 | path.re ... /g, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
 | normalizedPaths.js:11:7:11:27 | path | normalizedPaths.js:13:19:13:22 | path |
 | normalizedPaths.js:11:7:11:27 | path | normalizedPaths.js:13:19:13:22 | path |
 | normalizedPaths.js:11:7:11:27 | path | normalizedPaths.js:13:19:13:22 | path |
@@ -6391,6 +6509,8 @@ edges
 | TaintedPath.js:184:29:184:53 | path.re ... /g, '') | TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:184:29:184:53 | path.re ... /g, '') | This path depends on $@. | TaintedPath.js:173:24:173:30 | req.url | a user-provided value |
 | TaintedPath.js:185:29:185:51 | path.re ... /g, '') | TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:185:29:185:51 | path.re ... /g, '') | This path depends on $@. | TaintedPath.js:173:24:173:30 | req.url | a user-provided value |
 | TaintedPath.js:186:29:186:57 | path.re ... /g, '') | TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:186:29:186:57 | path.re ... /g, '') | This path depends on $@. | TaintedPath.js:173:24:173:30 | req.url | a user-provided value |
+| TaintedPath.js:201:29:201:73 | "prefix ... +/, '') | TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') | This path depends on $@. | TaintedPath.js:173:24:173:30 | req.url | a user-provided value |
+| TaintedPath.js:202:29:202:84 | pathMod ... +/, '') | TaintedPath.js:173:24:173:30 | req.url | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') | This path depends on $@. | TaintedPath.js:173:24:173:30 | req.url | a user-provided value |
 | normalizedPaths.js:13:19:13:22 | path | normalizedPaths.js:11:14:11:27 | req.query.path | normalizedPaths.js:13:19:13:22 | path | This path depends on $@. | normalizedPaths.js:11:14:11:27 | req.query.path | a user-provided value |
 | normalizedPaths.js:14:19:14:29 | './' + path | normalizedPaths.js:11:14:11:27 | req.query.path | normalizedPaths.js:14:19:14:29 | './' + path | This path depends on $@. | normalizedPaths.js:11:14:11:27 | req.query.path | a user-provided value |
 | normalizedPaths.js:15:19:15:38 | path + '/index.html' | normalizedPaths.js:11:14:11:27 | req.query.path | normalizedPaths.js:15:19:15:38 | path + '/index.html' | This path depends on $@. | normalizedPaths.js:11:14:11:27 | req.query.path | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -1298,10 +1298,10 @@ nodes
 | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
 | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
 | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
-| TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
-| TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
-| TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
-| TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
 | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
 | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
 | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
@@ -1311,14 +1311,6 @@ nodes
 | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
 | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
 | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
-| TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:202:50:202:53 | path |
 | TaintedPath.js:202:50:202:53 | path |
 | TaintedPath.js:202:50:202:53 | path |
 | TaintedPath.js:202:50:202:53 | path |
@@ -4451,14 +4443,6 @@ edges
 | TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
 | TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
 | TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
-| TaintedPath.js:173:7:173:48 | path | TaintedPath.js:202:50:202:53 | path |
 | TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
 | TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
 | TaintedPath.js:173:14:173:37 | url.par ... , true) | TaintedPath.js:173:14:173:43 | url.par ... ).query |
@@ -4667,6 +4651,14 @@ edges
 | TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
 | TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
 | TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
 | TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
 | TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
 | TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
@@ -4675,22 +4667,6 @@ edges
 | TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
 | TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
 | TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
-| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
-| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
-| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
-| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
-| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
-| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
-| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
-| TaintedPath.js:202:29:202:54 | pathMod ... e(path) | TaintedPath.js:202:29:202:84 | pathMod ... +/, '') |
-| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
-| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
-| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
-| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
-| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
-| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
-| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
-| TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
 | TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
 | TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
 | TaintedPath.js:202:50:202:53 | path | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -1294,6 +1294,10 @@ nodes
 | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
 | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
 | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
 | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
 | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
 | TaintedPath.js:202:29:202:54 | pathMod ... e(path) |
@@ -4639,6 +4643,22 @@ edges
 | TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
 | TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
 | TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:43 | path | TaintedPath.js:201:40:201:73 | path.re ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
+| TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
 | TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
 | TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |
 | TaintedPath.js:201:40:201:73 | path.re ... +/, '') | TaintedPath.js:201:29:201:73 | "prefix ... +/, '') |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.js
@@ -191,4 +191,13 @@ var server = http.createServer(function(req, res) {
     res.write(fs.readFileSync(path.replace(/\./g, ''))); // OK
   	res.write(fs.readFileSync(path.replace(/\.\.|BLA/g, ''))); // OK
   }
+
+  // removing of "../" from prefix.
+  res.write(fs.readFileSync("prefix" + pathModule.normalize(path).replace(/^(\.\.[\/\\])+/, ''))); // OK
+  res.write(fs.readFileSync("prefix" + pathModule.normalize(path).replace(/(\.\.[\/\\])+/, ''))); // OK
+  res.write(fs.readFileSync("prefix" + pathModule.normalize(path).replace(/(\.\.\/)+/, ''))); // OK
+  res.write(fs.readFileSync("prefix" + pathModule.normalize(path).replace(/(\.\.\/)*/, ''))); // OK
+
+  res.write(fs.readFileSync("prefix" + path.replace(/^(\.\.[\/\\])+/, ''))); // NOT OK - not normalized
+  res.write(fs.readFileSync(pathModule.normalize(path).replace(/^(\.\.[\/\\])+/, ''))); // NOT OK (can be absolute)
 });


### PR DESCRIPTION
Gets us a TN for the fix in CVE-2017-16107