### PR TITLE
C++: IR data flow from WriteSideEffectInstructions to partial ChiInstruction operands

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/dataflow/internal/DataFlowUtil.qll
@@ -360,6 +360,11 @@ private predicate simpleInstructionLocalFlowStep(Instruction iFrom, Instruction 
   // for now.
   iTo.getAnOperand().(ChiTotalOperand).getDef() = iFrom
   or
+  // Flow from write side effects to partial operands of non-conflated chi instructions
+  // does not seem to cause issues with field conflation.
+  iTo.getAnOperand().(ChiPartialOperand).getDef() = iFrom.(WriteSideEffectInstruction) and
+  not iTo.isResultConflated()
+  or
   // Flow through modeled functions
   modelFlow(iFrom, iTo)
 }

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_diff.expected
@@ -45,9 +45,6 @@
 | test.cpp:359:13:359:18 | test.cpp:365:10:365:14 | AST only |
 | test.cpp:373:13:373:18 | test.cpp:369:10:369:14 | AST only |
 | test.cpp:373:13:373:18 | test.cpp:375:10:375:14 | AST only |
-| test.cpp:382:48:382:54 | test.cpp:385:8:385:10 | AST only |
-| test.cpp:388:53:388:59 | test.cpp:392:8:392:10 | AST only |
-| test.cpp:388:53:388:59 | test.cpp:394:10:394:12 | AST only |
 | test.cpp:399:7:399:9 | test.cpp:401:8:401:10 | AST only |
 | test.cpp:405:7:405:9 | test.cpp:408:8:408:10 | AST only |
 | test.cpp:416:7:416:11 | test.cpp:418:8:418:12 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/dataflow-tests/test_ir.expected
@@ -61,6 +61,9 @@
 | test.cpp:266:12:266:12 | x | test.cpp:265:22:265:27 | call to source |
 | test.cpp:289:14:289:14 | x | test.cpp:305:17:305:22 | call to source |
 | test.cpp:318:7:318:7 | x | test.cpp:314:4:314:9 | call to source |
+| test.cpp:385:8:385:10 | tmp | test.cpp:382:48:382:54 | source1 |
+| test.cpp:392:8:392:10 | tmp | test.cpp:388:53:388:59 | source1 |
+| test.cpp:394:10:394:12 | tmp | test.cpp:388:53:388:59 | source1 |
 | test.cpp:450:9:450:22 | (statement expression) | test.cpp:449:26:449:32 | source1 |
 | test.cpp:461:8:461:12 | local | test.cpp:449:26:449:32 | source1 |
 | true_upon_entry.cpp:13:8:13:8 | x | true_upon_entry.cpp:9:11:9:16 | call to source |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_diff.expected
@@ -28,7 +28,6 @@
 | taint.cpp:181:8:181:9 | taint.cpp:185:11:185:16 | AST only |
 | taint.cpp:195:7:195:7 | taint.cpp:192:23:192:28 | AST only |
 | taint.cpp:195:7:195:7 | taint.cpp:193:6:193:6 | AST only |
-| taint.cpp:216:7:216:7 | taint.cpp:207:6:207:11 | AST only |
 | taint.cpp:229:3:229:6 | taint.cpp:223:10:223:15 | AST only |
 | taint.cpp:233:8:233:8 | taint.cpp:223:10:223:15 | AST only |
 | taint.cpp:236:3:236:6 | taint.cpp:223:10:223:15 | AST only |

--- a/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
+++ b/cpp/ql/test/library-tests/dataflow/taint-tests/test_ir.expected
@@ -12,6 +12,7 @@
 | taint.cpp:168:8:168:14 | tainted | taint.cpp:164:19:164:24 | call to source |
 | taint.cpp:210:7:210:7 | x | taint.cpp:207:6:207:11 | call to source |
 | taint.cpp:215:7:215:7 | x | taint.cpp:207:6:207:11 | call to source |
+| taint.cpp:216:7:216:7 | y | taint.cpp:207:6:207:11 | call to source |
 | taint.cpp:250:8:250:8 | a | taint.cpp:223:10:223:15 | call to source |
 | taint.cpp:280:7:280:7 | t | taint.cpp:275:6:275:11 | call to source |
 | taint.cpp:289:7:289:7 | t | taint.cpp:275:6:275:11 | call to source |


### PR DESCRIPTION
Previously we did not catch _data_ flows such as:
```cpp
int a = source();
int b = 0;
memcpy(&b, &a, sizeof(int));
sink(b); // tainted
```
because there's a `ChiInstruction` between the `WriteSideEffect` instruction and the load in `sink(b)`. (Note that this was a still caught by taint flow).

This PR recovers these flows by inserting flow from write side effect instructions to the partial operand of `Chi` instructions, similar to how https://github.com/Semmle/ql/pull/3219 handles taint flows.