### PR TITLE
C++: Fix `cpp/new-free-mismatch` false positives

### DIFF
--- a/change-notes/1.24/analysis-cpp.md
+++ b/change-notes/1.24/analysis-cpp.md
@@ -53,3 +53,4 @@ The following changes in version 1.24 affect C/C++ analysis in all applications.
   * The library now models data flow through formatting functions such as `sprintf`.
 * The security pack taint tracking library (`semmle.code.cpp.security.TaintTracking`) uses a new intermediate representation. This provides a more precise analysis of pointers to stack variables and flow through parameters, improving the results of many security queries.
 * The global value numbering library (`semmle.code.cpp.valuenumbering.GlobalValueNumbering`) uses a new intermediate representation to provide a more precise analysis of heap allocated memory and pointers to stack variables.
+* `freeCall` in `semmle.code.cpp.commons.Alloc` has been deprecated. The`Allocation` and `Deallocation` models in `semmle.code.cpp.models.interfaces` should be used instead.

--- a/cpp/ql/src/Critical/MemoryFreed.qll
+++ b/cpp/ql/src/Critical/MemoryFreed.qll
@@ -4,7 +4,7 @@ private predicate freed(Expr e) {
   e = any(DeallocationExpr de).getFreedExpr()
   or
   exists(ExprCall c |
-    // cautiously assume that any ExprCall could be a freeCall.
+    // cautiously assume that any `ExprCall` could be a deallocation expression.
     c.getAnArgument() = e
   )
 }

