### PR TITLE
Python: ObjectAPI to ValueAPI: WrongNameForArgumentInClassInstantiation

### DIFF
--- a/python/ql/src/Classes/WrongNameForArgumentInClassInstantiation.ql
+++ b/python/ql/src/Classes/WrongNameForArgumentInClassInstantiation.ql
@@ -16,9 +16,9 @@
 import python
 import Expressions.CallArgs
 
-from Call call, ClassObject cls, string name, FunctionObject init
+from Call call, ClassValue cls, string name, FunctionValue init
 where
-    illegally_named_parameter_objectapi(call, cls, name) and
-    init = get_function_or_initializer_objectapi(cls)
+    illegally_named_parameter(call, cls, name) and
+    init = get_function_or_initializer(cls)
 select call, "Keyword argument '" + name + "' is not a supported parameter name of $@.", init,
     init.getQualifiedName()

--- a/python/ql/test/query-tests/Classes/Arguments/WrongNameForArgumentInClassInstantiation.expected
+++ b/python/ql/test/query-tests/Classes/Arguments/WrongNameForArgumentInClassInstantiation.expected
@@ -1,4 +1,4 @@
-| wrong_arguments.py:65:1:65:7 | F0() | Keyword argument 'y' is not a supported parameter name of $@. | wrong_arguments.py:4:5:4:26 | Function __init__ | F0.__init__ |
-| wrong_arguments.py:66:1:66:7 | F1() | Keyword argument 'z' is not a supported parameter name of $@. | wrong_arguments.py:8:5:8:36 | Function __init__ | F1.__init__ |
-| wrong_arguments.py:67:1:67:12 | F2() | Keyword argument 'y' is not a supported parameter name of $@. | wrong_arguments.py:12:5:12:30 | Function __init__ | F2.__init__ |
-| wrong_arguments.py:92:1:92:27 | F6() | Keyword argument 'z' is not a supported parameter name of $@. | wrong_arguments.py:28:5:28:30 | Function __init__ | F6.__init__ |
+| wrong_arguments.py:65:1:65:7 | F0() | Keyword argument 'y' is not a supported parameter name of $@. | wrong_arguments.py:4:5:4:26 | Function F0.__init__ | F0.__init__ |
+| wrong_arguments.py:66:1:66:7 | F1() | Keyword argument 'z' is not a supported parameter name of $@. | wrong_arguments.py:8:5:8:36 | Function F1.__init__ | F1.__init__ |
+| wrong_arguments.py:67:1:67:12 | F2() | Keyword argument 'y' is not a supported parameter name of $@. | wrong_arguments.py:12:5:12:30 | Function F2.__init__ | F2.__init__ |
+| wrong_arguments.py:92:1:92:27 | F6() | Keyword argument 'z' is not a supported parameter name of $@. | wrong_arguments.py:28:5:28:30 | Function F6.__init__ | F6.__init__ |


### PR DESCRIPTION
This PR is part of the ValueAPI modernization effort.