### PR TITLE
C++/C#: Reuse unaliased SSA when building aliased SSA

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -1273,6 +1273,14 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() { result = this.getAnInputOperand().getDef() }
+
+  /**
+   * Gets the input operand representing the value that flows from the specified predecessor block.
+   */
+  final PhiInputOperand getInputOperand(IRBlock predecessorBlock) {
+    result = this.getAnOperand() and
+    result.getPredecessorBlock() = predecessorBlock
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasConfiguration.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasConfiguration.qll
@@ -2,9 +2,13 @@ private import AliasConfigurationInternal
 private import semmle.code.cpp.ir.implementation.unaliased_ssa.IR
 private import cpp
 private import AliasAnalysis
+private import semmle.code.cpp.ir.implementation.unaliased_ssa.internal.SimpleSSA as UnaliasedSSA
 
 private newtype TAllocation =
-  TVariableAllocation(IRVariable var) or
+  TVariableAllocation(IRVariable var) {
+    // Only model variables that were not already handled in unaliased SSA.
+    not UnaliasedSSA::isVariableModeled(var)
+  } or
   TIndirectParameterAllocation(IRAutomaticUserVariable var) {
     exists(InitializeIndirectionInstruction instr | instr.getIRVariable() = var)
   } or

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasedSSA.qll
@@ -557,6 +557,9 @@ private Overlap getVariableMemoryLocationOverlap(
 }
 
 MemoryLocation getResultMemoryLocation(Instruction instr) {
+  // Ignore instructions that already have modeled results, because SSA construction can just reuse
+  // their def/use information.
+  not instr.isResultModeled() and
   exists(MemoryAccessKind kind, boolean isMayAccess |
     kind = instr.getResultMemoryAccess() and
     (if instr.hasResultMayMemoryAccess() then isMayAccess = true else isMayAccess = false) and
@@ -588,6 +591,9 @@ MemoryLocation getResultMemoryLocation(Instruction instr) {
 }
 
 MemoryLocation getOperandMemoryLocation(MemoryOperand operand) {
+  // Ignore operands that are already modeled, because SSA construction can just reuse their def/use
+  // information.
+  not operand.getAnyDef().isResultModeled() and
   exists(MemoryAccessKind kind, boolean isMayAccess |
     kind = operand.getMemoryAccess() and
     (if operand.hasMayReadMemoryAccess() then isMayAccess = true else isMayAccess = false) and

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -1273,6 +1273,14 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() { result = this.getAnInputOperand().getDef() }
+
+  /**
+   * Gets the input operand representing the value that flows from the specified predecessor block.
+   */
+  final PhiInputOperand getInputOperand(IRBlock predecessorBlock) {
+    result = this.getAnOperand() and
+    result.getPredecessorBlock() = predecessorBlock
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -1273,6 +1273,14 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() { result = this.getAnInputOperand().getDef() }
+
+  /**
+   * Gets the input operand representing the value that flows from the specified predecessor block.
+   */
+  final PhiInputOperand getInputOperand(IRBlock predecessorBlock) {
+    result = this.getAnOperand() and
+    result.getPredecessorBlock() = predecessorBlock
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SimpleSSA.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SimpleSSA.qll
@@ -17,7 +17,7 @@ private predicate isTotalAccess(Allocation var, AddressOperand addrOperand, IRTy
  * variable if its address never escapes and all reads and writes of that variable access the entire
  * variable using the original type of the variable.
  */
-private predicate isVariableModeled(Allocation var) {
+predicate isVariableModeled(Allocation var) {
   not allocationEscapes(var) and
   forall(Instruction instr, AddressOperand addrOperand, IRType type |
     addrOperand = instr.getResultAddressOperand() and

--- a/cpp/ql/test/library-tests/ir/points_to/points_to.cpp
+++ b/cpp/ql/test/library-tests/ir/points_to/points_to.cpp
@@ -37,51 +37,51 @@ void Locals() {
 }
 
 void PointsTo(
-  int a,         //$raw,ussa=a
-  Point& b,      //$raw,ussa=b $ussa=*b
-  Point* c,      //$raw,ussa=c $ussa=*c
-  int* d,        //$raw,ussa=d $ussa=*d
-  DerivedSI* e,  //$raw,ussa=e $ussa=*e
-  DerivedMI* f,  //$raw,ussa=f $ussa=*f
-  DerivedVI* g   //$raw,ussa=g $ussa=*g
+  int a,         //$raw=a
+  Point& b,      //$raw=b $ussa=*b
+  Point* c,      //$raw=c $ussa=*c
+  int* d,        //$raw=d $ussa=*d
+  DerivedSI* e,  //$raw=e $ussa=*e
+  DerivedMI* f,  //$raw=f $ussa=*f
+  DerivedVI* g   //$raw=g $ussa=*g
 ) {
 
-  int i = a;  //$raw,ussa=a
-  i = *&a;  //$raw,ussa=a
-  i = *(&a + 0);  //$raw,ussa=a
-  i = b.x;  //$raw,ussa=b $ussa=*b[0..4)<int>
-  i = b.y;  //$raw,ussa=b $ussa=*b[4..8)<int>
-  i = c->x;  //$raw,ussa=c $ussa=*c[0..4)<int>
-  i = c->y;  //$raw,ussa=c $ussa=*c[4..8)<int>
-  i = *d;  //$raw,ussa=d $ussa=*d[0..4)<int>
-  i = *(d + 0);  //$raw,ussa=d $ussa=*d[0..4)<int>
-  i = d[5];  //$raw,ussa=d $ussa=*d[20..24)<int>
-  i = 5[d];  //$raw,ussa=d $ussa=*d[20..24)<int>
-  i = d[a];  //$raw,ussa=d $raw,ussa=a $ussa=*d[?..?)<int>
-  i = a[d];  //$raw,ussa=d $raw,ussa=a $ussa=*d[?..?)<int>
+  int i = a;  //$raw=a
+  i = *&a;  //$raw=a
+  i = *(&a + 0);  //$raw=a
+  i = b.x;  //$raw=b $ussa=*b[0..4)<int>
+  i = b.y;  //$raw=b $ussa=*b[4..8)<int>
+  i = c->x;  //$raw=c $ussa=*c[0..4)<int>
+  i = c->y;  //$raw=c $ussa=*c[4..8)<int>
+  i = *d;  //$raw=d $ussa=*d[0..4)<int>
+  i = *(d + 0);  //$raw=d $ussa=*d[0..4)<int>
+  i = d[5];  //$raw=d $ussa=*d[20..24)<int>
+  i = 5[d];  //$raw=d $ussa=*d[20..24)<int>
+  i = d[a];  //$raw=d $raw=a $ussa=*d[?..?)<int>
+  i = a[d];  //$raw=d $raw=a $ussa=*d[?..?)<int>
 
-  int* p = &b.x;  //$raw,ussa=b
+  int* p = &b.x;  //$raw=b
   i = *p;  //$ussa=*b[0..4)<int>
-  p = &b.y;  //$raw,ussa=b
+  p = &b.y;  //$raw=b
   i = *p;  //$ussa=*b[4..8)<int>
-  p = &c->x;  //$raw,ussa=c
+  p = &c->x;  //$raw=c
   i = *p;  //$ussa=*c[0..4)<int>
-  p = &c->y;  //$raw,ussa=c
+  p = &c->y;  //$raw=c
   i = *p;  //$ussa=*c[4..8)<int>
-  p = &d[5];  //$raw,ussa=d
+  p = &d[5];  //$raw=d
   i = *p;  //$ussa=*d[20..24)<int>
-  p = &d[a];  //$raw,ussa=d $raw,ussa=a
+  p = &d[a];  //$raw=d $raw=a
   i = *p;  //$ussa=*d[?..?)<int>
 
-  Point* q = &c[a];  //$raw,ussa=c $raw,ussa=a
+  Point* q = &c[a];  //$raw=c $raw=a
   i = q->x;  //$ussa=*c[?..?)<int>
   i = q->y;  //$ussa=*c[?..?)<int>
 
-  i = e->b1;  //$raw,ussa=e $ussa=*e[0..4)<int>
-  i = e->dsi;  //$raw,ussa=e $ussa=*e[4..8)<int>
-  i = f->b1;  //$raw,ussa=f $ussa=*f[0..4)<int>
-  i = f->b2;  //$raw,ussa=f $ussa=*f[4..8)<int>
-  i = f->dmi;  //$raw,ussa=f $ussa=*f[8..12)<int>
-  i = g->b1;  //$raw,ussa=g $ussa=*g[?..?)<int>
-  i = g->dvi;  //$raw,ussa=g $ussa=*g[8..12)<int>
+  i = e->b1;  //$raw=e $ussa=*e[0..4)<int>
+  i = e->dsi;  //$raw=e $ussa=*e[4..8)<int>
+  i = f->b1;  //$raw=f $ussa=*f[0..4)<int>
+  i = f->b2;  //$raw=f $ussa=*f[4..8)<int>
+  i = f->dmi;  //$raw=f $ussa=*f[8..12)<int>
+  i = g->b1;  //$raw=g $ussa=*g[?..?)<int>
+  i = g->dvi;  //$raw=g $ussa=*g[8..12)<int>
 }

--- a/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
@@ -1483,3 +1483,91 @@ ssa.cpp:
 #  291|     v291_10(void)           = UnmodeledUse                    : mu*
 #  291|     v291_11(void)           = AliasedUse                      : ~m295_12
 #  291|     v291_12(void)           = ExitFunction                    : 
+
+#  299| int DegeneratePhiAfterUnreachable()
+#  299|   Block 0
+#  299|     v299_1(void)       = EnterFunction       : 
+#  299|     m299_2(unknown)    = AliasedDefinition   : 
+#  299|     m299_3(unknown)    = InitializeNonLocal  : 
+#  299|     m299_4(unknown)    = Chi                 : total:m299_2, partial:m299_3
+#  299|     mu299_5(unknown)   = UnmodeledDefinition : 
+#  300|     r300_1(glval<int>) = VariableAddress[a]  : 
+#  300|     r300_2(int)        = Constant[5]         : 
+#  300|     m300_3(int)        = Store               : &:r300_1, r300_2
+#  301|     r301_1(glval<int>) = VariableAddress[b]  : 
+#  301|     r301_2(int)        = Constant[5]         : 
+#  301|     m301_3(int)        = Store               : &:r301_1, r301_2
+#  302|     r302_1(glval<int>) = VariableAddress[a]  : 
+#  302|     r302_2(int)        = Load                : &:r302_1, m300_3
+#  302|     r302_3(glval<int>) = VariableAddress[b]  : 
+#  302|     r302_4(int)        = Load                : &:r302_3, m301_3
+#  302|     r302_5(bool)       = CompareEQ           : r302_2, r302_4
+#  302|     v302_6(void)       = ConditionalBranch   : r302_5
+#-----|   False -> Block 2
+#-----|   True -> Block 1
+
+#  303|   Block 1
+#  303|     r303_1(glval<int>) = VariableAddress[#return] : 
+#  303|     r303_2(int)        = Constant[0]              : 
+#  303|     m303_3(int)        = Store                    : &:r303_1, r303_2
+#  299|     r299_6(glval<int>) = VariableAddress[#return] : 
+#  299|     v299_7(void)       = ReturnValue              : &:r299_6, m303_3
+#  299|     v299_8(void)       = UnmodeledUse             : mu*
+#  299|     v299_9(void)       = AliasedUse               : m299_3
+#  299|     v299_10(void)      = ExitFunction             : 
+
+#  299|   Block 2
+#  299|     v299_11(void) = Unreached : 
+
+#  312| int TwoDegeneratePhisAfterUnreachable()
+#  312|   Block 0
+#  312|     v312_1(void)       = EnterFunction       : 
+#  312|     m312_2(unknown)    = AliasedDefinition   : 
+#  312|     m312_3(unknown)    = InitializeNonLocal  : 
+#  312|     m312_4(unknown)    = Chi                 : total:m312_2, partial:m312_3
+#  312|     mu312_5(unknown)   = UnmodeledDefinition : 
+#  313|     r313_1(glval<int>) = VariableAddress[a]  : 
+#  313|     r313_2(int)        = Constant[5]         : 
+#  313|     m313_3(int)        = Store               : &:r313_1, r313_2
+#  314|     r314_1(glval<int>) = VariableAddress[b]  : 
+#  314|     r314_2(int)        = Constant[5]         : 
+#  314|     m314_3(int)        = Store               : &:r314_1, r314_2
+#  315|     r315_1(glval<int>) = VariableAddress[r]  : 
+#  315|     m315_2(int)        = Uninitialized[r]    : &:r315_1
+#  316|     r316_1(glval<int>) = VariableAddress[a]  : 
+#  316|     r316_2(int)        = Load                : &:r316_1, m313_3
+#  316|     r316_3(glval<int>) = VariableAddress[b]  : 
+#  316|     r316_4(int)        = Load                : &:r316_3, m314_3
+#  316|     r316_5(bool)       = CompareEQ           : r316_2, r316_4
+#  316|     v316_6(void)       = ConditionalBranch   : r316_5
+#-----|   False -> Block 3
+#-----|   True -> Block 1
+
+#  317|   Block 1
+#  317|     r317_1(glval<int>) = VariableAddress[a] : 
+#  317|     r317_2(int)        = Load               : &:r317_1, m313_3
+#  317|     r317_3(int)        = Constant[5]        : 
+#  317|     r317_4(bool)       = CompareLT          : r317_2, r317_3
+#  317|     v317_5(void)       = ConditionalBranch  : r317_4
+#-----|   False -> Block 2
+#-----|   True -> Block 3
+
+#  324|   Block 2
+#  324|     r324_1(int)        = Constant[1]              : 
+#  324|     r324_2(glval<int>) = VariableAddress[r]       : 
+#  324|     m324_3(int)        = Store                    : &:r324_2, r324_1
+#  330|     r330_1(glval<int>) = VariableAddress[x]       : 
+#  330|     r330_2(int)        = Constant[7]              : 
+#  330|     m330_3(int)        = Store                    : &:r330_1, r330_2
+#  338|     r338_1(glval<int>) = VariableAddress[#return] : 
+#  338|     r338_2(glval<int>) = VariableAddress[r]       : 
+#  338|     r338_3(int)        = Load                     : &:r338_2, m324_3
+#  338|     m338_4(int)        = Store                    : &:r338_1, r338_3
+#  312|     r312_6(glval<int>) = VariableAddress[#return] : 
+#  312|     v312_7(void)       = ReturnValue              : &:r312_6, m338_4
+#  312|     v312_8(void)       = UnmodeledUse             : mu*
+#  312|     v312_9(void)       = AliasedUse               : m312_3
+#  312|     v312_10(void)      = ExitFunction             : 
+
+#  312|   Block 3
+#  312|     v312_11(void) = Unreached : 

--- a/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir_unsound.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir_unsound.expected
@@ -1471,3 +1471,91 @@ ssa.cpp:
 #  291|     v291_10(void)           = UnmodeledUse                    : mu*
 #  291|     v291_11(void)           = AliasedUse                      : ~m295_12
 #  291|     v291_12(void)           = ExitFunction                    : 
+
+#  299| int DegeneratePhiAfterUnreachable()
+#  299|   Block 0
+#  299|     v299_1(void)       = EnterFunction       : 
+#  299|     m299_2(unknown)    = AliasedDefinition   : 
+#  299|     m299_3(unknown)    = InitializeNonLocal  : 
+#  299|     m299_4(unknown)    = Chi                 : total:m299_2, partial:m299_3
+#  299|     mu299_5(unknown)   = UnmodeledDefinition : 
+#  300|     r300_1(glval<int>) = VariableAddress[a]  : 
+#  300|     r300_2(int)        = Constant[5]         : 
+#  300|     m300_3(int)        = Store               : &:r300_1, r300_2
+#  301|     r301_1(glval<int>) = VariableAddress[b]  : 
+#  301|     r301_2(int)        = Constant[5]         : 
+#  301|     m301_3(int)        = Store               : &:r301_1, r301_2
+#  302|     r302_1(glval<int>) = VariableAddress[a]  : 
+#  302|     r302_2(int)        = Load                : &:r302_1, m300_3
+#  302|     r302_3(glval<int>) = VariableAddress[b]  : 
+#  302|     r302_4(int)        = Load                : &:r302_3, m301_3
+#  302|     r302_5(bool)       = CompareEQ           : r302_2, r302_4
+#  302|     v302_6(void)       = ConditionalBranch   : r302_5
+#-----|   False -> Block 2
+#-----|   True -> Block 1
+
+#  303|   Block 1
+#  303|     r303_1(glval<int>) = VariableAddress[#return] : 
+#  303|     r303_2(int)        = Constant[0]              : 
+#  303|     m303_3(int)        = Store                    : &:r303_1, r303_2
+#  299|     r299_6(glval<int>) = VariableAddress[#return] : 
+#  299|     v299_7(void)       = ReturnValue              : &:r299_6, m303_3
+#  299|     v299_8(void)       = UnmodeledUse             : mu*
+#  299|     v299_9(void)       = AliasedUse               : m299_3
+#  299|     v299_10(void)      = ExitFunction             : 
+
+#  299|   Block 2
+#  299|     v299_11(void) = Unreached : 
+
+#  312| int TwoDegeneratePhisAfterUnreachable()
+#  312|   Block 0
+#  312|     v312_1(void)       = EnterFunction       : 
+#  312|     m312_2(unknown)    = AliasedDefinition   : 
+#  312|     m312_3(unknown)    = InitializeNonLocal  : 
+#  312|     m312_4(unknown)    = Chi                 : total:m312_2, partial:m312_3
+#  312|     mu312_5(unknown)   = UnmodeledDefinition : 
+#  313|     r313_1(glval<int>) = VariableAddress[a]  : 
+#  313|     r313_2(int)        = Constant[5]         : 
+#  313|     m313_3(int)        = Store               : &:r313_1, r313_2
+#  314|     r314_1(glval<int>) = VariableAddress[b]  : 
+#  314|     r314_2(int)        = Constant[5]         : 
+#  314|     m314_3(int)        = Store               : &:r314_1, r314_2
+#  315|     r315_1(glval<int>) = VariableAddress[r]  : 
+#  315|     m315_2(int)        = Uninitialized[r]    : &:r315_1
+#  316|     r316_1(glval<int>) = VariableAddress[a]  : 
+#  316|     r316_2(int)        = Load                : &:r316_1, m313_3
+#  316|     r316_3(glval<int>) = VariableAddress[b]  : 
+#  316|     r316_4(int)        = Load                : &:r316_3, m314_3
+#  316|     r316_5(bool)       = CompareEQ           : r316_2, r316_4
+#  316|     v316_6(void)       = ConditionalBranch   : r316_5
+#-----|   False -> Block 3
+#-----|   True -> Block 1
+
+#  317|   Block 1
+#  317|     r317_1(glval<int>) = VariableAddress[a] : 
+#  317|     r317_2(int)        = Load               : &:r317_1, m313_3
+#  317|     r317_3(int)        = Constant[5]        : 
+#  317|     r317_4(bool)       = CompareLT          : r317_2, r317_3
+#  317|     v317_5(void)       = ConditionalBranch  : r317_4
+#-----|   False -> Block 2
+#-----|   True -> Block 3
+
+#  324|   Block 2
+#  324|     r324_1(int)        = Constant[1]              : 
+#  324|     r324_2(glval<int>) = VariableAddress[r]       : 
+#  324|     m324_3(int)        = Store                    : &:r324_2, r324_1
+#  330|     r330_1(glval<int>) = VariableAddress[x]       : 
+#  330|     r330_2(int)        = Constant[7]              : 
+#  330|     m330_3(int)        = Store                    : &:r330_1, r330_2
+#  338|     r338_1(glval<int>) = VariableAddress[#return] : 
+#  338|     r338_2(glval<int>) = VariableAddress[r]       : 
+#  338|     r338_3(int)        = Load                     : &:r338_2, m324_3
+#  338|     m338_4(int)        = Store                    : &:r338_1, r338_3
+#  312|     r312_6(glval<int>) = VariableAddress[#return] : 
+#  312|     v312_7(void)       = ReturnValue              : &:r312_6, m338_4
+#  312|     v312_8(void)       = UnmodeledUse             : mu*
+#  312|     v312_9(void)       = AliasedUse               : m312_3
+#  312|     v312_10(void)      = ExitFunction             : 
+
+#  312|   Block 3
+#  312|     v312_11(void) = Unreached : 

--- a/cpp/ql/test/library-tests/ir/ssa/ssa.cpp
+++ b/cpp/ql/test/library-tests/ir/ssa/ssa.cpp
@@ -295,3 +295,45 @@ Point *NewAliasing(int x) {
   A* a = new A;
   return p;
 }
+
+int DegeneratePhiAfterUnreachable() {
+  int a = 5;
+  int b = 5;
+  if (a == b) {
+    return 0;
+  }
+  else {
+    // Unreachable, so the `Phi` for the return variable would have only the other `return`
+    // expression as input.
+    return 1;
+  }
+}
+
+int TwoDegeneratePhisAfterUnreachable() {
+  int a = 5;
+  int b = 5;
+  int r;
+  if (a == b) {
+    if (a < 5) {
+      // Unreachable.
+      r = 0;  // r0
+    }
+    else {
+      // After unreachable code removal, this feeds a degenerate `Phi` which in turn feeds another
+      // degenerate `Phi`.
+      r = 1;  // r1
+    }
+    // r01 = Phi(r0, r1) <-- First degenerate `Phi` here.
+
+    // The below statement is just to keep the above `if`/`else` from going directly to the `return`
+    // statement.
+    int x = 7;
+  }
+  else {
+    // Unreachable
+    r = 2;  // r2
+  }
+  // r012 = Phi(r01, r2) <-- Second degenerate `Phi` here.
+
+  return r;
+}

--- a/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
@@ -1359,3 +1359,113 @@ ssa.cpp:
 #  291|     v291_9(void)            = UnmodeledUse                    : mu*
 #  291|     v291_10(void)           = AliasedUse                      : ~mu291_4
 #  291|     v291_11(void)           = ExitFunction                    : 
+
+#  299| int DegeneratePhiAfterUnreachable()
+#  299|   Block 0
+#  299|     v299_1(void)       = EnterFunction       : 
+#  299|     mu299_2(unknown)   = AliasedDefinition   : 
+#  299|     mu299_3(unknown)   = InitializeNonLocal  : 
+#  299|     mu299_4(unknown)   = UnmodeledDefinition : 
+#  300|     r300_1(glval<int>) = VariableAddress[a]  : 
+#  300|     r300_2(int)        = Constant[5]         : 
+#  300|     m300_3(int)        = Store               : &:r300_1, r300_2
+#  301|     r301_1(glval<int>) = VariableAddress[b]  : 
+#  301|     r301_2(int)        = Constant[5]         : 
+#  301|     m301_3(int)        = Store               : &:r301_1, r301_2
+#  302|     r302_1(glval<int>) = VariableAddress[a]  : 
+#  302|     r302_2(int)        = Load                : &:r302_1, m300_3
+#  302|     r302_3(glval<int>) = VariableAddress[b]  : 
+#  302|     r302_4(int)        = Load                : &:r302_3, m301_3
+#  302|     r302_5(bool)       = CompareEQ           : r302_2, r302_4
+#  302|     v302_6(void)       = ConditionalBranch   : r302_5
+#-----|   False -> Block 3
+#-----|   True -> Block 2
+
+#  299|   Block 1
+#  299|     m299_5(int)        = Phi                      : from 2:m303_3, from 3:m308_3
+#  299|     r299_6(glval<int>) = VariableAddress[#return] : 
+#  299|     v299_7(void)       = ReturnValue              : &:r299_6, m299_5
+#  299|     v299_8(void)       = UnmodeledUse             : mu*
+#  299|     v299_9(void)       = AliasedUse               : ~mu299_4
+#  299|     v299_10(void)      = ExitFunction             : 
+
+#  303|   Block 2
+#  303|     r303_1(glval<int>) = VariableAddress[#return] : 
+#  303|     r303_2(int)        = Constant[0]              : 
+#  303|     m303_3(int)        = Store                    : &:r303_1, r303_2
+#-----|   Goto -> Block 1
+
+#  308|   Block 3
+#  308|     r308_1(glval<int>) = VariableAddress[#return] : 
+#  308|     r308_2(int)        = Constant[1]              : 
+#  308|     m308_3(int)        = Store                    : &:r308_1, r308_2
+#-----|   Goto -> Block 1
+
+#  312| int TwoDegeneratePhisAfterUnreachable()
+#  312|   Block 0
+#  312|     v312_1(void)       = EnterFunction       : 
+#  312|     mu312_2(unknown)   = AliasedDefinition   : 
+#  312|     mu312_3(unknown)   = InitializeNonLocal  : 
+#  312|     mu312_4(unknown)   = UnmodeledDefinition : 
+#  313|     r313_1(glval<int>) = VariableAddress[a]  : 
+#  313|     r313_2(int)        = Constant[5]         : 
+#  313|     m313_3(int)        = Store               : &:r313_1, r313_2
+#  314|     r314_1(glval<int>) = VariableAddress[b]  : 
+#  314|     r314_2(int)        = Constant[5]         : 
+#  314|     m314_3(int)        = Store               : &:r314_1, r314_2
+#  315|     r315_1(glval<int>) = VariableAddress[r]  : 
+#  315|     m315_2(int)        = Uninitialized[r]    : &:r315_1
+#  316|     r316_1(glval<int>) = VariableAddress[a]  : 
+#  316|     r316_2(int)        = Load                : &:r316_1, m313_3
+#  316|     r316_3(glval<int>) = VariableAddress[b]  : 
+#  316|     r316_4(int)        = Load                : &:r316_3, m314_3
+#  316|     r316_5(bool)       = CompareEQ           : r316_2, r316_4
+#  316|     v316_6(void)       = ConditionalBranch   : r316_5
+#-----|   False -> Block 5
+#-----|   True -> Block 1
+
+#  317|   Block 1
+#  317|     r317_1(glval<int>) = VariableAddress[a] : 
+#  317|     r317_2(int)        = Load               : &:r317_1, m313_3
+#  317|     r317_3(int)        = Constant[5]        : 
+#  317|     r317_4(bool)       = CompareLT          : r317_2, r317_3
+#  317|     v317_5(void)       = ConditionalBranch  : r317_4
+#-----|   False -> Block 3
+#-----|   True -> Block 2
+
+#  319|   Block 2
+#  319|     r319_1(int)        = Constant[0]        : 
+#  319|     r319_2(glval<int>) = VariableAddress[r] : 
+#  319|     m319_3(int)        = Store              : &:r319_2, r319_1
+#-----|   Goto -> Block 4
+
+#  324|   Block 3
+#  324|     r324_1(int)        = Constant[1]        : 
+#  324|     r324_2(glval<int>) = VariableAddress[r] : 
+#  324|     m324_3(int)        = Store              : &:r324_2, r324_1
+#-----|   Goto -> Block 4
+
+#  330|   Block 4
+#  330|     m330_1(int)        = Phi                : from 2:m319_3, from 3:m324_3
+#  330|     r330_2(glval<int>) = VariableAddress[x] : 
+#  330|     r330_3(int)        = Constant[7]        : 
+#  330|     m330_4(int)        = Store              : &:r330_2, r330_3
+#-----|   Goto -> Block 6
+
+#  334|   Block 5
+#  334|     r334_1(int)        = Constant[2]        : 
+#  334|     r334_2(glval<int>) = VariableAddress[r] : 
+#  334|     m334_3(int)        = Store              : &:r334_2, r334_1
+#-----|   Goto -> Block 6
+
+#  338|   Block 6
+#  338|     m338_1(int)        = Phi                      : from 4:m330_1, from 5:m334_3
+#  338|     r338_2(glval<int>) = VariableAddress[#return] : 
+#  338|     r338_3(glval<int>) = VariableAddress[r]       : 
+#  338|     r338_4(int)        = Load                     : &:r338_3, m338_1
+#  338|     m338_5(int)        = Store                    : &:r338_2, r338_4
+#  312|     r312_5(glval<int>) = VariableAddress[#return] : 
+#  312|     v312_6(void)       = ReturnValue              : &:r312_5, m338_5
+#  312|     v312_7(void)       = UnmodeledUse             : mu*
+#  312|     v312_8(void)       = AliasedUse               : ~mu312_4
+#  312|     v312_9(void)       = ExitFunction             : 

--- a/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir_unsound.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir_unsound.expected
@@ -1359,3 +1359,113 @@ ssa.cpp:
 #  291|     v291_9(void)            = UnmodeledUse                    : mu*
 #  291|     v291_10(void)           = AliasedUse                      : ~mu291_4
 #  291|     v291_11(void)           = ExitFunction                    : 
+
+#  299| int DegeneratePhiAfterUnreachable()
+#  299|   Block 0
+#  299|     v299_1(void)       = EnterFunction       : 
+#  299|     mu299_2(unknown)   = AliasedDefinition   : 
+#  299|     mu299_3(unknown)   = InitializeNonLocal  : 
+#  299|     mu299_4(unknown)   = UnmodeledDefinition : 
+#  300|     r300_1(glval<int>) = VariableAddress[a]  : 
+#  300|     r300_2(int)        = Constant[5]         : 
+#  300|     m300_3(int)        = Store               : &:r300_1, r300_2
+#  301|     r301_1(glval<int>) = VariableAddress[b]  : 
+#  301|     r301_2(int)        = Constant[5]         : 
+#  301|     m301_3(int)        = Store               : &:r301_1, r301_2
+#  302|     r302_1(glval<int>) = VariableAddress[a]  : 
+#  302|     r302_2(int)        = Load                : &:r302_1, m300_3
+#  302|     r302_3(glval<int>) = VariableAddress[b]  : 
+#  302|     r302_4(int)        = Load                : &:r302_3, m301_3
+#  302|     r302_5(bool)       = CompareEQ           : r302_2, r302_4
+#  302|     v302_6(void)       = ConditionalBranch   : r302_5
+#-----|   False -> Block 3
+#-----|   True -> Block 2
+
+#  299|   Block 1
+#  299|     m299_5(int)        = Phi                      : from 2:m303_3, from 3:m308_3
+#  299|     r299_6(glval<int>) = VariableAddress[#return] : 
+#  299|     v299_7(void)       = ReturnValue              : &:r299_6, m299_5
+#  299|     v299_8(void)       = UnmodeledUse             : mu*
+#  299|     v299_9(void)       = AliasedUse               : ~mu299_4
+#  299|     v299_10(void)      = ExitFunction             : 
+
+#  303|   Block 2
+#  303|     r303_1(glval<int>) = VariableAddress[#return] : 
+#  303|     r303_2(int)        = Constant[0]              : 
+#  303|     m303_3(int)        = Store                    : &:r303_1, r303_2
+#-----|   Goto -> Block 1
+
+#  308|   Block 3
+#  308|     r308_1(glval<int>) = VariableAddress[#return] : 
+#  308|     r308_2(int)        = Constant[1]              : 
+#  308|     m308_3(int)        = Store                    : &:r308_1, r308_2
+#-----|   Goto -> Block 1
+
+#  312| int TwoDegeneratePhisAfterUnreachable()
+#  312|   Block 0
+#  312|     v312_1(void)       = EnterFunction       : 
+#  312|     mu312_2(unknown)   = AliasedDefinition   : 
+#  312|     mu312_3(unknown)   = InitializeNonLocal  : 
+#  312|     mu312_4(unknown)   = UnmodeledDefinition : 
+#  313|     r313_1(glval<int>) = VariableAddress[a]  : 
+#  313|     r313_2(int)        = Constant[5]         : 
+#  313|     m313_3(int)        = Store               : &:r313_1, r313_2
+#  314|     r314_1(glval<int>) = VariableAddress[b]  : 
+#  314|     r314_2(int)        = Constant[5]         : 
+#  314|     m314_3(int)        = Store               : &:r314_1, r314_2
+#  315|     r315_1(glval<int>) = VariableAddress[r]  : 
+#  315|     m315_2(int)        = Uninitialized[r]    : &:r315_1
+#  316|     r316_1(glval<int>) = VariableAddress[a]  : 
+#  316|     r316_2(int)        = Load                : &:r316_1, m313_3
+#  316|     r316_3(glval<int>) = VariableAddress[b]  : 
+#  316|     r316_4(int)        = Load                : &:r316_3, m314_3
+#  316|     r316_5(bool)       = CompareEQ           : r316_2, r316_4
+#  316|     v316_6(void)       = ConditionalBranch   : r316_5
+#-----|   False -> Block 5
+#-----|   True -> Block 1
+
+#  317|   Block 1
+#  317|     r317_1(glval<int>) = VariableAddress[a] : 
+#  317|     r317_2(int)        = Load               : &:r317_1, m313_3
+#  317|     r317_3(int)        = Constant[5]        : 
+#  317|     r317_4(bool)       = CompareLT          : r317_2, r317_3
+#  317|     v317_5(void)       = ConditionalBranch  : r317_4
+#-----|   False -> Block 3
+#-----|   True -> Block 2
+
+#  319|   Block 2
+#  319|     r319_1(int)        = Constant[0]        : 
+#  319|     r319_2(glval<int>) = VariableAddress[r] : 
+#  319|     m319_3(int)        = Store              : &:r319_2, r319_1
+#-----|   Goto -> Block 4
+
+#  324|   Block 3
+#  324|     r324_1(int)        = Constant[1]        : 
+#  324|     r324_2(glval<int>) = VariableAddress[r] : 
+#  324|     m324_3(int)        = Store              : &:r324_2, r324_1
+#-----|   Goto -> Block 4
+
+#  330|   Block 4
+#  330|     m330_1(int)        = Phi                : from 2:m319_3, from 3:m324_3
+#  330|     r330_2(glval<int>) = VariableAddress[x] : 
+#  330|     r330_3(int)        = Constant[7]        : 
+#  330|     m330_4(int)        = Store              : &:r330_2, r330_3
+#-----|   Goto -> Block 6
+
+#  334|   Block 5
+#  334|     r334_1(int)        = Constant[2]        : 
+#  334|     r334_2(glval<int>) = VariableAddress[r] : 
+#  334|     m334_3(int)        = Store              : &:r334_2, r334_1
+#-----|   Goto -> Block 6
+
+#  338|   Block 6
+#  338|     m338_1(int)        = Phi                      : from 4:m330_1, from 5:m334_3
+#  338|     r338_2(glval<int>) = VariableAddress[#return] : 
+#  338|     r338_3(glval<int>) = VariableAddress[r]       : 
+#  338|     r338_4(int)        = Load                     : &:r338_3, m338_1
+#  338|     m338_5(int)        = Store                    : &:r338_2, r338_4
+#  312|     r312_5(glval<int>) = VariableAddress[#return] : 
+#  312|     v312_6(void)       = ReturnValue              : &:r312_5, m338_5
+#  312|     v312_7(void)       = UnmodeledUse             : mu*
+#  312|     v312_8(void)       = AliasedUse               : ~mu312_4
+#  312|     v312_9(void)       = ExitFunction             : 

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
@@ -1273,6 +1273,14 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() { result = this.getAnInputOperand().getDef() }
+
+  /**
+   * Gets the input operand representing the value that flows from the specified predecessor block.
+   */
+  final PhiInputOperand getInputOperand(IRBlock predecessorBlock) {
+    result = this.getAnOperand() and
+    result.getPredecessorBlock() = predecessorBlock
+  }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -1273,6 +1273,14 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() { result = this.getAnInputOperand().getDef() }
+
+  /**
+   * Gets the input operand representing the value that flows from the specified predecessor block.
+   */
+  final PhiInputOperand getInputOperand(IRBlock predecessorBlock) {
+    result = this.getAnOperand() and
+    result.getPredecessorBlock() = predecessorBlock
+  }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/SimpleSSA.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/SimpleSSA.qll
@@ -17,7 +17,7 @@ private predicate isTotalAccess(Allocation var, AddressOperand addrOperand, IRTy
  * variable if its address never escapes and all reads and writes of that variable access the entire
  * variable using the original type of the variable.
  */
-private predicate isVariableModeled(Allocation var) {
+predicate isVariableModeled(Allocation var) {
   not allocationEscapes(var) and
   forall(Instruction instr, AddressOperand addrOperand, IRType type |
     addrOperand = instr.getResultAddressOperand() and


### PR DESCRIPTION
_Leaving this PR as a draft until I have perf measurements from real snapshots to validate the expected speedup_

We build SSA twice. The first iteration, "unaliased SSA", considers only those memory locations that are not aliased, do not have their address escape, and are always accessed in their entirety and as their underlying declared type. The second iteration, "aliased SSA", considers all memory locations. However, since whatever defs and uses we computed for unaliased SSA are still valid for aliased SSA, because they never overlap with the aliased memory locations that aliased SSA adds into the mix. If we can reuse the unaliased SSA information directly, we can potentially save significant cost in building aliased SSA.

The main changes in this PR are in `SSAConstruction.qll`. Instead of throwing away all `Phi` instructions from the previous IR iteration, we bring them along. When computing the definition for a given use, if that use already had a definition in the previous iteration, we reuse that definition. This is slightly complicated by the possibility of degenerate (single-operand) `Phi` instructions due to unreachable code being eliminated between iterations. If we would have wound up with a degenerate `Phi` instruction, we recurse to the definition of that `Phi` instruction's sole reachable input operand. See the new test cases for a couple examples.

In aliased SSA's `AliasConfiguration.qll`, I stopped creating allocations for variables that were already modeled in unaliased SSA. This in turn prevents us from creating memory locations for those variables and their defs and uses, which is where we hope to reduce evaluation time.

I also tweaked the `getInstructionUniqueId()` predicate to reuse the unique ID from the previous stage, which preserves ordering of `Phi` instructions in a block to minimize test output diffs.

The `points_to` test had to be updated to no longer expect points-to analysis on unaliased SSA to report results that were already reported when running on raw IR.

Finally, I added `PhiInstruction.getInputOperand()`. I'm surprised we didn't have it already.