### PR TITLE
C#: Add missing CFG edge from generic `catch` block to `finally` block

### DIFF
--- a/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
+++ b/csharp/ql/src/semmle/code/csharp/controlflow/ControlFlowGraph.qll
@@ -1710,9 +1710,9 @@ module ControlFlow {
           exists(getAThrownException(ts, cfe, c)) and
           result = first(ts.getCatchClause(0))
           or
-          exists(SpecificCatchClause scc, int i | scc = ts.getCatchClause(i) |
-            cfe = scc and
-            scc = last(ts.getCatchClause(i), c) and
+          exists(CatchClause cc, int i | cc = ts.getCatchClause(i) |
+            cfe = cc and
+            cc = last(ts.getCatchClause(i), c) and
             (
               // Flow from one `catch` clause to the next
               result = first(ts.getCatchClause(i + 1)) and
@@ -1725,7 +1725,7 @@ module ControlFlow {
             )
             or
             cfe = last(ts.getCatchClause(i), c) and
-            cfe = last(scc.getFilterClause(), _) and
+            cfe = last(cc.getFilterClause(), _) and
             (
               // Flow from last element of `catch` clause filter to next `catch` clause
               result = first(ts.getCatchClause(i + 1)) and
@@ -1739,7 +1739,7 @@ module ControlFlow {
             )
             or
             // Flow from last element of a `catch` block to first element of `finally` block
-            cfe = lastCatchClauseBlock(scc, c) and
+            cfe = lastCatchClauseBlock(cc, c) and
             result = first(ts.getFinally())
           )
           or

--- a/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/BasicBlock.expected
@@ -370,6 +370,10 @@
 | Finally.cs:211:13:211:29 | ...; | Finally.cs:213:9:213:24 | ... = ... | 8 |
 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | Finally.cs:211:13:211:28 | [finally: exception(Exception)] ... = ... | 4 |
 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | Finally.cs:211:13:211:28 | [finally: exception(ExceptionA)] ... = ... | 4 |
+| Finally.cs:216:10:216:12 | enter M11 | Finally.cs:220:31:220:35 | "Try" | 6 |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:220:13:220:36 | call to method WriteLine | 1 |
+| Finally.cs:222:9:225:9 | catch {...} | Finally.cs:224:13:224:38 | call to method WriteLine | 5 |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:216:10:216:12 | exit M11 | 8 |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:8:29:8:32 | access to parameter args | 3 |
 | Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | exit M1 | 1 |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | 1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -1625,7 +1625,6 @@ dominance
 | Finally.cs:217:5:231:5 | {...} | Finally.cs:218:9:229:9 | try {...} ... |
 | Finally.cs:218:9:229:9 | try {...} ... | Finally.cs:219:9:221:9 | {...} |
 | Finally.cs:219:9:221:9 | {...} | Finally.cs:220:13:220:37 | ...; |
-| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:227:9:229:9 | {...} |
 | Finally.cs:220:13:220:37 | ...; | Finally.cs:220:31:220:35 | "Try" |
 | Finally.cs:220:31:220:35 | "Try" | Finally.cs:220:13:220:36 | call to method WriteLine |
 | Finally.cs:220:31:220:35 | "Try" | Finally.cs:222:9:225:9 | catch {...} |
@@ -4538,7 +4537,6 @@ postDominance
 | Finally.cs:217:5:231:5 | {...} | Finally.cs:216:10:216:12 | enter M11 |
 | Finally.cs:218:9:229:9 | try {...} ... | Finally.cs:217:5:231:5 | {...} |
 | Finally.cs:219:9:221:9 | {...} | Finally.cs:218:9:229:9 | try {...} ... |
-| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:220:31:220:35 | "Try" |
 | Finally.cs:220:13:220:37 | ...; | Finally.cs:219:9:221:9 | {...} |
 | Finally.cs:220:31:220:35 | "Try" | Finally.cs:220:13:220:37 | ...; |
 | Finally.cs:223:9:225:9 | {...} | Finally.cs:222:9:225:9 | catch {...} |
@@ -4546,6 +4544,7 @@ postDominance
 | Finally.cs:224:13:224:39 | ...; | Finally.cs:223:9:225:9 | {...} |
 | Finally.cs:224:31:224:37 | "Catch" | Finally.cs:224:13:224:39 | ...; |
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:220:13:220:36 | call to method WriteLine |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:224:13:224:38 | call to method WriteLine |
 | Finally.cs:228:13:228:40 | call to method WriteLine | Finally.cs:228:31:228:39 | "Finally" |
 | Finally.cs:228:13:228:41 | ...; | Finally.cs:227:9:229:9 | {...} |
 | Finally.cs:228:31:228:39 | "Finally" | Finally.cs:228:13:228:41 | ...; |
@@ -6985,7 +6984,6 @@ blockDominance
 | Finally.cs:216:10:216:12 | enter M11 | Finally.cs:222:9:225:9 | catch {...} |
 | Finally.cs:216:10:216:12 | enter M11 | Finally.cs:227:9:229:9 | {...} |
 | Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:220:13:220:36 | call to method WriteLine |
-| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:227:9:229:9 | {...} |
 | Finally.cs:222:9:225:9 | catch {...} | Finally.cs:222:9:225:9 | catch {...} |
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:227:9:229:9 | {...} |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | enter M1 |
@@ -8793,11 +8791,11 @@ postBlockDominance
 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; |
 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; |
 | Finally.cs:216:10:216:12 | enter M11 | Finally.cs:216:10:216:12 | enter M11 |
-| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:216:10:216:12 | enter M11 |
 | Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:220:13:220:36 | call to method WriteLine |
 | Finally.cs:222:9:225:9 | catch {...} | Finally.cs:222:9:225:9 | catch {...} |
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:216:10:216:12 | enter M11 |
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:220:13:220:36 | call to method WriteLine |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:222:9:225:9 | catch {...} |
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:227:9:229:9 | {...} |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | enter M1 |
 | Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | enter M1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Dominance.expected
@@ -1621,6 +1621,25 @@ dominance
 | Finally.cs:213:9:213:12 | this access | Finally.cs:213:22:213:24 | "1" |
 | Finally.cs:213:9:213:25 | ...; | Finally.cs:213:9:213:12 | this access |
 | Finally.cs:213:22:213:24 | "1" | Finally.cs:213:9:213:24 | ... = ... |
+| Finally.cs:216:10:216:12 | enter M11 | Finally.cs:217:5:231:5 | {...} |
+| Finally.cs:217:5:231:5 | {...} | Finally.cs:218:9:229:9 | try {...} ... |
+| Finally.cs:218:9:229:9 | try {...} ... | Finally.cs:219:9:221:9 | {...} |
+| Finally.cs:219:9:221:9 | {...} | Finally.cs:220:13:220:37 | ...; |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:227:9:229:9 | {...} |
+| Finally.cs:220:13:220:37 | ...; | Finally.cs:220:31:220:35 | "Try" |
+| Finally.cs:220:31:220:35 | "Try" | Finally.cs:220:13:220:36 | call to method WriteLine |
+| Finally.cs:220:31:220:35 | "Try" | Finally.cs:222:9:225:9 | catch {...} |
+| Finally.cs:222:9:225:9 | catch {...} | Finally.cs:223:9:225:9 | {...} |
+| Finally.cs:223:9:225:9 | {...} | Finally.cs:224:13:224:39 | ...; |
+| Finally.cs:224:13:224:39 | ...; | Finally.cs:224:31:224:37 | "Catch" |
+| Finally.cs:224:31:224:37 | "Catch" | Finally.cs:224:13:224:38 | call to method WriteLine |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:228:13:228:41 | ...; |
+| Finally.cs:228:13:228:40 | call to method WriteLine | Finally.cs:230:9:230:34 | ...; |
+| Finally.cs:228:13:228:41 | ...; | Finally.cs:228:31:228:39 | "Finally" |
+| Finally.cs:228:31:228:39 | "Finally" | Finally.cs:228:13:228:40 | call to method WriteLine |
+| Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:216:10:216:12 | exit M11 |
+| Finally.cs:230:9:230:34 | ...; | Finally.cs:230:27:230:32 | "Done" |
+| Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:9:230:33 | call to method WriteLine |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:7:5:10:5 | {...} |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:8:29:8:32 | access to parameter args |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | exit M1 |
@@ -4515,6 +4534,24 @@ postDominance
 | Finally.cs:213:9:213:24 | ... = ... | Finally.cs:213:22:213:24 | "1" |
 | Finally.cs:213:9:213:25 | ...; | Finally.cs:211:13:211:28 | ... = ... |
 | Finally.cs:213:22:213:24 | "1" | Finally.cs:213:9:213:12 | this access |
+| Finally.cs:216:10:216:12 | exit M11 | Finally.cs:230:9:230:33 | call to method WriteLine |
+| Finally.cs:217:5:231:5 | {...} | Finally.cs:216:10:216:12 | enter M11 |
+| Finally.cs:218:9:229:9 | try {...} ... | Finally.cs:217:5:231:5 | {...} |
+| Finally.cs:219:9:221:9 | {...} | Finally.cs:218:9:229:9 | try {...} ... |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:220:31:220:35 | "Try" |
+| Finally.cs:220:13:220:37 | ...; | Finally.cs:219:9:221:9 | {...} |
+| Finally.cs:220:31:220:35 | "Try" | Finally.cs:220:13:220:37 | ...; |
+| Finally.cs:223:9:225:9 | {...} | Finally.cs:222:9:225:9 | catch {...} |
+| Finally.cs:224:13:224:38 | call to method WriteLine | Finally.cs:224:31:224:37 | "Catch" |
+| Finally.cs:224:13:224:39 | ...; | Finally.cs:223:9:225:9 | {...} |
+| Finally.cs:224:31:224:37 | "Catch" | Finally.cs:224:13:224:39 | ...; |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:220:13:220:36 | call to method WriteLine |
+| Finally.cs:228:13:228:40 | call to method WriteLine | Finally.cs:228:31:228:39 | "Finally" |
+| Finally.cs:228:13:228:41 | ...; | Finally.cs:227:9:229:9 | {...} |
+| Finally.cs:228:31:228:39 | "Finally" | Finally.cs:228:13:228:41 | ...; |
+| Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:230:27:230:32 | "Done" |
+| Finally.cs:230:9:230:34 | ...; | Finally.cs:228:13:228:40 | call to method WriteLine |
+| Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:9:230:34 | ...; |
 | Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:6:10:6:11 | enter M1 |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:29:8:32 | access to parameter args |
@@ -6943,6 +6980,14 @@ blockDominance
 | Finally.cs:211:13:211:29 | ...; | Finally.cs:211:13:211:29 | ...; |
 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; |
 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; |
+| Finally.cs:216:10:216:12 | enter M11 | Finally.cs:216:10:216:12 | enter M11 |
+| Finally.cs:216:10:216:12 | enter M11 | Finally.cs:220:13:220:36 | call to method WriteLine |
+| Finally.cs:216:10:216:12 | enter M11 | Finally.cs:222:9:225:9 | catch {...} |
+| Finally.cs:216:10:216:12 | enter M11 | Finally.cs:227:9:229:9 | {...} |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:220:13:220:36 | call to method WriteLine |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:227:9:229:9 | {...} |
+| Finally.cs:222:9:225:9 | catch {...} | Finally.cs:222:9:225:9 | catch {...} |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:227:9:229:9 | {...} |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | enter M1 |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | exit M1 |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... |
@@ -8747,6 +8792,13 @@ postBlockDominance
 | Finally.cs:211:13:211:29 | ...; | Finally.cs:211:13:211:29 | ...; |
 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; |
 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; |
+| Finally.cs:216:10:216:12 | enter M11 | Finally.cs:216:10:216:12 | enter M11 |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:216:10:216:12 | enter M11 |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:220:13:220:36 | call to method WriteLine |
+| Finally.cs:222:9:225:9 | catch {...} | Finally.cs:222:9:225:9 | catch {...} |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:216:10:216:12 | enter M11 |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:220:13:220:36 | call to method WriteLine |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:227:9:229:9 | {...} |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | enter M1 |
 | Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | enter M1 |
 | Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | exit M1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EnclosingCallable.expected
@@ -1742,6 +1742,26 @@ nodeEnclosing
 | Finally.cs:213:9:213:24 | ... = ... | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:213:9:213:25 | ...; | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:213:22:213:24 | "1" | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:216:10:216:12 | enter M11 | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:216:10:216:12 | exit M11 | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:217:5:231:5 | {...} | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:218:9:229:9 | try {...} ... | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:219:9:221:9 | {...} | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:220:13:220:37 | ...; | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:220:31:220:35 | "Try" | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:222:9:225:9 | catch {...} | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:223:9:225:9 | {...} | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:224:13:224:38 | call to method WriteLine | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:224:13:224:39 | ...; | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:224:31:224:37 | "Catch" | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:228:13:228:40 | call to method WriteLine | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:228:13:228:41 | ...; | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:228:31:228:39 | "Finally" | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:230:9:230:34 | ...; | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:230:27:230:32 | "Done" | Finally.cs:216:10:216:12 | M11 |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:6:10:6:11 | M1 |
@@ -3548,6 +3568,10 @@ blockEnclosing
 | Finally.cs:211:13:211:29 | ...; | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:211:13:211:29 | [finally: exception(Exception)] ...; | Finally.cs:195:10:195:12 | M10 |
 | Finally.cs:211:13:211:29 | [finally: exception(ExceptionA)] ...; | Finally.cs:195:10:195:12 | M10 |
+| Finally.cs:216:10:216:12 | enter M11 | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:222:9:225:9 | catch {...} | Finally.cs:216:10:216:12 | M11 |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:216:10:216:12 | M11 |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:6:10:6:11 | exit M1 | Foreach.cs:6:10:6:11 | M1 |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | M1 |

--- a/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/EntryElement.expected
@@ -1169,6 +1169,24 @@
 | Finally.cs:213:9:213:24 | ... = ... | Finally.cs:213:9:213:12 | this access |
 | Finally.cs:213:9:213:25 | ...; | Finally.cs:213:9:213:25 | ...; |
 | Finally.cs:213:22:213:24 | "1" | Finally.cs:213:22:213:24 | "1" |
+| Finally.cs:217:5:231:5 | {...} | Finally.cs:217:5:231:5 | {...} |
+| Finally.cs:218:9:229:9 | try {...} ... | Finally.cs:218:9:229:9 | try {...} ... |
+| Finally.cs:219:9:221:9 | {...} | Finally.cs:219:9:221:9 | {...} |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:220:31:220:35 | "Try" |
+| Finally.cs:220:13:220:37 | ...; | Finally.cs:220:13:220:37 | ...; |
+| Finally.cs:220:31:220:35 | "Try" | Finally.cs:220:31:220:35 | "Try" |
+| Finally.cs:222:9:225:9 | catch {...} | Finally.cs:222:9:225:9 | catch {...} |
+| Finally.cs:223:9:225:9 | {...} | Finally.cs:223:9:225:9 | {...} |
+| Finally.cs:224:13:224:38 | call to method WriteLine | Finally.cs:224:31:224:37 | "Catch" |
+| Finally.cs:224:13:224:39 | ...; | Finally.cs:224:13:224:39 | ...; |
+| Finally.cs:224:31:224:37 | "Catch" | Finally.cs:224:31:224:37 | "Catch" |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:227:9:229:9 | {...} |
+| Finally.cs:228:13:228:40 | call to method WriteLine | Finally.cs:228:31:228:39 | "Finally" |
+| Finally.cs:228:13:228:41 | ...; | Finally.cs:228:13:228:41 | ...; |
+| Finally.cs:228:31:228:39 | "Finally" | Finally.cs:228:31:228:39 | "Finally" |
+| Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:230:27:230:32 | "Done" |
+| Finally.cs:230:9:230:34 | ...; | Finally.cs:230:9:230:34 | ...; |
+| Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:27:230:32 | "Done" |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:7:5:10:5 | {...} |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:29:8:32 | access to parameter args |
 | Foreach.cs:8:22:8:24 | String arg | Foreach.cs:8:22:8:24 | String arg |

--- a/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/ExitElement.expected
@@ -1652,6 +1652,31 @@
 | Finally.cs:213:9:213:24 | ... = ... | Finally.cs:213:9:213:24 | ... = ... | normal |
 | Finally.cs:213:9:213:25 | ...; | Finally.cs:213:9:213:24 | ... = ... | normal |
 | Finally.cs:213:22:213:24 | "1" | Finally.cs:213:22:213:24 | "1" | normal |
+| Finally.cs:217:5:231:5 | {...} | Finally.cs:230:9:230:33 | call to method WriteLine | normal |
+| Finally.cs:218:9:229:9 | try {...} ... | Finally.cs:228:13:228:40 | call to method WriteLine | normal |
+| Finally.cs:219:9:221:9 | {...} | Finally.cs:220:13:220:36 | call to method WriteLine | normal |
+| Finally.cs:219:9:221:9 | {...} | Finally.cs:220:13:220:36 | call to method WriteLine | throw(Exception) |
+| Finally.cs:219:9:221:9 | {...} | Finally.cs:220:31:220:35 | "Try" | throw(OutOfMemoryException) |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:220:13:220:36 | call to method WriteLine | normal |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:220:13:220:36 | call to method WriteLine | throw(Exception) |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:220:31:220:35 | "Try" | throw(OutOfMemoryException) |
+| Finally.cs:220:13:220:37 | ...; | Finally.cs:220:13:220:36 | call to method WriteLine | normal |
+| Finally.cs:220:13:220:37 | ...; | Finally.cs:220:13:220:36 | call to method WriteLine | throw(Exception) |
+| Finally.cs:220:13:220:37 | ...; | Finally.cs:220:31:220:35 | "Try" | throw(OutOfMemoryException) |
+| Finally.cs:220:31:220:35 | "Try" | Finally.cs:220:31:220:35 | "Try" | normal |
+| Finally.cs:220:31:220:35 | "Try" | Finally.cs:220:31:220:35 | "Try" | throw(OutOfMemoryException) |
+| Finally.cs:222:9:225:9 | catch {...} | Finally.cs:224:13:224:38 | call to method WriteLine | normal |
+| Finally.cs:223:9:225:9 | {...} | Finally.cs:224:13:224:38 | call to method WriteLine | normal |
+| Finally.cs:224:13:224:38 | call to method WriteLine | Finally.cs:224:13:224:38 | call to method WriteLine | normal |
+| Finally.cs:224:13:224:39 | ...; | Finally.cs:224:13:224:38 | call to method WriteLine | normal |
+| Finally.cs:224:31:224:37 | "Catch" | Finally.cs:224:31:224:37 | "Catch" | normal |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:228:13:228:40 | call to method WriteLine | normal |
+| Finally.cs:228:13:228:40 | call to method WriteLine | Finally.cs:228:13:228:40 | call to method WriteLine | normal |
+| Finally.cs:228:13:228:41 | ...; | Finally.cs:228:13:228:40 | call to method WriteLine | normal |
+| Finally.cs:228:31:228:39 | "Finally" | Finally.cs:228:31:228:39 | "Finally" | normal |
+| Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:230:9:230:33 | call to method WriteLine | normal |
+| Finally.cs:230:9:230:34 | ...; | Finally.cs:230:9:230:33 | call to method WriteLine | normal |
+| Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:27:230:32 | "Done" | normal |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | empty |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | empty |
 | Foreach.cs:8:22:8:24 | String arg | Foreach.cs:8:22:8:24 | String arg | normal |

--- a/csharp/ql/test/library-tests/controlflow/graph/Finally.cs
+++ b/csharp/ql/test/library-tests/controlflow/graph/Finally.cs
@@ -212,4 +212,21 @@ public class Finally
         }
         this.Field = "1";
     }
+
+    void M11()
+    {
+        try
+        {
+            Console.WriteLine("Try");
+        }
+        catch
+        {
+            Console.WriteLine("Catch");
+        }
+        finally
+        {
+            Console.WriteLine("Finally");
+        }
+        Console.WriteLine("Done");
+    }
 }

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -1829,6 +1829,7 @@
 | Finally.cs:220:31:220:35 | "Try" | Finally.cs:222:9:225:9 | catch {...} | semmle.label | exception(OutOfMemoryException) |
 | Finally.cs:222:9:225:9 | catch {...} | Finally.cs:223:9:225:9 | {...} | semmle.label | successor |
 | Finally.cs:223:9:225:9 | {...} | Finally.cs:224:13:224:39 | ...; | semmle.label | successor |
+| Finally.cs:224:13:224:38 | call to method WriteLine | Finally.cs:227:9:229:9 | {...} | semmle.label | successor |
 | Finally.cs:224:13:224:39 | ...; | Finally.cs:224:31:224:37 | "Catch" | semmle.label | successor |
 | Finally.cs:224:31:224:37 | "Catch" | Finally.cs:224:13:224:38 | call to method WriteLine | semmle.label | successor |
 | Finally.cs:227:9:229:9 | {...} | Finally.cs:228:13:228:41 | ...; | semmle.label | successor |

--- a/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/NodeGraph.expected
@@ -1818,6 +1818,26 @@
 | Finally.cs:213:9:213:24 | ... = ... | Finally.cs:195:10:195:12 | exit M10 | semmle.label | successor |
 | Finally.cs:213:9:213:25 | ...; | Finally.cs:213:9:213:12 | this access | semmle.label | successor |
 | Finally.cs:213:22:213:24 | "1" | Finally.cs:213:9:213:24 | ... = ... | semmle.label | successor |
+| Finally.cs:216:10:216:12 | enter M11 | Finally.cs:217:5:231:5 | {...} | semmle.label | successor |
+| Finally.cs:217:5:231:5 | {...} | Finally.cs:218:9:229:9 | try {...} ... | semmle.label | successor |
+| Finally.cs:218:9:229:9 | try {...} ... | Finally.cs:219:9:221:9 | {...} | semmle.label | successor |
+| Finally.cs:219:9:221:9 | {...} | Finally.cs:220:13:220:37 | ...; | semmle.label | successor |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:222:9:225:9 | catch {...} | semmle.label | exception(Exception) |
+| Finally.cs:220:13:220:36 | call to method WriteLine | Finally.cs:227:9:229:9 | {...} | semmle.label | successor |
+| Finally.cs:220:13:220:37 | ...; | Finally.cs:220:31:220:35 | "Try" | semmle.label | successor |
+| Finally.cs:220:31:220:35 | "Try" | Finally.cs:220:13:220:36 | call to method WriteLine | semmle.label | successor |
+| Finally.cs:220:31:220:35 | "Try" | Finally.cs:222:9:225:9 | catch {...} | semmle.label | exception(OutOfMemoryException) |
+| Finally.cs:222:9:225:9 | catch {...} | Finally.cs:223:9:225:9 | {...} | semmle.label | successor |
+| Finally.cs:223:9:225:9 | {...} | Finally.cs:224:13:224:39 | ...; | semmle.label | successor |
+| Finally.cs:224:13:224:39 | ...; | Finally.cs:224:31:224:37 | "Catch" | semmle.label | successor |
+| Finally.cs:224:31:224:37 | "Catch" | Finally.cs:224:13:224:38 | call to method WriteLine | semmle.label | successor |
+| Finally.cs:227:9:229:9 | {...} | Finally.cs:228:13:228:41 | ...; | semmle.label | successor |
+| Finally.cs:228:13:228:40 | call to method WriteLine | Finally.cs:230:9:230:34 | ...; | semmle.label | successor |
+| Finally.cs:228:13:228:41 | ...; | Finally.cs:228:31:228:39 | "Finally" | semmle.label | successor |
+| Finally.cs:228:31:228:39 | "Finally" | Finally.cs:228:13:228:40 | call to method WriteLine | semmle.label | successor |
+| Finally.cs:230:9:230:33 | call to method WriteLine | Finally.cs:216:10:216:12 | exit M11 | semmle.label | successor |
+| Finally.cs:230:9:230:34 | ...; | Finally.cs:230:27:230:32 | "Done" | semmle.label | successor |
+| Finally.cs:230:27:230:32 | "Done" | Finally.cs:230:9:230:33 | call to method WriteLine | semmle.label | successor |
 | Foreach.cs:6:10:6:11 | enter M1 | Foreach.cs:7:5:10:5 | {...} | semmle.label | successor |
 | Foreach.cs:7:5:10:5 | {...} | Foreach.cs:8:29:8:32 | access to parameter args | semmle.label | successor |
 | Foreach.cs:8:9:9:13 | foreach (... ... in ...) ... | Foreach.cs:6:10:6:11 | exit M1 | semmle.label | empty |

--- a/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
+++ b/csharp/ql/test/library-tests/controlflow/graph/Nodes.expected
@@ -710,6 +710,7 @@ entryPoint
 | Finally.cs:147:10:147:11 | M8 | Finally.cs:148:5:170:5 | {...} |
 | Finally.cs:176:10:176:11 | M9 | Finally.cs:177:5:193:5 | {...} |
 | Finally.cs:195:10:195:12 | M10 | Finally.cs:196:5:214:5 | {...} |
+| Finally.cs:216:10:216:12 | M11 | Finally.cs:217:5:231:5 | {...} |
 | Foreach.cs:6:10:6:11 | M1 | Foreach.cs:7:5:10:5 | {...} |
 | Foreach.cs:12:10:12:11 | M2 | Foreach.cs:13:5:16:5 | {...} |
 | Foreach.cs:18:10:18:11 | M3 | Foreach.cs:19:5:22:5 | {...} |


### PR DESCRIPTION
For code such as
```
    void M11()
    {
        try
        {
            Console.WriteLine("Try");
        }
        catch
        {
            Console.WriteLine("Catch");
        }
        finally
        {
            Console.WriteLine("Finally");
        }
        Console.WriteLine("Done");
    }
```
we were missing a CFG edge from the exit node of the `catch` block to the entry node of the `finally` block (marked in red below):
<img width="309" alt="Screenshot 2020-04-22 at 08 27 40" src="https://user-images.githubusercontent.com/3667920/79948132-8ecb1200-8473-11ea-8193-36a60c437ad5.png">

This caused for example the false positive reported on https://github.com/Semmle/ql/issues/3305.