### PR TITLE
CodeQL docs: fix link text in 'CodeQL queries' map topic

### DIFF
--- a/docs/language/learn-ql/writing-queries/writing-queries.rst
+++ b/docs/language/learn-ql/writing-queries/writing-queries.rst
@@ -22,4 +22,4 @@ CodeQL queries are used in code scanning analyses to find problems in source cod
 - :doc:`Providing locations in CodeQL queries <../locations>`: CodeQL includes mechanisms for extracting the location of elements in a codebase. Use these mechanisms when writing custom CodeQL queries and libraries to help display information to users.
 - :doc:`About data flow analysis <../intro-to-data-flow>`: Data flow analysis is used to compute the possible values that a variable can hold at various points in a program, determining how those values propagate through the program and where they are used. 
 - :doc:`Creating path queries <path-queries>`: You can create path queries to visualize the flow of information through a codebase.
-- :doc:`trouble shooting query performance <debugging-queries>`: Improve the performance of your CodeQL queries by following a few simple guidelines.
+- :doc:`Troubleshooting query performance <debugging-queries>`: Improve the performance of your CodeQL queries by following a few simple guidelines.


### PR DESCRIPTION
This fixes a typo.