### PR TITLE
Add extractor field in base language QL packs

### DIFF
--- a/cpp/ql/src/qlpack.yml
+++ b/cpp/ql/src/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql-cpp
 version: 0.0.0
 dbscheme: semmlecode.cpp.dbscheme
 suites: codeql-suites
+extractor: cpp

--- a/cpp/ql/test/qlpack.yml
+++ b/cpp/ql/test/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql-cpp-tests
 version: 0.0.0
 libraryPathDependencies: codeql-cpp
+extractor: cpp

--- a/csharp/ql/src/qlpack.yml
+++ b/csharp/ql/src/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql-csharp
 version: 0.0.0
 dbscheme: semmlecode.csharp.dbscheme
 suites: codeql-suites
+extractor: csharp

--- a/csharp/ql/test/qlpack.yml
+++ b/csharp/ql/test/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql-csharp-tests
 version: 0.0.0
 libraryPathDependencies: codeql-csharp
+extractor: csharp

--- a/java/ql/src/qlpack.yml
+++ b/java/ql/src/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql-java
 version: 0.0.0
 dbscheme: config/semmlecode.dbscheme
 suites: codeql-suites
+extractor: java

--- a/java/ql/test/qlpack.yml
+++ b/java/ql/test/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql-java-tests
 version: 0.0.0
 libraryPathDependencies: codeql-java
+extractor: java

--- a/javascript/ql/src/qlpack.yml
+++ b/javascript/ql/src/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql-javascript
 version: 0.0.0
 dbscheme: semmlecode.javascript.dbscheme
 suites: codeql-suites
+extractor: javascript

--- a/javascript/ql/test/qlpack.yml
+++ b/javascript/ql/test/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql-javascript-tests
 version: 0.0.0
 libraryPathDependencies: codeql-javascript
+extractor: javascript

--- a/python/ql/src/qlpack.yml
+++ b/python/ql/src/qlpack.yml
@@ -2,3 +2,4 @@ name: codeql-python
 version: 0.0.0
 dbscheme: semmlecode.python.dbscheme
 suites: codeql-suites
+extractor: python

--- a/python/ql/test/qlpack.yml
+++ b/python/ql/test/qlpack.yml
@@ -1,3 +1,4 @@
 name: codeql-python-tests
 version: 0.0.0
 libraryPathDependencies: codeql-python
+extractor: python


### PR DESCRIPTION
The functionality of https://git.semmle.com/Semmle/code/pull/36591 depends on `extractor` fields being present in the base language packs, rather than just in test packs.

They shouldn't do any harm and have been tolerated by the `qlpack.yml` parser since release 2.0.1 of the CodeQL CLI.