### PR TITLE
JS: Avoid depending on location information in a few places

### DIFF
--- a/javascript/ql/src/semmle/javascript/AST.qll
+++ b/javascript/ql/src/semmle/javascript/AST.qll
@@ -23,6 +23,10 @@ import javascript
 class ASTNode extends @ast_node, Locatable {
   override Location getLocation() { hasLocation(this, result) }
 
+  override File getFile() {
+    result = getLocation().getFile() // Specialized for performance reasons
+  }
+
   /** Gets the first token belonging to this element. */
   Token getFirstToken() {
     exists(Location l1, Location l2 |

--- a/javascript/ql/src/semmle/javascript/NPM.qll
+++ b/javascript/ql/src/semmle/javascript/NPM.qll
@@ -190,7 +190,7 @@ class BugTrackerInfo extends JSONValue {
   }
 
   /** Gets the bug tracker URL. */
-  string getURL() {
+  string getUrl() {
     result = this.(JSONObject).getPropStringValue("url") or
     result = this.(JSONString).getValue()
   }

--- a/javascript/ql/src/semmle/javascript/NPM.qll
+++ b/javascript/ql/src/semmle/javascript/NPM.qll
@@ -233,7 +233,7 @@ class ContributorInfo extends JSONValue {
   }
 
   /** Gets the contributor's homepage URL. */
-  string getURL() {
+  string getUrl() {
     result = this.(JSONObject).getPropStringValue("url") or
     result = parseInfo(3)
   }
@@ -249,7 +249,7 @@ class RepositoryInfo extends JSONObject {
   string getType() { result = getPropStringValue("type") }
 
   /** Gets the repository URL. */
-  string getURL() { result = getPropStringValue("url") }
+  string getUrl() { result = getPropStringValue("url") }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -173,7 +173,7 @@ module DataFlow {
     }
 
     /** Gets the file this data flow node comes from. */
-    File getFile() { hasLocationInfo(result.getAbsolutePath(), _, _, _, _) }
+    File getFile() { none() } // overridden in subclasses
 
     /** Gets the start line of this data flow node. */
     int getStartLine() { hasLocationInfo(_, result, _, _, _) }
@@ -313,6 +313,8 @@ module DataFlow {
       astNode.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
     }
 
+    override File getFile() { result = astNode.getFile() }
+
     override string toString() { result = astNode.toString() }
   }
 
@@ -336,6 +338,8 @@ module DataFlow {
     }
 
     override string toString() { result = ssa.getSourceVariable().getName() }
+
+    override File getFile() { result = ssa.getBasicBlock().getFile() }
 
     override ASTNode getAstNode() { none() }
   }
@@ -361,6 +365,8 @@ module DataFlow {
 
     override string toString() { result = prop.(ASTNode).toString() }
 
+    override File getFile() { result = prop.(ASTNode).getFile() }
+
     override ASTNode getAstNode() { result = prop }
   }
 
@@ -384,6 +390,8 @@ module DataFlow {
 
     override string toString() { result = "..." + rest.toString() }
 
+    override File getFile() { result = pattern.getFile() }
+
     override ASTNode getAstNode() { result = rest }
   }
 
@@ -405,6 +413,8 @@ module DataFlow {
     }
 
     override string toString() { result = pattern.toString() }
+
+    override File getFile() { result = pattern.getFile() }
 
     override ASTNode getAstNode() { result = pattern }
   }
@@ -428,6 +438,8 @@ module DataFlow {
     }
 
     override string toString() { result = elt.toString() }
+
+    override File getFile() { result = pattern.getFile() }
 
     override ASTNode getAstNode() { result = elt }
   }
@@ -456,6 +468,8 @@ module DataFlow {
 
     override string toString() { result = elt.toString() }
 
+    override File getFile() { result = arr.getFile() }
+
     override ASTNode getAstNode() { result = elt }
   }
 
@@ -478,6 +492,8 @@ module DataFlow {
     }
 
     override string toString() { result = "reflective call" }
+
+    override File getFile() { result = call.getFile() }
   }
 
   /**
@@ -497,6 +513,8 @@ module DataFlow {
     }
 
     override string toString() { result = imprt.toString() }
+
+    override File getFile() { result = imprt.getFile() }
   }
 
   /**
@@ -924,6 +942,8 @@ module DataFlow {
     ) {
       p.getLocation().hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
     }
+
+    override File getFile() { result = p.getFile() }
   }
 
   /**
@@ -944,6 +964,8 @@ module DataFlow {
 
     /** Gets the attribute corresponding to this data flow node. */
     HTML::Attribute getAttribute() { result = attr }
+
+    override File getFile() { result = attr.getFile() }
   }
 
   /**
@@ -968,6 +990,8 @@ module DataFlow {
      * Gets the function corresponding to this exceptional return node.
      */
     Function getFunction() { result = function }
+
+    override File getFile() { result = function.getFile() }
   }
 
   /**
@@ -992,6 +1016,8 @@ module DataFlow {
      * Gets the invocation corresponding to this exceptional return node.
      */
     DataFlow::InvokeNode getInvocation() { result = invoke.flow() }
+
+    override File getFile() { result = invoke.getFile() }
   }
 
   /**
@@ -1218,6 +1244,10 @@ module DataFlow {
             .getLocation()
             .hasLocationInfo(filepath, startline, startcolumn, endline, endcolumn)
       )
+    }
+
+    override File getFile() {
+      exists(StmtContainer container | this = TThisNode(container) | result = container.getFile())
     }
   }
 

--- a/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/DataFlow.qll
@@ -165,11 +165,7 @@ module DataFlow {
     predicate hasLocationInfo(
       string filepath, int startline, int startcolumn, int endline, int endcolumn
     ) {
-      filepath = "" and
-      startline = 0 and
-      startcolumn = 0 and
-      endline = 0 and
-      endcolumn = 0
+      none()
     }
 
     /** Gets the file this data flow node comes from. */


### PR DESCRIPTION
Changes `getFile()` to be computed more directly instead of going through location information. Ultimately it still comes from the location table, but previously the indirection caused a separate copy of the location table to be materialized.

Also has a few other tweaks such as renaming `getURL` to `getUrl` since the former has a special meaning in QL as a location provider.

Evaluations all look good. They use https://github.com/Semmle/ql/pull/3237 as the baseline, compared with the merge of the two PRs.
- [Full query suite on smoke-test](https://git.semmle.com/asger/dist-compare-reports/tree/js/location-tweaks_1586444110302)
- [Security on nightly](https://git.semmle.com/asger/dist-compare-reports/tree/js/location-tweaks_1586506554324)
- [Re-run of fastest and slowest of above](https://git.semmle.com/asger/dist-compare-reports/tree/js/location-tweaks_1586520602947)