### PR TITLE
C++/C#: Prevent accidental import of ValueNumberPropertyProvider

### DIFF
--- a/config/identical-files.json
+++ b/config/identical-files.json
@@ -242,6 +242,13 @@
     "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/ValueNumbering.qll",
     "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll"
   ],
+  "C++ IR PrintValueNumbering": [
+    "cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/PrintValueNumbering.qll",
+    "cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/PrintValueNumbering.qll",
+    "cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/PrintValueNumbering.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/PrintValueNumbering.qll",
+    "csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/PrintValueNumbering.qll"
+  ],
   "C++ IR ConstantAnalysis": [
     "cpp/ql/src/semmle/code/cpp/ir/implementation/raw/constant/ConstantAnalysis.qll",
     "cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/constant/ConstantAnalysis.qll",

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/PrintValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/PrintValueNumbering.qll
@@ -1,0 +1,17 @@
+private import internal.ValueNumberingImports
+private import ValueNumbering
+
+/**
+ * Provides additional information about value numbering in IR dumps.
+ */
+class ValueNumberPropertyProvider extends IRPropertyProvider {
+  override string getInstructionProperty(Instruction instr, string key) {
+    exists(ValueNumber vn |
+      vn = valueNumber(instr) and
+      key = "valnum" and
+      if strictcount(vn.getAnInstruction()) > 1
+      then result = vn.getDebugString()
+      else result = "unique"
+    )
+  }
+}

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/gvn/ValueNumbering.qll
@@ -2,21 +2,6 @@ private import internal.ValueNumberingInternal
 private import internal.ValueNumberingImports
 
 /**
- * Provides additional information about value numbering in IR dumps.
- */
-class ValueNumberPropertyProvider extends IRPropertyProvider {
-  override string getInstructionProperty(Instruction instr, string key) {
-    exists(ValueNumber vn |
-      vn = valueNumber(instr) and
-      key = "valnum" and
-      if strictcount(vn.getAnInstruction()) > 1
-      then result = vn.getDebugString()
-      else result = "unique"
-    )
-  }
-}
-
-/**
  * The value number assigned to a particular set of instructions that produce equivalent results.
  */
 class ValueNumber extends TValueNumber {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/PrintValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/PrintValueNumbering.qll
@@ -1,0 +1,17 @@
+private import internal.ValueNumberingImports
+private import ValueNumbering
+
+/**
+ * Provides additional information about value numbering in IR dumps.
+ */
+class ValueNumberPropertyProvider extends IRPropertyProvider {
+  override string getInstructionProperty(Instruction instr, string key) {
+    exists(ValueNumber vn |
+      vn = valueNumber(instr) and
+      key = "valnum" and
+      if strictcount(vn.getAnInstruction()) > 1
+      then result = vn.getDebugString()
+      else result = "unique"
+    )
+  }
+}

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -2,21 +2,6 @@ private import internal.ValueNumberingInternal
 private import internal.ValueNumberingImports
 
 /**
- * Provides additional information about value numbering in IR dumps.
- */
-class ValueNumberPropertyProvider extends IRPropertyProvider {
-  override string getInstructionProperty(Instruction instr, string key) {
-    exists(ValueNumber vn |
-      vn = valueNumber(instr) and
-      key = "valnum" and
-      if strictcount(vn.getAnInstruction()) > 1
-      then result = vn.getDebugString()
-      else result = "unique"
-    )
-  }
-}
-
-/**
  * The value number assigned to a particular set of instructions that produce equivalent results.
  */
 class ValueNumber extends TValueNumber {

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/PrintValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/PrintValueNumbering.qll
@@ -1,0 +1,17 @@
+private import internal.ValueNumberingImports
+private import ValueNumbering
+
+/**
+ * Provides additional information about value numbering in IR dumps.
+ */
+class ValueNumberPropertyProvider extends IRPropertyProvider {
+  override string getInstructionProperty(Instruction instr, string key) {
+    exists(ValueNumber vn |
+      vn = valueNumber(instr) and
+      key = "valnum" and
+      if strictcount(vn.getAnInstruction()) > 1
+      then result = vn.getDebugString()
+      else result = "unique"
+    )
+  }
+}

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -2,21 +2,6 @@ private import internal.ValueNumberingInternal
 private import internal.ValueNumberingImports
 
 /**
- * Provides additional information about value numbering in IR dumps.
- */
-class ValueNumberPropertyProvider extends IRPropertyProvider {
-  override string getInstructionProperty(Instruction instr, string key) {
-    exists(ValueNumber vn |
-      vn = valueNumber(instr) and
-      key = "valnum" and
-      if strictcount(vn.getAnInstruction()) > 1
-      then result = vn.getDebugString()
-      else result = "unique"
-    )
-  }
-}
-
-/**
  * The value number assigned to a particular set of instructions that produce equivalent results.
  */
 class ValueNumber extends TValueNumber {

--- a/cpp/ql/test/library-tests/valuenumbering/GlobalValueNumbering/ir_gvn.ql
+++ b/cpp/ql/test/library-tests/valuenumbering/GlobalValueNumbering/ir_gvn.ql
@@ -5,3 +5,4 @@
 import semmle.code.cpp.ir.PrintIR
 import semmle.code.cpp.ir.IR
 import semmle.code.cpp.ir.ValueNumbering
+import semmle.code.cpp.ir.implementation.aliased_ssa.gvn.PrintValueNumbering

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/PrintValueNumbering.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/PrintValueNumbering.qll
@@ -1,0 +1,17 @@
+private import internal.ValueNumberingImports
+private import ValueNumbering
+
+/**
+ * Provides additional information about value numbering in IR dumps.
+ */
+class ValueNumberPropertyProvider extends IRPropertyProvider {
+  override string getInstructionProperty(Instruction instr, string key) {
+    exists(ValueNumber vn |
+      vn = valueNumber(instr) and
+      key = "valnum" and
+      if strictcount(vn.getAnInstruction()) > 1
+      then result = vn.getDebugString()
+      else result = "unique"
+    )
+  }
+}

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/ValueNumbering.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/gvn/ValueNumbering.qll
@@ -2,21 +2,6 @@ private import internal.ValueNumberingInternal
 private import internal.ValueNumberingImports
 
 /**
- * Provides additional information about value numbering in IR dumps.
- */
-class ValueNumberPropertyProvider extends IRPropertyProvider {
-  override string getInstructionProperty(Instruction instr, string key) {
-    exists(ValueNumber vn |
-      vn = valueNumber(instr) and
-      key = "valnum" and
-      if strictcount(vn.getAnInstruction()) > 1
-      then result = vn.getDebugString()
-      else result = "unique"
-    )
-  }
-}
-
-/**
  * The value number assigned to a particular set of instructions that produce equivalent results.
  */
 class ValueNumber extends TValueNumber {

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/PrintValueNumbering.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/PrintValueNumbering.qll
@@ -1,0 +1,17 @@
+private import internal.ValueNumberingImports
+private import ValueNumbering
+
+/**
+ * Provides additional information about value numbering in IR dumps.
+ */
+class ValueNumberPropertyProvider extends IRPropertyProvider {
+  override string getInstructionProperty(Instruction instr, string key) {
+    exists(ValueNumber vn |
+      vn = valueNumber(instr) and
+      key = "valnum" and
+      if strictcount(vn.getAnInstruction()) > 1
+      then result = vn.getDebugString()
+      else result = "unique"
+    )
+  }
+}

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/gvn/ValueNumbering.qll
@@ -2,21 +2,6 @@ private import internal.ValueNumberingInternal
 private import internal.ValueNumberingImports
 
 /**
- * Provides additional information about value numbering in IR dumps.
- */
-class ValueNumberPropertyProvider extends IRPropertyProvider {
-  override string getInstructionProperty(Instruction instr, string key) {
-    exists(ValueNumber vn |
-      vn = valueNumber(instr) and
-      key = "valnum" and
-      if strictcount(vn.getAnInstruction()) > 1
-      then result = vn.getDebugString()
-      else result = "unique"
-    )
-  }
-}
-
-/**
  * The value number assigned to a particular set of instructions that produce equivalent results.
  */
 class ValueNumber extends TValueNumber {


### PR DESCRIPTION
Up until now, importing the IR ValueNumbering library changed the output of IR dumps since the `ValueNumberPropertyProvider` class was directly implemented in the `ValueNumbering.qll` file. 
So when importing a library that that used value numbering, the `getAdditionalInstructionProperty` predicate in `PrintIR` would find an implementation of the `IRPropertyProvider` class, causing value numbers to be printed.

This PR moves the `ValueNumberPropertyProvider` class into a separate file `PrintValueNumbering.qll` (the name is modelled after `ir/implementation/aliased_ssa/constant/PrintConstantAnalysis.qll`) that can be imported if you wish to include value numbering in the IR dumps.