### PR TITLE
Java/C++/C#: Use `unique` to improve join order fix

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl2.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl3.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImpl4.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowImplLocal.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -43,7 +43,7 @@ class Node extends TNode {
   /**
    * INTERNAL: Do not use. Alternative name for `getFunction`.
    */
-  final Function getEnclosingCallable() { result = unique( | | this.getFunction()) }
+  final Function getEnclosingCallable() { result = unique(Function f | f = this.getFunction() | f) }
 
   /** Gets the type of this node. */
   Type getType() { none() } // overridden in subclasses

--- a/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/dataflow/internal/DataFlowUtil.qll
@@ -43,7 +43,7 @@ class Node extends TNode {
   /**
    * INTERNAL: Do not use. Alternative name for `getFunction`.
    */
-  Function getEnclosingCallable() { result = this.getFunction() }
+  final Function getEnclosingCallable() { result = unique( | | this.getFunction()) }
 
   /** Gets the type of this node. */
   Type getType() { none() } // overridden in subclasses

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl2.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl3.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowImpl4.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl2.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl3.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl4.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
+++ b/csharp/ql/src/semmle/code/csharp/dataflow/internal/DataFlowImpl5.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl2.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl3.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl4.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]

--- a/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
+++ b/java/ql/src/semmle/code/java/dataflow/internal/DataFlowImpl5.qll
@@ -2293,12 +2293,13 @@ private class PathNodeSink extends PathNodeImpl, TPathNodeSink {
  * a callable is recorded by `cc`.
  */
 private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCtx sc, AccessPath ap) {
-  exists(
-    AccessPath ap0, Node midnode, Configuration conf, DataFlowCallable enclosing,
-    LocalCallContext localCC
-  |
-    pathIntoLocalStep(mid, midnode, cc, enclosing, sc, ap0, conf) and
-    localCC = getLocalCallContext(cc, enclosing)
+  exists(AccessPath ap0, Node midnode, Configuration conf, LocalCallContext localCC |
+    midnode = mid.getNode() and
+    conf = mid.getConfiguration() and
+    cc = mid.getCallContext() and
+    sc = mid.getSummaryCtx() and
+    localCC = getLocalCallContext(cc, midnode.getEnclosingCallable()) and
+    ap0 = mid.getAp()
   |
     localFlowBigStep(midnode, node, true, _, conf, localCC) and
     ap = ap0
@@ -2329,20 +2330,6 @@ private predicate pathStep(PathNodeMid mid, Node node, CallContext cc, SummaryCt
   pathOutOfCallable(mid, node, cc) and ap = mid.getAp() and sc instanceof SummaryCtxNone
   or
   pathThroughCallable(mid, node, cc, ap) and sc = mid.getSummaryCtx()
-}
-
-pragma[nomagic]
-private predicate pathIntoLocalStep(
-  PathNodeMid mid, Node midnode, CallContext cc, DataFlowCallable enclosing, SummaryCtx sc,
-  AccessPath ap0, Configuration conf
-) {
-  midnode = mid.getNode() and
-  cc = mid.getCallContext() and
-  conf = mid.getConfiguration() and
-  localFlowBigStep(midnode, _, _, _, conf, _) and
-  enclosing = midnode.getEnclosingCallable() and
-  sc = mid.getSummaryCtx() and
-  ap0 = mid.getAp()
 }
 
 pragma[nomagic]


### PR DESCRIPTION
This PR uses the new `unique` aggregate to replace the join-order fix from #2872, which had a performance overhead for all languages, with a fix that has overhead only for C++ AST.

See the commit messages for an abundance of detail.

**Do not merge** until `unique` has been stable for a while.