### PR TITLE
JS: Rephrase flowsTo to avoid redundant SourceNode::Range check

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Sources.qll
@@ -39,11 +39,7 @@ class SourceNode extends DataFlow::Node {
    * Holds if this node flows into `sink` in zero or more local (that is,
    * intra-procedural) steps.
    */
-  cached
-  predicate flowsTo(DataFlow::Node sink) {
-    sink = this or
-    flowsTo(sink.getAPredecessor())
-  }
+  predicate flowsTo(DataFlow::Node sink) { hasLocalSource(sink, this) }
 
   /**
    * Holds if this node flows into `sink` in zero or more local (that is,
@@ -193,6 +189,24 @@ class SourceNode extends DataFlow::Node {
   DataFlow::SourceNode backtrack(TypeBackTracker t2, TypeBackTracker t) {
     t2 = t.step(result, this)
   }
+}
+
+/**
+ * Holds if `source` is a `SourceNode` that can reach `sink` via local flow steps.
+ *
+ * The slightly backwards parametering ordering is to force correct indexing.
+ */
+cached
+private predicate hasLocalSource(DataFlow::Node sink, DataFlow::Node source) {
+  // Declaring `source` to be a `SourceNode` currently causes a redundant check in the
+  // recursive case, so instead we check it explicitly here.
+  source = sink and
+  source instanceof DataFlow::SourceNode
+  or
+  exists(DataFlow::Node mid |
+    hasLocalSource(mid, source) and
+    DataFlow::localFlowStep(mid, sink)
+  )
 }
 
 module SourceNode {


### PR DESCRIPTION
`SourceNode.flowsTo` had a redundant check in the recursive case, and the optimizer decided to put that check first in the join order.

This eliminates the check shown below:
```diff
  incremental
  Sources::SourceNode::flowsTo#ff(/* Sources::SourceNode */ TNode this,
                                  /* DataFlow::DataFlow::Node */ cached TNode sink) :-
    (Sources::SourceNode::Range#class(sink), this = sink);
    exists(/* DataFlow::DataFlow::Node */ cached TNode call_result |
-     Sources::SourceNode::Range#class(this), // <-- redundant
      rec Sources::SourceNode::flowsTo#ff(this, call_result),
      DataFlow::DataFlow::localFlowStep(call_result, sink)
```

Due to the equality in the base case, the check is changed to refer to refer to `sink` instead of `source` by some normalization step, which I'm guessing is confusing the step that was supposed to eliminate the check in the recursive case. My attempts at fixing this in the optimizer didn't quite pan out hence this workaround, but I'll bring the issue up with the core team.

The DIL now looks like this:
```js
 persistent incremental
 Sources::hasLocalSource#ff(/* DataFlow::DataFlow::Node */ TNode sink,
                            /* DataFlow::DataFlow::Node */ cached TNode source) :-
   (Sources::SourceNode::Range#class(source), sink = source);
   exists(/* DataFlow::DataFlow::Node */ cached TNode arg |
     rec Sources::hasLocalSource#ff(arg, source),
     DataFlow::DataFlow::localFlowStep(arg, sink)
   )
```

I've confirmed that the above is the only change in the DIL (modulo renaming). I'm a little perplexed by the absence of the `persistent` modifier in the original DIL, though.

[Evaluation of XSS on nightly.slugs](https://git.semmle.com/asger/dist-compare-reports/tree/js/flows-to-redundant-check_1587317455119) looks fairly uninteresting. I'm waiting for a run on big-apps.