### PR TITLE
CodeQL docs: further updates to 'Learn CodeQL' project

### DIFF
--- a/docs/language/learn-ql/cpp/ql-for-cpp.rst
+++ b/docs/language/learn-ql/cpp/ql-for-cpp.rst
@@ -34,11 +34,11 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
 
 -  :doc:`Detecting a potential buffer overflow <zero-space-terminator>`: You can use CodeQL to detect potential buffer overflows by checking for allocations equal to ``strlen`` in C and C++.
 
+-  :doc:`Using the guards library in C and C++ <guards>`: You can use the CodeQL guards library to identify conditional expressions that control the execution of other parts of a program in C and C++ codebases. 
+
 -  :doc:`Using range analysis for C and C++ <range-analysis>`: You can use range analysis to determine the upper or lower bounds on an expression, or whether an expression could potentially over or underflow.
 
 -  :doc:`Hash consing and value numbering <value-numbering-hash-cons>`: You can use specialized CodeQL libraries to recognize expressions that are syntactically identical or compute the same value at runtime in C and C++ codebases.
-
--  :doc:`Using the guards library in C and C++ <guards>`: You can use the CodeQL guards library to identify conditional expressions that control the execution of other parts of a program in C and C++ codebases. 
 
 Further reading
 ---------------

--- a/docs/language/learn-ql/cpp/ql-for-cpp.rst
+++ b/docs/language/learn-ql/cpp/ql-for-cpp.rst
@@ -34,6 +34,12 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
 
 -  :doc:`Detecting a potential buffer overflow <zero-space-terminator>`: You can use CodeQL to detect potential buffer overflows by checking for allocations equal to ``strlen`` in C and C++.
 
+-  :doc:`Using range analysis for C and C++ <range-analysis>`: You can use range analysis to determine the upper or lower bounds on an expression, or whether an expression could potentially over or underflow.
+
+-  :doc:`Hash consing and value numbering <value-numbering-hash-cons>`: You can use specialized CodeQL libraries to recognize expressions that are syntactically identical or compute the same value at runtime in C and C++ codebases.
+
+-  :doc:`Using the guards library in C and C++ <guards>`: You can use the CodeQL guards library to identify conditional expressions that control the execution of other parts of a program in C and C++ codebases. 
+
 Further reading
 ---------------
 

--- a/docs/language/learn-ql/java/ql-for-java.rst
+++ b/docs/language/learn-ql/java/ql-for-java.rst
@@ -18,7 +18,7 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
 
 -  `Basic Java query <https://lgtm.com/help/lgtm/console/ql-java-basic-example>`__: Learn to write and run a simple CodeQL query using LGTM.
 
--  :doc:`CodeQL library for Java <introduce-libraries-java>`: When analyzing C or C++ code, you can use the large collection of classes in the CodeQL library for C and C++.
+-  :doc:`CodeQL library for Java <introduce-libraries-java>`: When analyzing C or C++ code, you can use the large collection of classes in the CodeQL library for Java.
 
 -  :doc:`Analyzing data flow in Java <dataflow>`: You can use CodeQL to track the flow of data through a Java program to its use. 
 
@@ -34,7 +34,7 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
 
 -  :doc:`Working with source locations <source-locations>`: You can use the location of entities within Java code to look for potential errors. Locations allow you to deduce the presence, or absence, of white space which, in some cases, may indicate a problem.
 
--  :doc:`lasses for working with Java code <ast-class-reference>`: CodeQL has a large selection of classes for working with Java statements and expressions.
+-  :doc:`Classes for working with Java code <ast-class-reference>`: CodeQL has a large selection of classes for working with Java statements and expressions.
 
 
 Further reading

--- a/docs/language/learn-ql/java/ql-for-java.rst
+++ b/docs/language/learn-ql/java/ql-for-java.rst
@@ -18,7 +18,7 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
 
 -  `Basic Java query <https://lgtm.com/help/lgtm/console/ql-java-basic-example>`__: Learn to write and run a simple CodeQL query using LGTM.
 
--  :doc:`CodeQL library for Java <introduce-libraries-java>`: When analyzing C or C++ code, you can use the large collection of classes in the CodeQL library for Java.
+-  :doc:`CodeQL library for Java <introduce-libraries-java>`: When analyzing Java code, you can use the large collection of classes in the CodeQL library for Java.
 
 -  :doc:`Analyzing data flow in Java <dataflow>`: You can use CodeQL to track the flow of data through a Java program to its use. 
 


### PR DESCRIPTION
A few more things that slipped through the cracks when working on the `docs-preparation` branch.

Previews:
- [CodeQL for C and C++](http://docteam.internal.semmle.com/james/tidy-up-branch/learn-ql/cpp/ql-for-cpp.html)--some topics were missed from the toc.
- [CodeQL for Java](http://docteam.internal.semmle.com/james/tidy-up-branch/learn-ql/java/ql-for-java.html)--fixed a couple of typos.