### PR TITLE
Python: Add more deprecated annotations

### DIFF
--- a/python/ql/src/semmle/python/dataflow/TaintTracking.qll
+++ b/python/ql/src/semmle/python/dataflow/TaintTracking.qll
@@ -659,7 +659,7 @@ module DataFlow {
         }
     }
 
-    private class ConfigurationAdapter extends TaintTracking::Configuration {
+    deprecated private class ConfigurationAdapter extends TaintTracking::Configuration {
         ConfigurationAdapter() { this instanceof Configuration }
 
         override predicate isSource(DataFlow::Node node, TaintKind kind) {
@@ -727,7 +727,7 @@ module DataFlow {
     }
 }
 
-private class DataFlowType extends TaintKind {
+deprecated private class DataFlowType extends TaintKind {
     DataFlowType() {
         this = "Data flow" and
         exists(DataFlow::Configuration c)

--- a/python/ql/src/semmle/python/types/Extensions.qll
+++ b/python/ql/src/semmle/python/types/Extensions.qll
@@ -38,7 +38,7 @@ abstract deprecated class CustomPointsToFact extends @py_flow_node {
 }
 
 /* For backwards compatibility */
-class FinalCustomPointsToFact = CustomPointsToFact;
+deprecated class FinalCustomPointsToFact = CustomPointsToFact;
 
 abstract deprecated class CustomPointsToOriginFact extends CustomPointsToFact {
     abstract predicate pointsTo(Object value, ClassObject cls);
@@ -151,7 +151,7 @@ class ReModulePointToExtension extends PointsToExtension {
     private predicate pointsTo_helper(Context context) { context.appliesTo(this) }
 }
 
-private class BackwardCompatiblePointToExtension extends PointsToExtension {
+deprecated private class BackwardCompatiblePointToExtension extends PointsToExtension {
     BackwardCompatiblePointToExtension() { this instanceof CustomPointsToFact }
 
     override predicate pointsTo(Context context, ObjectInternal value, ControlFlowNode origin) {
@@ -174,7 +174,7 @@ private class BackwardCompatiblePointToExtension extends PointsToExtension {
     }
 }
 
-private predicate additionalAttribute(
+deprecated private predicate additionalAttribute(
     ObjectInternal owner, string name, ObjectInternal value, ControlFlowNode origin
 ) {
     exists(Object obj, ClassObject cls |

--- a/python/ql/src/semmle/python/types/Extensions.qll
+++ b/python/ql/src/semmle/python/types/Extensions.qll
@@ -37,7 +37,7 @@ abstract deprecated class CustomPointsToFact extends @py_flow_node {
     abstract predicate pointsTo(Context context, Object value, ClassObject cls, ControlFlowNode origin);
 }
 
-/* For backwards compatibility */
+/** DEPRECATED -- Use PointsToExtension instead */
 deprecated class FinalCustomPointsToFact = CustomPointsToFact;
 
 abstract deprecated class CustomPointsToOriginFact extends CustomPointsToFact {


### PR DESCRIPTION
These classes/predicates are not used by anything in our codebase, and is using
deprecated classes/predicates, so I think it's safe to assume they should also
have been marked with the deprecated annotation.

Changes the QL compiler warnings with:

```
-WARNING: Type Configuration has been deprecated and may be removed in future (/home/rasmus/code/ql/python/ql/src/semmle/python/dataflow/TaintTracking.qll:663,50-63)
-WARNING: Type Configuration has been deprecated and may be removed in future (/home/rasmus/code/ql/python/ql/src/semmle/python/dataflow/TaintTracking.qll:666,19-32)
-WARNING: Type Configuration has been deprecated and may be removed in future (/home/rasmus/code/ql/python/ql/src/semmle/python/dataflow/TaintTracking.qll:671,19-32)

-WARNING: Type CustomPointsToAttribute has been deprecated and may be removed in future (/home/rasmus/code/ql/python/ql/src/semmle/python/types/Extensions.qll:181,28-51)

-WARNING: Type CustomPointsToFact has been deprecated and may be removed in future (/home/rasmus/code/ql/python/ql/src/semmle/python/types/Extensions.qll:155,60-78)
-WARNING: Type CustomPointsToFact has been deprecated and may be removed in future (/home/rasmus/code/ql/python/ql/src/semmle/python/types/Extensions.qll:159,19-37)
-WARNING: Type CustomPointsToFact has been deprecated and may be removed in future (/home/rasmus/code/ql/python/ql/src/semmle/python/types/Extensions.qll:41,33-51)
+WARNING: Type CustomPointsToFact has been deprecated and may be removed in future (/home/rasmus/code/ql/python/ql/src/semmle/python/types/Extensions.qll:41,44-62)
```