### PR TITLE
Python: Remove deprecated annotation for old PointsTo::points_to

### DIFF
--- a/python/ql/src/semmle/python/pointsto/PointsTo.qll
+++ b/python/ql/src/semmle/python/pointsto/PointsTo.qll
@@ -114,7 +114,7 @@ module PointsTo {
 
     /* Backwards compatibility */
     cached
-    deprecated predicate points_to(
+    predicate points_to(
         ControlFlowNode f, PointsToContext context, Object obj, ClassObject cls, ControlFlowNode origin
     ) {
         exists(ObjectInternal value |

--- a/python/ql/test/3/library-tests/PointsTo/consts/BooleanConstants.expected
+++ b/python/ql/test/3/library-tests/PointsTo/consts/BooleanConstants.expected
@@ -1,5 +1,3 @@
-WARNING: Predicate points_to has been deprecated and may be removed in future (BooleanConstants.ql:6,25-44)
-WARNING: Predicate points_to has been deprecated and may be removed in future (BooleanConstants.ql:7,29-48)
 | module.py | 2 | ControlFlowNode for ImportExpr | import | true |
 | module.py | 2 | ControlFlowNode for sys | import | true |
 | module.py | 3 | ControlFlowNode for Compare | import | false |

--- a/python/ql/test/library-tests/PointsTo/extensions/Extend.expected
+++ b/python/ql/test/library-tests/PointsTo/extensions/Extend.expected
@@ -1,4 +1,3 @@
-WARNING: Predicate points_to has been deprecated and may be removed in future (Extend.ql:50,32-51)
 WARNING: Type CustomPointsToAttribute has been deprecated and may be removed in future (Extend.ql:22,34-57)
 WARNING: Type CustomPointsToObjectFact has been deprecated and may be removed in future (Extend.ql:38,32-56)
 WARNING: Type CustomPointsToOriginFact has been deprecated and may be removed in future (Extend.ql:5,28-52)

--- a/python/ql/test/library-tests/PointsTo/new/PointsToWithContext.expected
+++ b/python/ql/test/library-tests/PointsTo/new/PointsToWithContext.expected
@@ -1,4 +1,3 @@
-WARNING: Predicate points_to has been deprecated and may be removed in future (PointsToWithContext.ql:7,7-26)
 | a_simple.py:2 | ControlFlowNode for FloatLiteral | float 1.0 | builtin-class float | 2 | import |
 | a_simple.py:2 | ControlFlowNode for f1 | float 1.0 | builtin-class float | 2 | import |
 | a_simple.py:3 | ControlFlowNode for dict | builtin-class dict | builtin-class type | 3 | import |

--- a/python/ql/test/library-tests/PointsTo/new/PointsToWithType.expected
+++ b/python/ql/test/library-tests/PointsTo/new/PointsToWithType.expected
@@ -1,4 +1,3 @@
-WARNING: Predicate points_to has been deprecated and may be removed in future (PointsToWithType.ql:6,7-26)
 | a_simple.py:2 | ControlFlowNode for FloatLiteral | float 1.0 | builtin-class float | 2 |
 | a_simple.py:2 | ControlFlowNode for f1 | float 1.0 | builtin-class float | 2 |
 | a_simple.py:3 | ControlFlowNode for dict | builtin-class dict | builtin-class type | 3 |


### PR DESCRIPTION
We should only deprecate it when we're ready to deprecate the old refersTo and
all the old Object classes