### PR TITLE
JS: more precise getChild call for matching "../"

### DIFF
--- a/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/TaintedPathCustomizations.qll
@@ -285,7 +285,7 @@ module TaintedPath {
     exists(RegExpSequence seq | seq = result |
       seq.getChild(0).getConstantValue() = "." and
       seq.getChild(1).getConstantValue() = "." and
-      seq.getAChild().getAMatchedString() = "/"
+      seq.getChild(2).getAMatchedString() = "/"
     )
     or
     exists(RegExpGroup group | result = group | group.getChild(0) = getADotDotSlashMatcher())


### PR DESCRIPTION
Fixing this post-merge review comment: https://github.com/Semmle/ql/pull/3197#discussion_r404056474