### PR TITLE
C++: Add remote flow sources via models

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Fread.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Fread.qll
@@ -13,7 +13,8 @@ class Fread extends AliasFunction, RemoteFlowFunction {
 
   override predicate parameterIsAlwaysReturned(int n) { none() }
 
-  override predicate hasFlowSource(FunctionOutput output) {
-    output.isParameterDeref(0)
+  override predicate hasRemoteFlowSource(FunctionOutput output, string description) {
+    output.isParameterDeref(0) and
+    description = "String read by " + this.getName()
   }
 }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Fread.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Fread.qll
@@ -1,6 +1,7 @@
 import semmle.code.cpp.models.interfaces.Alias
+import semmle.code.cpp.models.interfaces.FlowSource
 
-class Fread extends AliasFunction {
+class Fread extends AliasFunction, RemoteFlowFunction {
   Fread() { this.hasGlobalName("fread") }
 
   override predicate parameterNeverEscapes(int n) {
@@ -11,4 +12,8 @@ class Fread extends AliasFunction {
   override predicate parameterEscapesOnlyViaReturn(int n) { none() }
 
   override predicate parameterIsAlwaysReturned(int n) { none() }
+
+  override predicate hasFlowSource(FunctionOutput output) {
+    output.isParameterDeref(0)
+  }
 }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Gets.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Gets.qll
@@ -3,12 +3,13 @@ import semmle.code.cpp.models.interfaces.Taint
 import semmle.code.cpp.models.interfaces.ArrayFunction
 import semmle.code.cpp.models.interfaces.Alias
 import semmle.code.cpp.models.interfaces.SideEffect
+import semmle.code.cpp.models.interfaces.FlowSource
 
 /**
  * The standard functions `gets` and `fgets`.
  */
 class GetsFunction extends DataFlowFunction, TaintFunction, ArrayFunction, AliasFunction,
-  SideEffectFunction {
+  SideEffectFunction, RemoteFlowFunction {
   GetsFunction() {
     exists(string name | hasGlobalOrStdName(name) |
       name = "gets" or // gets(str)
@@ -41,5 +42,9 @@ class GetsFunction extends DataFlowFunction, TaintFunction, ArrayFunction, Alias
     i = 0 and
     buffer = true and
     mustWrite = true
+  }
+
+  override predicate hasFlowSource(FunctionOutput output) {
+    output.isParameterDeref(0)
   }
 }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Gets.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Gets.qll
@@ -44,7 +44,8 @@ class GetsFunction extends DataFlowFunction, TaintFunction, ArrayFunction, Alias
     mustWrite = true
   }
 
-  override predicate hasFlowSource(FunctionOutput output) {
-    output.isParameterDeref(0)
+  override predicate hasRemoteFlowSource(FunctionOutput output, string description) {
+    output.isParameterDeref(0) and
+    description = "String read by " + this.getName()
   }
 }

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/FlowSource.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/FlowSource.qll
@@ -1,0 +1,18 @@
+/**
+ * Provides a class for modeling functions that return data from potentially untrusted sources. To use
+ * this QL library, create a QL class extending `DataFlowFunction` with a
+ * characteristic predicate that selects the function or set of functions you
+ * are modeling. Within that class, override the predicates provided by
+ * `RemoteFlowFunction` to match the flow within that function.
+ */
+
+import cpp
+import FunctionInputsAndOutputs
+import semmle.code.cpp.models.Models
+
+/**
+ * A library function which returns data read from a network connection.
+ */
+abstract class RemoteFlowFunction extends Function {
+  abstract predicate hasFlowSource(FunctionOutput output);
+}

--- a/cpp/ql/src/semmle/code/cpp/models/interfaces/FlowSource.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/interfaces/FlowSource.qll
@@ -14,5 +14,8 @@ import semmle.code.cpp.models.Models
  * A library function which returns data read from a network connection.
  */
 abstract class RemoteFlowFunction extends Function {
-  abstract predicate hasFlowSource(FunctionOutput output);
+  /**
+   * Holds if remote data described by `description` flows from `output` of a call to this function.
+   */
+  abstract predicate hasRemoteFlowSource(FunctionOutput output, string description);
 }

--- a/cpp/ql/src/semmle/code/cpp/security/FlowSources.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/FlowSources.qll
@@ -11,8 +11,8 @@ import semmle.code.cpp.models.interfaces.FlowSource
 abstract class RemoteFlowSource extends DataFlow::Node {
 }
 
-class FileDescriptorTaintedReturnSource extends RemoteFlowSource {
-  FileDescriptorTaintedReturnSource() {
+private class TaintedReturnSource extends RemoteFlowSource {
+  TaintedReturnSource() {
     exists(RemoteFlowFunction func, CallInstruction instr, FunctionOutput output |
       asInstruction() = instr and
       instr.getStaticCallTarget() = func and
@@ -22,9 +22,9 @@ class FileDescriptorTaintedReturnSource extends RemoteFlowSource {
   }
 }
 
-class FileTaintedParameterSource extends RemoteFlowSource {
-  FileTaintedParameterSource() {
-    exists(RemoteFlowFunction func, ReadSideEffectInstruction instr, FunctionOutput output |
+private class TaintedParameterSource extends RemoteFlowSource {
+  TaintedParameterSource() {
+    exists(RemoteFlowFunction func, WriteSideEffectInstruction instr, FunctionOutput output |
       asInstruction() = instr and
       instr.getPrimaryInstruction().(CallInstruction).getStaticCallTarget() = func and
       func.hasFlowSource(output) and
@@ -32,4 +32,3 @@ class FileTaintedParameterSource extends RemoteFlowSource {
     )
   }
 }
-

--- a/cpp/ql/src/semmle/code/cpp/security/FlowSources.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/FlowSources.qll
@@ -9,26 +9,38 @@ import semmle.code.cpp.models.interfaces.FlowSource
 
 /** A data flow source of remote user input. */
 abstract class RemoteFlowSource extends DataFlow::Node {
+  /** Gets a string that describes the type of this remote flow source. */
+  abstract string getSourceType();
 }
 
 private class TaintedReturnSource extends RemoteFlowSource {
+  string sourceType;
   TaintedReturnSource() {
     exists(RemoteFlowFunction func, CallInstruction instr, FunctionOutput output |
       asInstruction() = instr and
       instr.getStaticCallTarget() = func and
-      func.hasFlowSource(output) and
+      func.hasRemoteFlowSource(output, sourceType) and
       output.isReturnValue()
     )
+  }
+
+  override string getSourceType() {
+    result = sourceType
   }
 }
 
 private class TaintedParameterSource extends RemoteFlowSource {
+  string sourceType;
   TaintedParameterSource() {
     exists(RemoteFlowFunction func, WriteSideEffectInstruction instr, FunctionOutput output |
       asInstruction() = instr and
       instr.getPrimaryInstruction().(CallInstruction).getStaticCallTarget() = func and
-      func.hasFlowSource(output) and
+      func.hasRemoteFlowSource(output, sourceType) and
       output.isParameterDeref(instr.getIndex())
     )
+  }
+
+  override string getSourceType() {
+    result = sourceType
   }
 }

--- a/cpp/ql/src/semmle/code/cpp/security/FlowSources.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/FlowSources.qll
@@ -1,0 +1,35 @@
+/**
+ * Provides classes representing various flow sources for taint tracking.
+ */
+
+import cpp
+import semmle.code.cpp.ir.dataflow.DataFlow
+private import semmle.code.cpp.ir.IR
+import semmle.code.cpp.models.interfaces.FlowSource
+
+/** A data flow source of remote user input. */
+abstract class RemoteFlowSource extends DataFlow::Node {
+}
+
+class FileDescriptorTaintedReturnSource extends RemoteFlowSource {
+  FileDescriptorTaintedReturnSource() {
+    exists(RemoteFlowFunction func, CallInstruction instr, FunctionOutput output |
+      asInstruction() = instr and
+      instr.getStaticCallTarget() = func and
+      func.hasFlowSource(output) and
+      output.isReturnValue()
+    )
+  }
+}
+
+class FileTaintedParameterSource extends RemoteFlowSource {
+  FileTaintedParameterSource() {
+    exists(RemoteFlowFunction func, ReadSideEffectInstruction instr, FunctionOutput output |
+      asInstruction() = instr and
+      instr.getPrimaryInstruction().(CallInstruction).getStaticCallTarget() = func and
+      func.hasFlowSource(output) and
+      output.isParameterDeref(instr.getIndex())
+    )
+  }
+}
+

--- a/cpp/ql/src/semmle/code/cpp/security/FlowSources.qll
+++ b/cpp/ql/src/semmle/code/cpp/security/FlowSources.qll
@@ -15,6 +15,7 @@ abstract class RemoteFlowSource extends DataFlow::Node {
 
 private class TaintedReturnSource extends RemoteFlowSource {
   string sourceType;
+
   TaintedReturnSource() {
     exists(RemoteFlowFunction func, CallInstruction instr, FunctionOutput output |
       asInstruction() = instr and
@@ -24,13 +25,12 @@ private class TaintedReturnSource extends RemoteFlowSource {
     )
   }
 
-  override string getSourceType() {
-    result = sourceType
-  }
+  override string getSourceType() { result = sourceType }
 }
 
 private class TaintedParameterSource extends RemoteFlowSource {
   string sourceType;
+
   TaintedParameterSource() {
     exists(RemoteFlowFunction func, WriteSideEffectInstruction instr, FunctionOutput output |
       asInstruction() = instr and
@@ -40,7 +40,5 @@ private class TaintedParameterSource extends RemoteFlowSource {
     )
   }
 
-  override string getSourceType() {
-    result = sourceType
-  }
+  override string getSourceType() { result = sourceType }
 }


### PR DESCRIPTION
This adds a new `RemoteFlowSource` class for IR flow, based on a new model interface. I've included flow source models for `fread` and `gets`, since they had model classes already.

This is consistent with the direction the C++ library is moving for flow sinks such as allocation sizes and format arguments, but rather different from the Java and C# versions of `RemoteFlowSource`. I've also opened #3274 showing a version that's closer to the Java and C# versions.