### PR TITLE
Python: Fix remaining deprecation warnings.

### DIFF
--- a/python/ql/src/Resources/FileOpen.qll
+++ b/python/ql/src/Resources/FileOpen.qll
@@ -79,7 +79,7 @@ predicate def_is_open(EssaDefinition def, ControlFlowNode open) {
         passes_open_files(refinement)
     )
     or
-    exists(PyNodeRefinement refinement | refinement = def |
+    exists(EssaNodeRefinement refinement | refinement = def |
         not closes_file(def) and
         not wraps_file(refinement.getDefiningNode(), refinement.getInput()) and
         var_is_open(refinement.getInput(), open)

--- a/python/ql/src/semmle/python/dataflow/TaintTracking.qll
+++ b/python/ql/src/semmle/python/dataflow/TaintTracking.qll
@@ -132,15 +132,6 @@ abstract class TaintKind extends string {
     }
 
     /**
-     * DEPRECATED -- Use `TaintFlow.additionalFlowStepVar(EssaVariable fromvar, EssaVariable tovar, TaintKind kind)` instead.
-     *
-     * Holds if this kind of taint passes from variable `fromvar` to  variable `tovar`
-     * This predicate is present for completeness. It is unlikely that any `TaintKind`
-     * implementation will ever need to override it.
-     */
-    deprecated predicate additionalFlowStepVar(EssaVariable fromvar, EssaVariable tovar) { none() }
-
-    /**
      * Holds if this kind of taint "taints" `expr`.
      */
     final predicate taints(ControlFlowNode expr) {
@@ -356,41 +347,6 @@ abstract class Sanitizer extends string {
 
     /** Holds if `def` shows value to be untainted with `taint` */
     predicate sanitizingDefinition(TaintKind taint, EssaDefinition def) { none() }
-}
-
-/**
- * DEPRECATED -- Use DataFlowExtension instead.
- *  An extension to taint-flow. For adding library or framework specific flows.
- * Examples include flow from a request to untrusted part of that request or
- * from a socket to data from that socket.
- */
-abstract deprecated class TaintFlow extends string {
-    bindingset[this]
-    TaintFlow() { any() }
-
-    /**
-     * Holds if `fromnode` being tainted with `fromkind` will result in `tonode` being tainted with `tokind`.
-     * Extensions to `TaintFlow` should override this to provide additional taint steps.
-     */
-    predicate additionalFlowStep(
-        ControlFlowNode fromnode, TaintKind fromkind, ControlFlowNode tonode, TaintKind tokind
-    ) {
-        none()
-    }
-
-    /**
-     * Holds if the given `kind` of taint passes from variable `fromvar` to variable `tovar`.
-     * This predicate is present for completeness. Most `TaintFlow` implementations will not need to override it.
-     */
-    predicate additionalFlowStepVar(EssaVariable fromvar, EssaVariable tovar, TaintKind kind) {
-        none()
-    }
-
-    /**
-     * Holds if the given `kind` of taint cannot pass from variable `fromvar` to variable `tovar`.
-     * This predicate is present for completeness. Most `TaintFlow` implementations will not need to override it.
-     */
-    predicate prunedFlowStepVar(EssaVariable fromvar, EssaVariable tovar, TaintKind kind) { none() }
 }
 
 /**

--- a/python/ql/src/semmle/python/dataflow/TaintTracking.qll
+++ b/python/ql/src/semmle/python/dataflow/TaintTracking.qll
@@ -155,7 +155,7 @@ abstract class TaintKind extends string {
      * For example, if this were a kind of string taint
      * the `result` would be `theStrType()`.
      */
-    ClassValue getType() { result.(ClassObjectInternal).getSource() = this.getClass() }
+    ClassValue getType() { none() }
 
     /**
      * Gets the boolean values (may be one, neither, or both) that
@@ -180,7 +180,10 @@ abstract class TaintKind extends string {
     TaintKind getTaintForIteration() { none() }
 
     predicate flowStep(DataFlow::Node fromnode, DataFlow::Node tonode, string edgeLabel) {
-        this.additionalFlowStepVar(fromnode.asVariable(), tonode.asVariable()) and
+        exists(DataFlowExtension::DataFlowVariable v |
+            v = fromnode.asVariable() and
+            v.getASuccessorVariable() = tonode.asVariable()
+        ) and
         edgeLabel = "custom taint variable step"
     }
 }


### PR DESCRIPTION
I believe this should take care of the three remaining deprecation warnings.

For `getType`, I couldn't find any uses of an overridden `getClass` in any of our `TaintKind`s, and so it should be safe to simply replace the default implementation of `getType` with `none()`. (Given how general these classes are, I don't think there's any reasonable default to give here anyway.)