### PR TITLE
JS: add support for util.promisify with child_process calls

### DIFF
--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -87,8 +87,6 @@
 | Identical operands (`js/redundant-operation`) | Fewer results | This query now recognizes cases where the operands change a value using ++/-- expressions. |
 | Superfluous trailing arguments (`js/superfluous-trailing-arguments`) | Fewer results | This query now recognizes cases where a function uses the `Function.arguments` value to process a variable number of parameters. |
 | Incomplete URL scheme check (`js/incomplete-url-scheme-check`) | More results | This query now recognizes additional variations of URL scheme checks. |
-| Uncontrolled data used in path expression (`js/path-injection`) | More results | This query now recognizes additional file system calls. |
-| Uncontrolled command line (`js/command-line-injection`) | More results | This query now recognizes additional command execution calls. |
 
 ## Changes to libraries
 

--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -87,6 +87,8 @@
 | Identical operands (`js/redundant-operation`) | Fewer results | This query now recognizes cases where the operands change a value using ++/-- expressions. |
 | Superfluous trailing arguments (`js/superfluous-trailing-arguments`) | Fewer results | This query now recognizes cases where a function uses the `Function.arguments` value to process a variable number of parameters. |
 | Incomplete URL scheme check (`js/incomplete-url-scheme-check`) | More results | This query now recognizes more variations of URL scheme checks. |
+| Uncontrolled data used in path expression (`js/path-injection`) | More results | This query now recognizes more file system calls. |
+| Uncontrolled command line (`js/command-line-injection`) | More results | This query now recognizes more command execution calls. |
 
 ## Changes to libraries
 

--- a/change-notes/1.24/analysis-javascript.md
+++ b/change-notes/1.24/analysis-javascript.md
@@ -86,9 +86,9 @@
 | Useless regular-expression character escape (`js/useless-regexp-character-escape`) | Fewer false positive results | This query now distinguishes escapes in strings and regular expression literals. |
 | Identical operands (`js/redundant-operation`) | Fewer results | This query now recognizes cases where the operands change a value using ++/-- expressions. |
 | Superfluous trailing arguments (`js/superfluous-trailing-arguments`) | Fewer results | This query now recognizes cases where a function uses the `Function.arguments` value to process a variable number of parameters. |
-| Incomplete URL scheme check (`js/incomplete-url-scheme-check`) | More results | This query now recognizes more variations of URL scheme checks. |
-| Uncontrolled data used in path expression (`js/path-injection`) | More results | This query now recognizes more file system calls. |
-| Uncontrolled command line (`js/command-line-injection`) | More results | This query now recognizes more command execution calls. |
+| Incomplete URL scheme check (`js/incomplete-url-scheme-check`) | More results | This query now recognizes additional variations of URL scheme checks. |
+| Uncontrolled data used in path expression (`js/path-injection`) | More results | This query now recognizes additional file system calls. |
+| Uncontrolled command line (`js/command-line-injection`) | More results | This query now recognizes additional command execution calls. |
 
 ## Changes to libraries
 

