### PR TITLE
C++: Replace underscores with dashes in query @id

### DIFF
--- a/cpp/ql/src/Likely Bugs/Protocols/TlsSettingsMisconfiguration.ql
+++ b/cpp/ql/src/Likely Bugs/Protocols/TlsSettingsMisconfiguration.ql
@@ -3,7 +3,7 @@
  * @description Using the TLS or SSLv23 protocol from the boost::asio library, but not disabling deprecated protocols, or disabling minimum-recommended protocols.
  * @kind problem
  * @problem.severity error
- * @id cpp/boost/tls_settings_misconfiguration
+ * @id cpp/boost/tls-settings-misconfiguration
  * @tags security
  */
 


### PR DESCRIPTION
The query id in `TlsSettingsMisconfiguration.ql` was syntactically invalid. See https://github.slack.com/archives/CP0LHP150/p1586426614314900 for @aibaars comments.