### PR TITLE
JS: Refactor isAmbient computation

### DIFF
--- a/javascript/ql/src/semmle/javascript/AST.qll
+++ b/javascript/ql/src/semmle/javascript/AST.qll
@@ -184,9 +184,7 @@ class ASTNode extends @ast_node, Locatable {
  * Holds if the given file is a `.d.ts` file.
  */
 cached
-private predicate isAmbientTopLevel(TopLevel tl) {
-  tl.getFile().getBaseName().matches("%.d.ts")
-}
+private predicate isAmbientTopLevel(TopLevel tl) { tl.getFile().getBaseName().matches("%.d.ts") }
 
 /**
  * A toplevel syntactic unit; that is, a stand-alone script, an inline script

--- a/javascript/ql/src/semmle/javascript/Classes.qll
+++ b/javascript/ql/src/semmle/javascript/Classes.qll
@@ -1059,12 +1059,6 @@ class FieldDeclaration extends MemberDeclaration, @field {
 
   /** Holds if this is a TypeScript field marked as definitely assigned with the `!` operator. */
   predicate hasDefiniteAssignmentAssertion() { hasDefiniteAssignmentAssertion(this) }
-
-  override predicate isAmbient() {
-    hasDeclareKeyword(this)
-    or
-    getParent().isAmbient()
-  }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/ES2015Modules.qll
+++ b/javascript/ql/src/semmle/javascript/ES2015Modules.qll
@@ -79,11 +79,6 @@ class ImportDeclaration extends Stmt, Import, @importdeclaration {
 
   /** Holds if this is declared with the `type` keyword, so it only imports types. */
   predicate isTypeOnly() { hasTypeKeyword(this) }
-
-  override predicate isAmbient() {
-    Stmt.super.isAmbient() or
-    isTypeOnly()
-  }
 }
 
 /** A literal path expression appearing in an `import` declaration. */
@@ -267,11 +262,6 @@ abstract class ExportDeclaration extends Stmt, @exportdeclaration {
 
   /** Holds if is declared with the `type` keyword, so only types are exported. */
   predicate isTypeOnly() { hasTypeKeyword(this) }
-
-  override predicate isAmbient() {
-    Stmt.super.isAmbient() or
-    isTypeOnly()
-  }
 }
 
 /**
@@ -422,11 +412,6 @@ class ExportNamedDeclaration extends ExportDeclaration, @exportnameddeclaration 
 
   /** Gets an export specifier of this declaration. */
   ExportSpecifier getASpecifier() { result = getSpecifier(_) }
-
-  override predicate isAmbient() {
-    // An export such as `export declare function f()` should be seen as ambient.
-    hasDeclareKeyword(getOperand()) or getParent().isAmbient()
-  }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/Functions.qll
+++ b/javascript/ql/src/semmle/javascript/Functions.qll
@@ -397,8 +397,6 @@ class Function extends @function, Parameterized, TypeParameterized, StmtContaine
    */
   predicate isAbstract() { exists(MethodDeclaration md | this = md.getBody() | md.isAbstract()) }
 
-  override predicate isAmbient() { getParent().isAmbient() or not hasBody() }
-
   /**
    * Holds if this function cannot be invoked using `new` because it
    * is of the given `kind`.

--- a/javascript/ql/src/semmle/javascript/Stmt.qll
+++ b/javascript/ql/src/semmle/javascript/Stmt.qll
@@ -54,8 +54,6 @@ class Stmt extends @stmt, ExprOrStmt, Documentable {
     getContainer().(Expr).getEnclosingStmt().nestedIn(outer)
   }
 
-  override predicate isAmbient() { hasDeclareKeyword(this) or getParent().isAmbient() }
-
   /**
    * Gets the `try` statement with a catch block containing this statement without
    * crossing function boundaries or other `try ` statements with catch blocks.
@@ -931,8 +929,6 @@ class DebuggerStmt extends @debuggerstmt, Stmt {
  */
 class FunctionDeclStmt extends @functiondeclstmt, Stmt, Function {
   override Stmt getEnclosingStmt() { result = this }
-
-  override predicate isAmbient() { Function.super.isAmbient() }
 }
 
 /**

--- a/javascript/ql/src/semmle/javascript/TypeScript.qll
+++ b/javascript/ql/src/semmle/javascript/TypeScript.qll
@@ -155,8 +155,6 @@ class ExternalModuleDeclaration extends Stmt, StmtContainer, @externalmoduledecl
   int getNumStmt() { result = count(getAStmt()) }
 
   override StmtContainer getEnclosingContainer() { result = this.getContainer() }
-
-  override predicate isAmbient() { any() }
 }
 
 /**
@@ -176,8 +174,6 @@ class GlobalAugmentationDeclaration extends Stmt, StmtContainer, @globalaugmenta
   int getNumStmt() { result = count(getAStmt()) }
 
   override StmtContainer getEnclosingContainer() { result = this.getContainer() }
-
-  override predicate isAmbient() { any() }
 }
 
 /** A TypeScript "import-equals" declaration. */
@@ -237,8 +233,6 @@ class ExportAsNamespaceDeclaration extends Stmt, @exportasnamespacedeclaration {
    * Gets the `X` in `export as namespace X`.
    */
   Identifier getIdentifier() { result = getChildExpr(0) }
-
-  override predicate isAmbient() { any() }
 }
 
 /**
@@ -258,8 +252,6 @@ class TypeAliasDeclaration extends @typealiasdeclaration, TypeParameterized, Stm
   TypeExpr getDefinition() { result = getChildTypeExpr(1) }
 
   override string describe() { result = "type alias " + getName() }
-
-  override predicate isAmbient() { any() }
 
   /**
    * Gets the canonical name of the type being defined.
@@ -285,8 +277,6 @@ class InterfaceDeclaration extends Stmt, InterfaceDefinition, @interfacedeclarat
   }
 
   override StmtContainer getContainer() { result = Stmt.super.getContainer() }
-
-  override predicate isAmbient() { any() }
 
   override string describe() { result = "interface " + getName() }
 
@@ -532,8 +522,6 @@ class LocalNamespaceName extends @local_namespace_name, LexicalName {
  */
 class TypeExpr extends ExprOrType, @typeexpr, TypeAnnotation {
   override string toString() { typeexprs(this, _, _, _, result) }
-
-  override predicate isAmbient() { any() }
 
   /**
    * Gets the static type expressed by this type annotation.
@@ -1409,8 +1397,6 @@ class EnumDeclaration extends NamespaceDefinition, @enumdeclaration, AST::ValueN
 
   /** Holds if this enumeration is declared with the `const` keyword. */
   predicate isConst() { isConstEnum(this) }
-
-  override predicate isAmbient() { hasDeclareKeyword(this) or getParent().isAmbient() }
 
   override ControlFlowNode getFirstControlFlowNode() { result = getIdentifier() }
 }


### PR DESCRIPTION
Fixes a performance issue in `ASTNode.isAmbient`.

Not every overrides invoked `super.isAmbient()` resulting in the dispatch predicate drawing in a very large negation containing almost all AST nodes. Simply invoking `super` is not trivial due to the complicated inheritance between AST nodes, and my attempts to doing so actually made the problem worse for some reason.

This PR brings the entire `isAmbient` definition into one place, and caches the part of it that depends on recursion (namely that the node is inside an ambient declaration). The actual `isAmbient` predicate is now looks like this:
```codeql
  pragma[inline]
  predicate isAmbient() {
    isAmbientInternal()
    or
    isAmbientTopLevel(getTopLevel())
    or
    this instanceof TypeExpr
  }
```
The first two cases depend on cached predicates without many indirections and the last one can often be eliminated by the optimizer at the use-site, for example, if calling `Function.isAmbient()`.

[A full evaluation on smoke-test](https://git.semmle.com/asger/dist-compare-reports/tree/js/isambient-refactor_1587343927331) looks very good, but I'll run a few queries on big snapshot as well.

As a sanity check, I've verified that vscode contains the same number of ambient node as before.