### PR TITLE
Python: Add missing override to ClassValue.hasAttribute

### DIFF
--- a/python/ql/src/semmle/python/objects/ObjectAPI.qll
+++ b/python/ql/src/semmle/python/objects/ObjectAPI.qll
@@ -540,10 +540,10 @@ class ClassValue extends Value {
     Value declaredAttribute(string name) { Types::declaredAttribute(this, name, result, _) }
 
     /**
-     * Holds if this class has the attribute `name`, including
-     * attributes declared by super classes.
+     * Holds if this class has the attribute `name`, including attributes
+     * declared by super classes.
      */
-    predicate hasAttribute(string name) { this.getMro().declares(name) }
+    override predicate hasAttribute(string name) { this.getMro().declares(name) }
 
     /**
      * Holds if this class declares the attribute `name`,


### PR DESCRIPTION
I was considering if this was actually something different than Value.hasAttribute, and the names were just accidentially the same. But after looking at the definition for Value, I'm happy about marking this as an override (I did not test whether it was needed though):

```codeql
class Value extends TObject {
    ...

    /** Holds if this value has the attribute `name` */
    predicate hasAttribute(string name) { this.(ObjectInternal).hasAttribute(name) }
```