--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -1,0 +1,22 @@
+# Improvements to JavaScript analysis
+
+## General improvements
+
+
+## New queries
+
+| **Query**                                                                       | **Tags**                                                          | **Purpose**                                                                                                                                                                            |
+|---------------------------------------------------------------------------------|-------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+
+
+## Changes to existing queries
+
+| **Query**                      | **Expected impact**          | **Change**                                                                |
+|--------------------------------|------------------------------|---------------------------------------------------------------------------|
+| Uncontrolled data used in path expression (`js/path-injection`) | More results | This query now recognizes additional file system calls. |
+| Uncontrolled command line (`js/command-line-injection`) | More results | This query now recognizes additional command execution calls. |
+
+## Changes to libraries
+
+
+

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -594,6 +594,14 @@ module NodeJSLib {
 
     ChildProcessMethodCall() {
       this = DataFlow::moduleMember("child_process", methodName).getACall()
+      or
+      exists(DataFlow::CallNode promisify |
+        promisify = DataFlow::moduleMember("util", "promisify").getACall()
+      |
+        this = promisify.getACall() and
+        promisify.getArgument(0).getALocalSource() =
+          DataFlow::moduleMember("child_process", methodName)
+      )
     }
 
     private DataFlow::Node getACommandArgument(boolean shell) {

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -587,15 +587,15 @@ module NodeJSLib {
   }
 
   /**
-   * Gets a possibly promisified (using `util.promisify`) version of the input `func`.
+   * Gets a possibly promisified (using `util.promisify`) version of the input `callback`.
    */
-  DataFlow::SourceNode maybePromisified(DataFlow::SourceNode func) {
-    result = func
+  DataFlow::SourceNode maybePromisified(DataFlow::SourceNode callback) {
+    result = callback
     or
     exists(DataFlow::CallNode promisify |
       promisify = DataFlow::moduleMember("util", "promisify").getACall()
     |
-      result = promisify and promisify.getArgument(0).getALocalSource() = func
+      result = promisify and promisify.getArgument(0).getALocalSource() = callback
     )
   }
 

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -589,7 +589,7 @@ module NodeJSLib {
   /**
    * Gets a possibly promisified (using `util.promisify`) version of the input `callback`.
    */
-  DataFlow::SourceNode maybePromisified(DataFlow::SourceNode callback) {
+  private DataFlow::SourceNode maybePromisified(DataFlow::SourceNode callback) {
     result = callback
     or
     exists(DataFlow::CallNode promisify |

--- a/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
+++ b/javascript/ql/src/semmle/javascript/frameworks/NodeJSLib.qll
@@ -459,7 +459,7 @@ module NodeJSLib {
   private class NodeJSFileSystemAccess extends FileSystemAccess, DataFlow::CallNode {
     string methodName;
 
-    NodeJSFileSystemAccess() { this = fsModuleMember(methodName).getACall() }
+    NodeJSFileSystemAccess() { this = maybePromisified(fsModuleMember(methodName)).getACall() }
 
     /**
      * Gets the name of the called method.

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/TaintedPath.expected
@@ -2082,6 +2082,92 @@ nodes
 | other-fs-libraries.js:24:35:24:38 | path |
 | other-fs-libraries.js:24:35:24:38 | path |
 | other-fs-libraries.js:24:35:24:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:24:38:30 | req.url |
+| other-fs-libraries.js:38:24:38:30 | req.url |
+| other-fs-libraries.js:38:24:38:30 | req.url |
+| other-fs-libraries.js:38:24:38:30 | req.url |
+| other-fs-libraries.js:38:24:38:30 | req.url |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:40:35:40:38 | path |
 | tainted-require.js:7:19:7:37 | req.param("module") |
 | tainted-require.js:7:19:7:37 | req.param("module") |
 | tainted-require.js:7:19:7:37 | req.param("module") |
@@ -5673,6 +5759,118 @@ edges
 | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:9:14:9:37 | url.par ... , true) |
 | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:9:14:9:37 | url.par ... , true) |
 | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:9:14:9:37 | url.par ... , true) |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:7:38:48 | path | other-fs-libraries.js:40:35:40:38 | path |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:37 | url.par ... , true) | other-fs-libraries.js:38:14:38:43 | url.par ... ).query |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:43 | url.par ... ).query | other-fs-libraries.js:38:14:38:48 | url.par ... ry.path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:14:38:48 | url.par ... ry.path | other-fs-libraries.js:38:7:38:48 | path |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
+| other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:38:14:38:37 | url.par ... , true) |
 | tainted-require.js:7:19:7:37 | req.param("module") | tainted-require.js:7:19:7:37 | req.param("module") |
 | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | tainted-sendFile.js:8:16:8:33 | req.param("gimme") |
 | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | tainted-sendFile.js:10:16:10:33 | req.param("gimme") |
@@ -6572,6 +6770,7 @@ edges
 | other-fs-libraries.js:17:35:17:38 | path | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:17:35:17:38 | path | This path depends on $@. | other-fs-libraries.js:9:24:9:30 | req.url | a user-provided value |
 | other-fs-libraries.js:19:56:19:59 | path | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:19:56:19:59 | path | This path depends on $@. | other-fs-libraries.js:9:24:9:30 | req.url | a user-provided value |
 | other-fs-libraries.js:24:35:24:38 | path | other-fs-libraries.js:9:24:9:30 | req.url | other-fs-libraries.js:24:35:24:38 | path | This path depends on $@. | other-fs-libraries.js:9:24:9:30 | req.url | a user-provided value |
+| other-fs-libraries.js:40:35:40:38 | path | other-fs-libraries.js:38:24:38:30 | req.url | other-fs-libraries.js:40:35:40:38 | path | This path depends on $@. | other-fs-libraries.js:38:24:38:30 | req.url | a user-provided value |
 | tainted-require.js:7:19:7:37 | req.param("module") | tainted-require.js:7:19:7:37 | req.param("module") | tainted-require.js:7:19:7:37 | req.param("module") | This path depends on $@. | tainted-require.js:7:19:7:37 | req.param("module") | a user-provided value |
 | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | This path depends on $@. | tainted-sendFile.js:8:16:8:33 | req.param("gimme") | a user-provided value |
 | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | This path depends on $@. | tainted-sendFile.js:10:16:10:33 | req.param("gimme") | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/other-fs-libraries.js
+++ b/javascript/ql/test/query-tests/Security/CWE-022/TaintedPath/other-fs-libraries.js
@@ -31,3 +31,11 @@ function getFsModule(special) {
     return require("original-fs");
   }
 }
+
+var util = require("util");
+
+http.createServer(function(req, res) {
+  var path = url.parse(req.url, true).query.path;
+
+  util.promisify(fs.readFileSync)(path); // NOT OK
+});

--- a/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-078/CommandInjection.expected
@@ -39,6 +39,14 @@ nodes
 | child_process-test.js:54:25:54:49 | ['/C',  ... at(cmd) |
 | child_process-test.js:54:25:54:49 | ['/C',  ... at(cmd) |
 | child_process-test.js:54:46:54:48 | cmd |
+| child_process-test.js:70:9:70:49 | cmd |
+| child_process-test.js:70:15:70:38 | url.par ... , true) |
+| child_process-test.js:70:15:70:44 | url.par ... ).query |
+| child_process-test.js:70:15:70:49 | url.par ... ry.path |
+| child_process-test.js:70:25:70:31 | req.url |
+| child_process-test.js:70:25:70:31 | req.url |
+| child_process-test.js:72:29:72:31 | cmd |
+| child_process-test.js:72:29:72:31 | cmd |
 | execSeries.js:3:20:3:22 | arr |
 | execSeries.js:6:14:6:16 | arr |
 | execSeries.js:6:14:6:21 | arr[i++] |
@@ -129,6 +137,13 @@ edges
 | child_process-test.js:53:54:53:56 | cmd | child_process-test.js:53:46:53:57 | ["bar", cmd] |
 | child_process-test.js:54:46:54:48 | cmd | child_process-test.js:54:25:54:49 | ['/C',  ... at(cmd) |
 | child_process-test.js:54:46:54:48 | cmd | child_process-test.js:54:25:54:49 | ['/C',  ... at(cmd) |
+| child_process-test.js:70:9:70:49 | cmd | child_process-test.js:72:29:72:31 | cmd |
+| child_process-test.js:70:9:70:49 | cmd | child_process-test.js:72:29:72:31 | cmd |
+| child_process-test.js:70:15:70:38 | url.par ... , true) | child_process-test.js:70:15:70:44 | url.par ... ).query |
+| child_process-test.js:70:15:70:44 | url.par ... ).query | child_process-test.js:70:15:70:49 | url.par ... ry.path |
+| child_process-test.js:70:15:70:49 | url.par ... ry.path | child_process-test.js:70:9:70:49 | cmd |
+| child_process-test.js:70:25:70:31 | req.url | child_process-test.js:70:15:70:38 | url.par ... , true) |
+| child_process-test.js:70:25:70:31 | req.url | child_process-test.js:70:15:70:38 | url.par ... , true) |
 | execSeries.js:3:20:3:22 | arr | execSeries.js:6:14:6:16 | arr |
 | execSeries.js:6:14:6:16 | arr | execSeries.js:6:14:6:21 | arr[i++] |
 | execSeries.js:6:14:6:21 | arr[i++] | execSeries.js:14:24:14:30 | command |
@@ -197,6 +212,7 @@ edges
 | child_process-test.js:54:5:54:50 | cp.spaw ... t(cmd)) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:54:25:54:49 | ['/C',  ... at(cmd) | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:59:5:59:39 | cp.exec ... , args) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:50:15:50:17 | cmd | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
 | child_process-test.js:64:3:64:21 | cp.spawn(cmd, args) | child_process-test.js:6:25:6:31 | req.url | child_process-test.js:43:15:43:17 | cmd | This command depends on $@. | child_process-test.js:6:25:6:31 | req.url | a user-provided value |
+| child_process-test.js:72:29:72:31 | cmd | child_process-test.js:70:25:70:31 | req.url | child_process-test.js:72:29:72:31 | cmd | This command depends on $@. | child_process-test.js:70:25:70:31 | req.url | a user-provided value |
 | execSeries.js:14:41:14:47 | command | execSeries.js:18:34:18:40 | req.url | execSeries.js:14:41:14:47 | command | This command depends on $@. | execSeries.js:18:34:18:40 | req.url | a user-provided value |
 | other.js:7:33:7:35 | cmd | other.js:5:25:5:31 | req.url | other.js:7:33:7:35 | cmd | This command depends on $@. | other.js:5:25:5:31 | req.url | a user-provided value |
 | other.js:8:28:8:30 | cmd | other.js:5:25:5:31 | req.url | other.js:8:28:8:30 | cmd | This command depends on $@. | other.js:5:25:5:31 | req.url | a user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-078/child_process-test.js
+++ b/javascript/ql/test/query-tests/Security/CWE-078/child_process-test.js
@@ -63,3 +63,12 @@ var server = http.createServer(function(req, res) {
 function run(cmd, args) {
   cp.spawn(cmd, args); // NOT OK
 }
+
+var util = require("util")
+
+http.createServer(function(req, res) {
+    let cmd = url.parse(req.url, true).query.path;
+
+    util.promisify(cp.exec)(cmd); // NOT OK
+});
+


### PR DESCRIPTION
Adds support for the sink in CVE-2019-10776

A [quick smoke-test](https://git.semmle.com/erik/dist-compare-reports/tree/profiling-js-max.northeurope.cloudapp.azure.com_1586966334818) reveals decent performance, and what looks like a new TP. 