--- a/cpp/ql/src/Critical/NewDelete.qll
+++ b/cpp/ql/src/Critical/NewDelete.qll
@@ -14,13 +14,8 @@ import semmle.code.cpp.models.implementations.Deallocation
  */
 predicate allocExpr(Expr alloc, string kind) {
   (
-    alloc.(FunctionCall) instanceof AllocationExpr
-    or
-    alloc = any(NewOrNewArrayExpr new | not exists(new.getPlacementPointer()))
-  ) and
-  (
     exists(Function target |
-      alloc.(FunctionCall).getTarget() = target and
+      alloc.(AllocationExpr).(FunctionCall).getTarget() = target and
       (
         target.getName() = "operator new" and
         kind = "new"

--- a/cpp/ql/src/Critical/NewDelete.qll
+++ b/cpp/ql/src/Critical/NewDelete.qll
@@ -18,10 +18,16 @@ predicate allocExpr(Expr alloc, string kind) {
       alloc.(AllocationExpr).(FunctionCall).getTarget() = target and
       (
         target.getName() = "operator new" and
-        kind = "new"
+        kind = "new" and
+        // exclude placement new and custom overloads as they
+        // may not conform to assumptions
+        not target.getNumberOfParameters() > 1
         or
         target.getName() = "operator new[]" and
-        kind = "new[]"
+        kind = "new[]" and
+        // exclude placement new and custom overloads as they
+        // may not conform to assumptions
+        not target.getNumberOfParameters() > 1
         or
         not target instanceof OperatorNewAllocationFunction and
         kind = "malloc"

--- a/cpp/ql/src/Critical/NewDelete.qll
+++ b/cpp/ql/src/Critical/NewDelete.qll
@@ -5,6 +5,8 @@
 import cpp
 import semmle.code.cpp.controlflow.SSA
 import semmle.code.cpp.dataflow.DataFlow
+import semmle.code.cpp.models.implementations.Allocation
+import semmle.code.cpp.models.implementations.Deallocation
 
 /**
  * Holds if `alloc` is a use of `malloc` or `new`.  `kind` is
@@ -15,6 +17,7 @@ predicate allocExpr(Expr alloc, string kind) {
   not alloc.isFromUninstantiatedTemplate(_) and
   (
     alloc instanceof FunctionCall and
+    not alloc.(FunctionCall).getTarget() instanceof OperatorNewAllocationFunction and
     kind = "malloc"
     or
     alloc instanceof NewExpr and
@@ -111,6 +114,7 @@ predicate allocReaches(Expr e, Expr alloc, string kind) {
  */
 predicate freeExpr(Expr free, Expr freed, string kind) {
   freeCall(free, freed) and
+  not free.(FunctionCall).getTarget() instanceof OperatorDeleteDeallocationFunction and
   kind = "free"
   or
   free.(DeleteExpr).getExpr() = freed and

--- a/cpp/ql/src/Critical/NewDelete.qll
+++ b/cpp/ql/src/Critical/NewDelete.qll
@@ -16,9 +16,19 @@ predicate allocExpr(Expr alloc, string kind) {
   isAllocationExpr(alloc) and
   not alloc.isFromUninstantiatedTemplate(_) and
   (
-    alloc instanceof FunctionCall and
-    not alloc.(FunctionCall).getTarget() instanceof OperatorNewAllocationFunction and
-    kind = "malloc"
+    exists(Function target |
+      alloc.(FunctionCall).getTarget() = target and
+      (
+        target.getName() = "operator new" and
+        kind = "new"
+        or
+        target.getName() = "operator new[]" and
+        kind = "new[]"
+        or
+        not target instanceof OperatorNewAllocationFunction and
+        kind = "malloc"
+      )
+    )
     or
     alloc instanceof NewExpr and
     kind = "new" and
@@ -113,9 +123,20 @@ predicate allocReaches(Expr e, Expr alloc, string kind) {
  * describing the type of that free or delete.
  */
 predicate freeExpr(Expr free, Expr freed, string kind) {
-  freeCall(free, freed) and
-  not free.(FunctionCall).getTarget() instanceof OperatorDeleteDeallocationFunction and
-  kind = "free"
+  exists(Function target |
+    freeCall(free, freed) and
+    free.(FunctionCall).getTarget() = target and
+    (
+      target.getName() = "operator delete" and
+      kind = "delete"
+      or
+      target.getName() = "operator delete[]" and
+      kind = "delete[]"
+      or
+      not target instanceof OperatorDeleteDeallocationFunction and
+      kind = "free"
+    )
+  )
   or
   free.(DeleteExpr).getExpr() = freed and
   kind = "delete"

--- a/cpp/ql/src/semmle/code/cpp/commons/Alloc.qll
+++ b/cpp/ql/src/semmle/code/cpp/commons/Alloc.qll
@@ -23,6 +23,8 @@ predicate freeFunction(Function f, int argNum) { argNum = f.(DeallocationFunctio
 
 /**
  * A call to a library routine that frees memory.
+ *
+ * DEPRECATED: Use `DeallocationExpr` instead (this also includes `delete` expressions).
  */
 predicate freeCall(FunctionCall fc, Expr arg) { arg = fc.(DeallocationExpr).getFreedExpr() }
 

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
@@ -1,4 +1,10 @@
-import semmle.code.cpp.models.interfaces.Allocation
+/**
+ * Provides implementation classes modelling various methods of allocation
+ * (`malloc`, `new` etc). See `semmle.code.cpp.models.interfaces.Allocation`
+ * for usage information.
+ */
+
+ import semmle.code.cpp.models.interfaces.Allocation
 
 /**
  * An allocation function (such as `malloc`) that has an argument for the size

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
@@ -4,7 +4,7 @@
  * for usage information.
  */
 
- import semmle.code.cpp.models.interfaces.Allocation
+import semmle.code.cpp.models.interfaces.Allocation
 
 /**
  * An allocation function (such as `malloc`) that has an argument for the size

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Deallocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Deallocation.qll
@@ -4,7 +4,7 @@
  * for usage information.
  */
 
-import semmle.code.cpp.models.interfaces.Allocation
+import semmle.code.cpp.models.interfaces.Deallocation
 
 /**
  * A deallocation function such as `free`.

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Deallocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Deallocation.qll
@@ -4,7 +4,7 @@
  * for usage information.
  */
 
- import semmle.code.cpp.models.interfaces.Allocation
+import semmle.code.cpp.models.interfaces.Allocation
 
 /**
  * A deallocation function such as `free`.

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Deallocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Deallocation.qll
@@ -1,4 +1,10 @@
-import semmle.code.cpp.models.interfaces.Allocation
+/**
+ * Provides implementation classes  modelling various methods of deallocation
+ * (`free`, `delete` etc). See `semmle.code.cpp.models.interfaces.Deallocation`
+ * for usage information.
+ */
+
+ import semmle.code.cpp.models.interfaces.Allocation
 
 /**
  * A deallocation function such as `free`.

--- a/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
+++ b/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
@@ -1,7 +1,9 @@
 | test2.cpp:19:3:19:6 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test2.cpp:18:12:18:18 | new | new |
 | test2.cpp:26:3:26:6 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test2.cpp:25:7:25:13 | new | new |
 | test2.cpp:51:2:51:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test2.cpp:45:18:45:24 | new | new |
+| test2.cpp:55:2:55:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test2.cpp:46:20:46:33 | call to operator new | new |
 | test2.cpp:57:2:57:18 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test2.cpp:47:21:47:26 | call to malloc | malloc |
+| test2.cpp:58:2:58:18 | call to operator delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test2.cpp:47:21:47:26 | call to malloc | malloc |
 | test.cpp:36:2:36:17 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:27:18:27:23 | call to malloc | malloc |
 | test.cpp:41:2:41:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:26:7:26:17 | new | new |
 | test.cpp:68:3:68:11 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:64:28:64:33 | call to malloc | malloc |

--- a/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
+++ b/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
@@ -1,5 +1,9 @@
 | test2.cpp:19:3:19:6 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test2.cpp:18:12:18:18 | new | new |
 | test2.cpp:26:3:26:6 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test2.cpp:25:7:25:13 | new | new |
+| test2.cpp:50:2:50:18 | call to operator delete | There is a new/free mismatch between this free and the corresponding $@. | test2.cpp:45:18:45:24 | new | new |
+| test2.cpp:51:2:51:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test2.cpp:45:18:45:24 | new | new |
+| test2.cpp:53:2:53:17 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test2.cpp:46:20:46:33 | call to operator new | malloc |
+| test2.cpp:57:2:57:18 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test2.cpp:47:21:47:26 | call to malloc | malloc |
 | test.cpp:36:2:36:17 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:27:18:27:23 | call to malloc | malloc |
 | test.cpp:41:2:41:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:26:7:26:17 | new | new |
 | test.cpp:68:3:68:11 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:64:28:64:33 | call to malloc | malloc |

--- a/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
+++ b/cpp/ql/test/query-tests/Critical/NewFree/NewFreeMismatch.expected
@@ -1,8 +1,6 @@
 | test2.cpp:19:3:19:6 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test2.cpp:18:12:18:18 | new | new |
 | test2.cpp:26:3:26:6 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test2.cpp:25:7:25:13 | new | new |
-| test2.cpp:50:2:50:18 | call to operator delete | There is a new/free mismatch between this free and the corresponding $@. | test2.cpp:45:18:45:24 | new | new |
 | test2.cpp:51:2:51:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test2.cpp:45:18:45:24 | new | new |
-| test2.cpp:53:2:53:17 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test2.cpp:46:20:46:33 | call to operator new | malloc |
 | test2.cpp:57:2:57:18 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test2.cpp:47:21:47:26 | call to malloc | malloc |
 | test.cpp:36:2:36:17 | delete | There is a malloc/delete mismatch between this delete and the corresponding $@. | test.cpp:27:18:27:23 | call to malloc | malloc |
 | test.cpp:41:2:41:5 | call to free | There is a new/free mismatch between this free and the corresponding $@. | test.cpp:26:7:26:17 | new | new |

--- a/cpp/ql/test/query-tests/Critical/NewFree/test2.cpp
+++ b/cpp/ql/test/query-tests/Critical/NewFree/test2.cpp
@@ -52,9 +52,9 @@ void test_operator_new()
 
 	delete ptr_opnew; // GOOD
 	::operator delete(ptr_opnew); // GOOD
-	free(ptr_opnew); // BAD [NOT DETECTED]
+	free(ptr_opnew); // BAD
 
 	delete ptr_malloc; // BAD
-	::operator delete(ptr_malloc); // BAD [NOT DETECTED]
+	::operator delete(ptr_malloc); // BAD
 	free(ptr_malloc); // GOOD
 }

--- a/cpp/ql/test/query-tests/Critical/NewFree/test2.cpp
+++ b/cpp/ql/test/query-tests/Critical/NewFree/test2.cpp
@@ -47,10 +47,10 @@ void test_operator_new()
 	void *ptr_malloc = malloc(sizeof(int));
 
 	delete ptr_new; // GOOD
-	::operator delete(ptr_new); // GOOD [FALSE POSITIVE]
+	::operator delete(ptr_new); // GOOD
 	free(ptr_new); // BAD
 
-	delete ptr_opnew; // GOOD [FALSE POSITIVE]
+	delete ptr_opnew; // GOOD
 	::operator delete(ptr_opnew); // GOOD
 	free(ptr_opnew); // BAD [NOT DETECTED]
 

--- a/cpp/ql/test/query-tests/Critical/NewFree/test2.cpp
+++ b/cpp/ql/test/query-tests/Critical/NewFree/test2.cpp
@@ -34,3 +34,27 @@ public:
 };
 
 MyTest2Class<int> mt2c_i;
+
+// ---
+
+void* operator new(size_t);
+void operator delete(void*);
+
+void test_operator_new()
+{
+	void *ptr_new = new int;
+	void *ptr_opnew = ::operator new(sizeof(int));
+	void *ptr_malloc = malloc(sizeof(int));
+
+	delete ptr_new; // GOOD
+	::operator delete(ptr_new); // GOOD [FALSE POSITIVE]
+	free(ptr_new); // BAD
+
+	delete ptr_opnew; // GOOD [FALSE POSITIVE]
+	::operator delete(ptr_opnew); // GOOD
+	free(ptr_opnew); // BAD [NOT DETECTED]
+
+	delete ptr_malloc; // BAD
+	::operator delete(ptr_malloc); // BAD [NOT DETECTED]
+	free(ptr_malloc); // GOOD
+}


### PR DESCRIPTION
There were four new false positives for `cpp/new-free-mismatch` in `g/abseil/abseil-cpp`.  The issue was that calls to `allocator new` were being misrecognized as `malloc`-style allocations because they were function calls.

I've added test cases and tidied some things up as I went along, including deprecating another part of the legacy wrapper `alloc.qll` (something I've been meaning to get around to).

I'm thinking about the next step being wrapping the concept of an allocation `kind` (`"malloc"`, `"new"`, `"new[]"`) into the models themselves so that we can simplify this and similar code.  Perhaps we should also create additional `kind`s for some of the more exotic allocators, so that we can detect more kinds of mismatches.