### PR TITLE
JS: Add backwards-compatible predicates to SocketIO

### DIFF
--- a/javascript/ql/src/semmle/javascript/frameworks/SocketIO.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SocketIO.qll
@@ -283,9 +283,7 @@ module SocketIO {
     SendNode getASender() { result.getAReceiver() = this }
 
     /** Gets the acknowledgment callback, if any. */
-    ReceiveCallback getAck() {
-      result.getReceiveNode() = this
-    }
+    ReceiveCallback getAck() { result.getReceiveNode() = this }
 
     /** DEPRECATED. Use `getChannel()` instead. */
     deprecated string getEventName() { result = getChannel() }
@@ -374,9 +372,7 @@ module SocketIO {
     }
 
     /** Gets the acknowledgment callback, if any. */
-    SendCallback getAck() {
-      result.getSendNode()  =this
-    }
+    SendCallback getAck() { result.getSendNode() = this }
 
     /** DEPRECATED. Use `getChannel()` instead. */
     deprecated string getEventName() { result = getChannel() }
@@ -573,9 +569,7 @@ module SocketIOClient {
     DataFlow::SourceNode getAReceivedItem() { result = getReceivedItem(_) }
 
     /** Gets the acknowledgment callback, if any. */
-    DataFlow::SourceNode getAck() {
-      result.(ReceiveCallback).getReceiveNode() = this
-    }
+    DataFlow::SourceNode getAck() { result.(ReceiveCallback).getReceiveNode() = this }
 
     /** Gets a server-side node that may be sending the data received here. */
     SocketIO::SendNode getASender() {
@@ -660,9 +654,7 @@ module SocketIOClient {
     }
 
     /** Gets the acknowledgment callback, if any. */
-    DataFlow::FunctionNode getAck() {
-      result.(SendCallback).getSendNode() = this
-    }
+    DataFlow::FunctionNode getAck() { result.(SendCallback).getSendNode() = this }
 
     /** DEPRECATED. Use `getChannel()` instead. */
     deprecated string getEventName() { result = getChannel() }

--- a/javascript/ql/src/semmle/javascript/frameworks/SocketIO.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SocketIO.qll
@@ -283,8 +283,8 @@ module SocketIO {
     SendNode getASender() { result.getAReceiver() = this }
 
     /** Gets the acknowledgment callback, if any. */
-    DataFlow::SourceNode getAck() {
-      result.(ReceiveCallback).getReceiveNode() = this
+    ReceiveCallback getAck() {
+      result.getReceiveNode() = this
     }
 
     /** DEPRECATED. Use `getChannel()` instead. */
@@ -374,10 +374,8 @@ module SocketIO {
     }
 
     /** Gets the acknowledgment callback, if any. */
-    DataFlow::FunctionNode getAck() {
-      // acknowledgments are only available when sending through a socket
-      exists(getSocket()) and
-      result = getLastArgument().getALocalSource()
+    SendCallback getAck() {
+      result.getSendNode()  =this
     }
 
     /** DEPRECATED. Use `getChannel()` instead. */
@@ -576,8 +574,7 @@ module SocketIOClient {
 
     /** Gets the acknowledgment callback, if any. */
     DataFlow::SourceNode getAck() {
-      result = getListener().getLastParameter() and
-      exists(result.getAnInvocation())
+      result.(ReceiveCallback).getReceiveNode() = this
     }
 
     /** Gets a server-side node that may be sending the data received here. */
@@ -664,9 +661,7 @@ module SocketIOClient {
 
     /** Gets the acknowledgment callback, if any. */
     DataFlow::FunctionNode getAck() {
-      // acknowledgments are only available when sending through a socket
-      exists(getSocket()) and
-      result = getLastArgument().getALocalSource()
+      result.(SendCallback).getSendNode() = this
     }
 
     /** DEPRECATED. Use `getChannel()` instead. */

--- a/javascript/ql/src/semmle/javascript/frameworks/SocketIO.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/SocketIO.qll
@@ -85,8 +85,6 @@ module SocketIO {
 
     /**
      * DEPRECATED. Always returns `this` as a `ServerObject` now represents the origin of a server.
-     *
-     * Instead of `getOrigin()` to get a server origin from a reference, use `ServerObject.ref()` to get references to a given server.
      */
     deprecated DataFlow::SourceNode getOrigin() { result = this }
   }
@@ -285,9 +283,8 @@ module SocketIO {
     SendNode getASender() { result.getAReceiver() = this }
 
     /** Gets the acknowledgment callback, if any. */
-    DataFlow::FunctionNode getAck() {
-      result = getListener().getLastParameter() and
-      exists(result.getAnInvocation())
+    DataFlow::SourceNode getAck() {
+      result.(ReceiveCallback).getReceiveNode() = this
     }
 
     /** DEPRECATED. Use `getChannel()` instead. */
@@ -311,6 +308,9 @@ module SocketIO {
     override SocketIOClient::SendCallback getAReceiver() {
       result.getSendNode().getAReceiver() = rcv
     }
+
+    /** Gets the API call to which this is a callback. */
+    ReceiveNode getReceiveNode() { result = rcv }
   }
 
   /**
@@ -575,7 +575,7 @@ module SocketIOClient {
     DataFlow::SourceNode getAReceivedItem() { result = getReceivedItem(_) }
 
     /** Gets the acknowledgment callback, if any. */
-    DataFlow::FunctionNode getAck() {
+    DataFlow::SourceNode getAck() {
       result = getListener().getLastParameter() and
       exists(result.getAnInvocation())
     }
@@ -588,11 +588,11 @@ module SocketIOClient {
   }
 
   /** An acknowledgment callback from a receive node. */
-  class RecieveCallback extends EventDispatch::Range, DataFlow::SourceNode {
+  class ReceiveCallback extends EventDispatch::Range, DataFlow::SourceNode {
     override SocketObject emitter;
     ReceiveNode rcv;
 
-    RecieveCallback() {
+    ReceiveCallback() {
       this = rcv.getListener().getLastParameter() and
       exists(this.getAnInvocation()) and
       emitter = rcv.getEmitter()

--- a/javascript/ql/test/library-tests/frameworks/SocketIO/ClientReceiveNode_getAck.qll
+++ b/javascript/ql/test/library-tests/frameworks/SocketIO/ClientReceiveNode_getAck.qll
@@ -1,7 +1,7 @@
 import javascript
 
 query predicate test_ClientReceiveNode_getAck(
-  SocketIOClient::ReceiveNode rn, SocketIOClient::RecieveCallback res
+  SocketIOClient::ReceiveNode rn, SocketIOClient::ReceiveCallback res
 ) {
   res.getReceiveNode() = rn
 }


### PR DESCRIPTION
Makes the API exposed by `SocketIO` backwards compatible with clients from the 1.23 release. 

There are no DIL changes so an evaluation shouldn't be necessary.