### PR TITLE
Python: Fix FN in unused import

### DIFF
--- a/python/ql/test/query-tests/Imports/unused/UnusedImport.expected
+++ b/python/ql/test/query-tests/Imports/unused/UnusedImport.expected
@@ -1,3 +1,4 @@
+| import_structure_1.py:5:1:5:28 | Import | Import of 'bar' is not used. |
 | import_structure_2.py:6:1:6:23 | Import | Import of 'bar' is not used. |
 | imports_test.py:2:1:2:23 | Import | Import of 'module2' is not used. |
 | imports_test.py:6:1:6:12 | Import | Import of 'cycle' is not used. |

--- a/python/ql/test/query-tests/Imports/unused/UnusedImport.expected
+++ b/python/ql/test/query-tests/Imports/unused/UnusedImport.expected
@@ -1,3 +1,4 @@
+| import_structure_2.py:6:1:6:23 | Import | Import of 'bar' is not used. |
 | imports_test.py:2:1:2:23 | Import | Import of 'module2' is not used. |
 | imports_test.py:6:1:6:12 | Import | Import of 'cycle' is not used. |
 | imports_test.py:10:1:10:22 | Import | Import of 'top_level_cycle' is not used. |

--- a/python/ql/test/query-tests/Imports/unused/import_structure_1.py
+++ b/python/ql/test/query-tests/Imports/unused/import_structure_1.py
@@ -1,0 +1,8 @@
+# there should be no difference whether you import 2 things on 1 line, or use 2
+# lines
+from typing import Optional
+
+from unknown import foo, bar
+
+
+var: Optional['foo'] = None

--- a/python/ql/test/query-tests/Imports/unused/import_structure_2.py
+++ b/python/ql/test/query-tests/Imports/unused/import_structure_2.py
@@ -1,0 +1,8 @@
+# there should be no difference whether you import 2 things on 1 line, or use 2
+# lines
+from typing import Optional
+
+from unknown import foo
+from unknown import bar
+
+var: Optional['foo'] = None


### PR DESCRIPTION
```py
from unknown import foo, bar
var: Optional['foo'] = None
```

would not trigger an alert for `bar`, while the following would.

```py
from unknown import foo, bar
print(foo)
```

This PR fixes the above inconsistency.