### PR TITLE
C++: Add pragma[noinline] to StdStringConstructor

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/StdString.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/StdString.qll
@@ -4,6 +4,7 @@ import semmle.code.cpp.models.interfaces.Taint
  * The `std::basic_string` constructor(s).
  */
 class StdStringConstructor extends TaintFunction {
+  pragma[noinline]
   StdStringConstructor() { this.hasQualifiedName("std", "basic_string", "basic_string") }
 
   override predicate hasTaintFlow(FunctionInput input, FunctionOutput output) {


### PR DESCRIPTION
Fixes https://github.com/github/codeql-c-analysis-team/issues/52.

Currently, `TaintFunction::hasTaintFlow` produces a lot of cartesian products. They’re all pretty small in practice, but `StdStringConstructor` causes a blowup on `boost`. A fix is to add a `pragma[noinline]` to the charpred of `StdStringConstructor`.

Here's the tuple count before:
```
                      64       ~0%       {2} r91 = JOIN FunctionInputsAndOutputs::OutReturnValue#class#f AS L WITH FunctionInputsAndOutputs::InParameter::isParameter_dispred#ff AS R CARTESIAN PRODUCT OUTPUT L.<0>, R.<0>
                      64       ~0%       {2} r92 = STREAM DEDUP r91
                      20239488 ~0%       {6} r93 = JOIN r92 WITH functions AS R CARTESIAN PRODUCT OUTPUT R.<0>, "std", "basic_string", "basic_string", r92.<0>, r92.<1>
                      6080     ~4%       {3} r94 = JOIN r93 WITH Declaration::Declaration::hasQualifiedName_dispred#2#bbbf AS R ON FIRST 4 OUTPUT r93.<0>, r93.<5>, r93.<4>
                      7042     ~0%       {3} r95 = r90 \/ r94
```

and after:
```
                      64      ~0%       {2} r91 = JOIN FunctionInputsAndOutputs::OutReturnValue#class#f AS L WITH FunctionInputsAndOutputs::InParameter::isParameter_dispred#ff AS R CARTESIAN PRODUCT OUTPUT L.<0>, R.<0>
                      64      ~0%       {2} r92 = STREAM DEDUP r91
                      6080    ~4%       {3} r93 = JOIN r92 WITH StdString::StdStringConstructor#f AS R CARTESIAN PRODUCT OUTPUT R.<0>, r92.<1>, r92.<0>
                      7042    ~0%       {3} r94 = r90 \/ r93
```