### PR TITLE
C++: Add test cases more similar to issues/44.

### DIFF
--- a/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/localTaint.expected
@@ -152,6 +152,16 @@
 | stl.cpp:105:2:105:4 | ss1 [post update] | stl.cpp:110:7:110:9 | ss1 |  |
 | stl.cpp:106:2:106:4 | ss2 [post update] | stl.cpp:109:7:109:9 | ss2 |  |
 | stl.cpp:106:2:106:4 | ss2 [post update] | stl.cpp:111:7:111:9 | ss2 |  |
+| stl.cpp:124:16:124:28 | call to basic_string | stl.cpp:125:7:125:11 | path1 |  |
+| stl.cpp:124:17:124:26 | call to user_input | stl.cpp:124:16:124:28 | call to basic_string | TAINT |
+| stl.cpp:125:7:125:11 | path1 | stl.cpp:125:13:125:17 | call to c_str | TAINT |
+| stl.cpp:128:10:128:19 | call to user_input | stl.cpp:128:10:128:21 | call to basic_string | TAINT |
+| stl.cpp:128:10:128:21 | call to basic_string | stl.cpp:128:2:128:21 | ... = ... |  |
+| stl.cpp:128:10:128:21 | call to basic_string | stl.cpp:129:7:129:11 | path2 |  |
+| stl.cpp:129:7:129:11 | path2 | stl.cpp:129:13:129:17 | call to c_str | TAINT |
+| stl.cpp:131:15:131:24 | call to user_input | stl.cpp:131:15:131:27 | call to basic_string | TAINT |
+| stl.cpp:131:15:131:27 | call to basic_string | stl.cpp:132:7:132:11 | path3 |  |
+| stl.cpp:132:7:132:11 | path3 | stl.cpp:132:13:132:17 | call to c_str | TAINT |
 | taint.cpp:4:27:4:33 | source1 | taint.cpp:6:13:6:19 | source1 |  |
 | taint.cpp:4:40:4:45 | clean1 | taint.cpp:5:8:5:13 | clean1 |  |
 | taint.cpp:4:40:4:45 | clean1 | taint.cpp:6:3:6:8 | clean1 |  |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/stl.cpp
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/stl.cpp
@@ -110,3 +110,24 @@ void test_stringstream_int(int source)
 	sink(ss1.str());
 	sink(ss2.str()); // tainted [NOT DETECTED]
 }
+
+using namespace std;
+
+char *user_input() {
+  return source();
+}
+
+void sink(const char *filename, const char *mode);
+
+void test_strings2()
+{
+	string path1 = user_input();
+	sink(path1.c_str(), "r"); // tainted
+
+	string path2;
+	path2 = user_input();
+	sink(path2.c_str(), "r"); // tainted
+
+	string path3(user_input());
+	sink(path3.c_str(), "r"); // tainted
+}

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/taint.expected
@@ -11,6 +11,9 @@
 | stl.cpp:71:7:71:7 | a | stl.cpp:67:12:67:17 | call to source |
 | stl.cpp:73:7:73:7 | c | stl.cpp:69:16:69:21 | call to source |
 | stl.cpp:75:9:75:13 | call to c_str | stl.cpp:69:16:69:21 | call to source |
+| stl.cpp:125:13:125:17 | call to c_str | stl.cpp:117:10:117:15 | call to source |
+| stl.cpp:129:13:129:17 | call to c_str | stl.cpp:117:10:117:15 | call to source |
+| stl.cpp:132:13:132:17 | call to c_str | stl.cpp:117:10:117:15 | call to source |
 | taint.cpp:8:8:8:13 | clean1 | taint.cpp:4:27:4:33 | source1 |
 | taint.cpp:16:8:16:14 | source1 | taint.cpp:12:22:12:27 | call to source |
 | taint.cpp:17:8:17:16 | ++ ... | taint.cpp:12:22:12:27 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -10,6 +10,9 @@
 | format.cpp:106:8:106:14 | format.cpp:105:38:105:52 | AST only |
 | stl.cpp:73:7:73:7 | stl.cpp:69:16:69:21 | AST only |
 | stl.cpp:75:9:75:13 | stl.cpp:69:16:69:21 | AST only |
+| stl.cpp:125:13:125:17 | stl.cpp:117:10:117:15 | AST only |
+| stl.cpp:129:13:129:17 | stl.cpp:117:10:117:15 | AST only |
+| stl.cpp:132:13:132:17 | stl.cpp:117:10:117:15 | AST only |
 | taint.cpp:41:7:41:13 | taint.cpp:35:12:35:17 | AST only |
 | taint.cpp:42:7:42:13 | taint.cpp:35:12:35:17 | AST only |
 | taint.cpp:43:7:43:13 | taint.cpp:37:22:37:27 | AST only |


### PR DESCRIPTION
I was a bit concerned that my [fix](https://github.com/Semmle/ql/pull/1637) for https://github.com/github/codeql-c-analysis-team/issues/44 didn't contain any test cases particularly similar to the one given in the issue.  This PR resolves that by adding more cases (all three of which would not have been detected prior to the first PR).