### PR TITLE
New query: Incomplete HTML attribute sanitization

### DIFF
--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -10,6 +10,7 @@
 | **Query**                                                                       | **Tags**                                                          | **Purpose**                                                                                                                                                                            |
 |---------------------------------------------------------------------------------|-------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Cross-site scripting through DOM (`js/xss-through-dom`) | security, external/cwe/cwe-079, external/cwe/cwe-116 | Highlights potential XSS vulnerabilities where existing text from the DOM is used as HTML. Results are not shown on LGTM by default. |
+| Incomplete HTML attribute sanitization (`js/incomplete-html-attribute-sanitization`) | security, external/cwe/cwe-20, external/cwe/cwe-079, external/cwe/cwe-116 | Highlights potential XSS vulnerabilities due to incomplete sanitization of HTML meta-characters. Results are shown on LGTM by default. |
 
 ## Changes to existing queries
 

--- a/javascript/config/suites/javascript/security
+++ b/javascript/config/suites/javascript/security
@@ -19,6 +19,7 @@
 + semmlecode-javascript-queries/Security/CWE-094/CodeInjection.ql: /Security/CWE/CWE-094
 + semmlecode-javascript-queries/Security/CWE-094/UnsafeDynamicMethodAccess.ql: /Security/CWE/CWE-094
 + semmlecode-javascript-queries/Security/CWE-116/IncompleteSanitization.ql: /Security/CWE/CWE-116
++ semmlecode-javascript-queries/Security/CWE-116/IncompleteHtmlAttributeSanitization.ql: /Security/CWE/CWE-116
 + semmlecode-javascript-queries/Security/CWE-116/DoubleEscaping.ql: /Security/CWE/CWE-116
 + semmlecode-javascript-queries/Security/CWE-134/TaintedFormatString.ql: /Security/CWE/CWE-134
 + semmlecode-javascript-queries/Security/CWE-201/PostMessageStar.ql: /Security/CWE/CWE-201

--- a/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.qhelp
+++ b/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.qhelp
@@ -1,0 +1,86 @@
+<!DOCTYPE qhelp PUBLIC
+"-//Semmle//qhelp//EN"
+"qhelp.dtd">
+<qhelp>
+
+	<overview>
+		<p>
+
+			Sanitizing untrusted input for HTML meta-characters is an important
+			technique for preventing cross-site scripting attacks. Usually, this
+			is done by escaping <code>&lt;</code>, <code>&gt;</code>,
+			<code>&amp;</code> and <code>&quot;</code>. But the context in which
+			the sanitized value is used decides which characters that actually
+			need to be sanitized.
+
+		</p>
+
+		<p>
+
+			As a consequence, some programs only sanitize
+			<code>&lt;</code> and <code>&gt;</code> since those are the most
+			common dangerous characters. The lack of sanitization for
+			<code>&quot;</code> is problematic when an incompletely sanitized
+			value is used as an HTML attribute in a string that
+			<strong>later</strong> is parsed as HTML.
+
+		</p>
+
+	</overview>
+
+	<recommendation>
+
+		Sanitize all relevant HTML meta-characters when constructing
+		HTML dynamically, pay special attention to where the sanitized value is used.
+
+	</recommendation>
+
+	<example>
+
+		<p>
+
+			The following example code writes part of an HTTP request (which is
+			controlled by the user) to an HTML attribute of the server response.
+
+			The user-controlled value is, however, not sanitized for
+			<code>&quot;</code>. This leaves the website vulnerable to cross-site
+			scripting since an attacker can use a string like <code>"
+			onclick="alert(42)</code> to inject JavaScript code into the response.
+
+		</p>
+		<sample src="examples/IncompleteHtmlAttributeSanitization.js" />
+
+
+		<p>
+
+			Sanitizing the user-controlled data for
+			<code>&quot;</code> prevents the vulnerability:
+
+		</p>
+
+		<sample src="examples/IncompleteHtmlAttributeSanitizationGood.js" />
+
+	</example>
+
+	<references>
+		<li>
+			OWASP:
+			<a href="https://cheatsheetseries.owasp.org/cheatsheets/DOM_based_XSS_Prevention_Cheat_Sheet.html">DOM based
+			XSS Prevention Cheat Sheet</a>.
+		</li>
+		<li>
+			OWASP:
+			<a href="https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html">XSS
+			(Cross Site Scripting) Prevention Cheat Sheet</a>.
+		</li>
+		<li>
+			OWASP
+			<a href="https://www.owasp.org/index.php/Types_of_Cross-Site_Scripting">Types of Cross-Site
+			Scripting</a>.
+		</li>
+		<li>
+			Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.
+		</li>
+	</references>
+
+</qhelp>

--- a/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.qhelp
+++ b/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.qhelp
@@ -9,8 +9,8 @@
 			Sanitizing untrusted input for HTML meta-characters is an important
 			technique for preventing cross-site scripting attacks. Usually, this
 			is done by escaping <code>&lt;</code>, <code>&gt;</code>,
-			<code>&amp;</code> and <code>&quot;</code>. But the context in which
-			the sanitized value is used decides which characters that actually
+			<code>&amp;</code> and <code>&quot;</code>. However, the context in which
+			the sanitized value is used decides the characters that
 			need to be sanitized.
 
 		</p>
@@ -59,7 +59,7 @@
 		<p>
 
 			Sanitizing the user-controlled data for
-			<code>&quot;</code> prevents the vulnerability:
+			<code>&quot;</code> helps prevent the vulnerability:
 
 		</p>
 

--- a/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.qhelp
+++ b/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.qhelp
@@ -22,7 +22,7 @@
 			common dangerous characters. The lack of sanitization for
 			<code>&quot;</code> is problematic when an incompletely sanitized
 			value is used as an HTML attribute in a string that
-			<strong>later</strong> is parsed as HTML.
+			later is parsed as HTML.
 
 		</p>
 

--- a/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.qhelp
+++ b/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.qhelp
@@ -30,8 +30,13 @@
 
 	<recommendation>
 
-		Sanitize all relevant HTML meta-characters when constructing
-		HTML dynamically, pay special attention to where the sanitized value is used.
+		<p>
+
+			Sanitize all relevant HTML meta-characters when
+			constructing HTML dynamically, and pay special attention to where the
+			sanitized value is used.
+
+		</p>
 
 	</recommendation>
 
@@ -75,8 +80,7 @@
 		</li>
 		<li>
 			OWASP
-			<a href="https://www.owasp.org/index.php/Types_of_Cross-Site_Scripting">Types of Cross-Site
-			Scripting</a>.
+			<a href="https://owasp.org/www-community/Types_of_Cross-Site_Scripting">Types of Cross-Site</a>.
 		</li>
 		<li>
 			Wikipedia: <a href="http://en.wikipedia.org/wiki/Cross-site_scripting">Cross-site scripting</a>.

--- a/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.ql
+++ b/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.ql
@@ -1,0 +1,41 @@
+/**
+ * @name Incomplete HTML attribute sanitization
+ * @description Writing incompletely sanitized values to HTML
+ *              attribute strings  can lead to a cross-site
+ *              scripting vulnerability.
+ * @kind path-problem
+ * @problem.severity warning
+ * @precision high
+ * @id js/incomplete-html-attribute-sanitization
+ * @tags security
+ *       external/cwe/cwe-079
+ *       external/cwe/cwe-116
+ *       external/cwe/cwe-20
+ */
+
+import javascript
+import DataFlow::PathGraph
+import semmle.javascript.security.dataflow.IncompleteHtmlAttributeSanitization::IncompleteHtmlAttributeSanitization
+import semmle.javascript.security.IncompleteBlacklistSanitizer
+
+/**
+ * Gets a pretty string of the dangerous characters for `sink`.
+ */
+string prettyPrintDangerousCharaters(Sink sink) {
+  result =
+    strictconcat(string s |
+      s = describeCharacters(sink.getADangerousCharacter())
+    |
+      s, ", " order by s
+    ).regexpReplaceAll(",(?=[^,]+$)", " or")
+}
+
+from Configuration cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+where cfg.hasFlowPath(source, sink)
+select sink.getNode(), source, sink,
+  // this message is slightly sub-optimal as we do not have an easy way
+  // to get the flow labels that reach the sink, so the message includes
+  // all of them in a disjunction
+  "Cross-site scripting vulnerability as the output of $@ may contain " +
+    prettyPrintDangerousCharaters(sink.getNode()) + " when it reaches this attribute definition.",
+  source.getNode(), "this final HTML sanitizer step"

--- a/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.ql
+++ b/javascript/ql/src/Security/CWE-116/IncompleteHtmlAttributeSanitization.ql
@@ -1,7 +1,7 @@
 /**
  * @name Incomplete HTML attribute sanitization
  * @description Writing incompletely sanitized values to HTML
- *              attribute strings  can lead to a cross-site
+ *              attribute strings can lead to a cross-site
  *              scripting vulnerability.
  * @kind path-problem
  * @problem.severity warning

--- a/javascript/ql/src/Security/CWE-116/examples/IncompleteHtmlAttributeSanitization.js
+++ b/javascript/ql/src/Security/CWE-116/examples/IncompleteHtmlAttributeSanitization.js
@@ -1,0 +1,9 @@
+var app = require('express')();
+
+app.get('/user/:id', function(req, res) {
+	let id = req.params.id;
+	id = id.replace(/<|>/g, ""); // BAD
+	let userHtml = `<div data-id="${id}">${getUserName(id)} || Unknown name</div>`;
+	// ...
+	res.send(prefix + userHtml + suffix);
+});

--- a/javascript/ql/src/Security/CWE-116/examples/IncompleteHtmlAttributeSanitization.js
+++ b/javascript/ql/src/Security/CWE-116/examples/IncompleteHtmlAttributeSanitization.js
@@ -3,7 +3,7 @@ var app = require('express')();
 app.get('/user/:id', function(req, res) {
 	let id = req.params.id;
 	id = id.replace(/<|>/g, ""); // BAD
-	let userHtml = `<div data-id="${id}">${getUserName(id)} || Unknown name</div>`;
+	let userHtml = `<div data-id="${id}">${getUserName(id) || "Unknown name"}</div>`;
 	// ...
 	res.send(prefix + userHtml + suffix);
 });

--- a/javascript/ql/src/Security/CWE-116/examples/IncompleteHtmlAttributeSanitizationGood.js
+++ b/javascript/ql/src/Security/CWE-116/examples/IncompleteHtmlAttributeSanitizationGood.js
@@ -3,7 +3,7 @@ var app = require('express')();
 app.get('/user/:id', function(req, res) {
 	let id = req.params.id;
 	id = id.replace(/<|>|&|"/g, ""); // GOOD
-	let userHtml = `<div data-id="${id}">${getUserName(id)} || Unknown name</div>`;
+	let userHtml = `<div data-id="${id}">${getUserName(id) || "Unknown name"}</div>`;
 	// ...
 	res.send(prefix + userHtml + suffix);
 });

--- a/javascript/ql/src/Security/CWE-116/examples/IncompleteHtmlAttributeSanitizationGood.js
+++ b/javascript/ql/src/Security/CWE-116/examples/IncompleteHtmlAttributeSanitizationGood.js
@@ -1,0 +1,9 @@
+var app = require('express')();
+
+app.get('/user/:id', function(req, res) {
+	let id = req.params.id;
+	id = id.replace(/<|>|&|"/g, ""); // GOOD
+	let userHtml = `<div data-id="${id}">${getUserName(id)} || Unknown name</div>`;
+	// ...
+	res.send(prefix + userHtml + suffix);
+});

--- a/javascript/ql/src/semmle/javascript/security/IncompleteBlacklistSanitizer.qll
+++ b/javascript/ql/src/semmle/javascript/security/IncompleteBlacklistSanitizer.qll
@@ -1,0 +1,157 @@
+/**
+ * Provides classes and predicates for working with incomplete blacklist sanitizers.
+ */
+
+import javascript
+
+/**
+ * An incomplete black-list sanitizer.
+ */
+abstract class IncompleteBlacklistSanitizer extends DataFlow::Node {
+  /**
+   * Gets a relevant character that is not sanitized by this sanitizer.
+   */
+  abstract string getAnUnsanitizedCharacter();
+
+  /**
+   * Gets the kind of sanitization this sanitizer performs.
+   */
+  abstract string getKind();
+}
+
+/**
+ * Describes the characters represented by `rep`.
+ */
+string describeCharacters(string rep) {
+  rep = "\"" and result = "quotes"
+  or
+  rep = "&" and result = "ampersands"
+  or
+  rep = "<" and result = "less-thans"
+  or
+  rep = ">" and result = "greater-thans"
+}
+
+/**
+ * A local sequence of calls to `String.prototype.replace`,
+ * represented by the last call.
+ */
+class StringReplaceCallSequence extends DataFlow::CallNode {
+  StringReplaceCallSequence() {
+    this instanceof StringReplaceCall and
+    not exists(getAStringReplaceMethodCall(this)) // terminal
+  }
+
+  /**
+   * Gets a member of this sequence.
+   */
+  StringReplaceCall getAMember() { this = getAStringReplaceMethodCall*(result) }
+
+  /** Gets a string that is the replacement of this call. */
+  string getAReplacementString() {
+    // this is more restrictive than `StringReplaceCall::replaces/2`, in the name of precision
+    getAMember().getRawReplacement().getStringValue() = result
+  }
+
+  /** Gets a string that is being replaced by this call. */
+  string getAReplacedString() { getAMember().getAReplacedString() = result }
+}
+
+/**
+ * A specialized version of `DataFlow::Node::getAMethodCall` that is
+ * restricted to `StringReplaceCall`-nodes.
+ */
+private StringReplaceCall getAStringReplaceMethodCall(StringReplaceCall n) {
+  n.getAMethodCall() = result
+}
+
+/**
+ * Provides predicates and classes for reasoning about HTML sanitization.
+ */
+module HtmlSanitization {
+  private predicate fixedGlobalReplacement(StringReplaceCallSequence chain) {
+    forall(StringReplaceCall member | member = chain.getAMember() |
+      member.isGlobal() and member.getArgument(0) instanceof DataFlow::RegExpLiteralNode
+    )
+  }
+
+  /**
+   * Gets a HTML-relevant character that is replaced by `chain`.
+   */
+  private string getALikelyReplacedCharacter(StringReplaceCallSequence chain) {
+    result = "\"" and
+    (
+      chain.getAReplacedString() = result or
+      chain.getAReplacementString() = "&quot;" or
+      chain.getAReplacementString() = "&#34;"
+    )
+    or
+    result = "&" and
+    (
+      chain.getAReplacedString() = result or
+      chain.getAReplacementString() = "&amp;" or
+      chain.getAReplacementString() = "&#40;"
+    )
+    or
+    result = "<" and
+    (
+      chain.getAReplacedString() = result or
+      chain.getAReplacementString() = "&lt;" or
+      chain.getAReplacementString() = "&#60;"
+    )
+    or
+    result = ">" and
+    (
+      chain.getAReplacedString() = result or
+      chain.getAReplacementString() = "&gt;" or
+      chain.getAReplacementString() = "&#62;"
+    )
+  }
+
+  /**
+   * An incomplete sanitizer for HTML-relevant characters.
+   */
+  class IncompleteSanitizer extends IncompleteBlacklistSanitizer {
+    StringReplaceCallSequence chain;
+    string unsanitized;
+
+    IncompleteSanitizer() {
+      this = chain and
+      fixedGlobalReplacement(chain) and
+      not getALikelyReplacedCharacter(chain) = unsanitized and
+      (
+        // replaces `<` and `>`
+        getALikelyReplacedCharacter(chain) = "<" and
+        getALikelyReplacedCharacter(chain) = ">" and
+        (
+          unsanitized = "\""
+          or
+          unsanitized = "&"
+        )
+        or
+        // replaces '&' and either `<` or `>`
+        getALikelyReplacedCharacter(chain) = "&" and
+        (
+          getALikelyReplacedCharacter(chain) = ">" and
+          unsanitized = ">"
+          or
+          getALikelyReplacedCharacter(chain) = "<" and
+          unsanitized = "<"
+        )
+      ) and
+      // does not replace special characters that the browser doesn't care for
+      not chain.getAReplacedString() = ["!", "#", "*", "?", "@", "|", "~"] and
+      /// only replaces explicit characters: exclude character ranges and negated character classes
+      not exists(RegExpTerm t | t = chain.getAMember().getRegExp().getRoot().getAChild*() |
+        t.(RegExpCharacterClass).isInverted() or
+        t instanceof RegExpCharacterRange
+      ) and
+      // the replacements are either empty or HTML entities
+      chain.getAReplacementString().regexpMatch("(?i)(|(&[#a-z0-9]+;))")
+    }
+
+    override string getKind() { result = "HTML" }
+
+    override string getAnUnsanitizedCharacter() { result = unsanitized }
+  }
+}

--- a/javascript/ql/src/semmle/javascript/security/dataflow/IncompleteHtmlAttributeSanitization.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/IncompleteHtmlAttributeSanitization.qll
@@ -1,0 +1,58 @@
+/**
+ * Provides a taint tracking configuration for reasoning about
+ * incomplete HTML sanitization vulnerabilities.
+ *
+ * Note, for performance reasons: only import this file if
+ * `IncompleteHtmlAttributeSanitization::Configuration` is needed, otherwise
+ * `IncompleteHtmlAttributeSanitizationCustomizations` should be imported instead.
+ */
+
+import javascript
+
+module IncompleteHtmlAttributeSanitization {
+  import IncompleteHtmlAttributeSanitizationCustomizations::IncompleteHtmlAttributeSanitization
+
+  private module Label {
+    class Quote extends DataFlow::FlowLabel {
+      Quote() { this = "\"" }
+    }
+
+    class Ampersand extends DataFlow::FlowLabel {
+      Ampersand() { this = "&" }
+    }
+
+    DataFlow::FlowLabel characterToLabel(string c) { c = result }
+  }
+
+  /**
+   * A taint-tracking configuration for reasoning about incomplete HTML sanitization vulnerabilities.
+   */
+  class Configuration extends TaintTracking::Configuration {
+    Configuration() { this = "IncompleteHtmlAttributeSanitization" }
+
+    override predicate isSource(DataFlow::Node source, DataFlow::FlowLabel label) {
+      label = Label::characterToLabel(source.(Source).getAnUnsanitizedCharacter())
+    }
+
+    override predicate isSink(DataFlow::Node sink, DataFlow::FlowLabel label) {
+      label = Label::characterToLabel(sink.(Sink).getADangerousCharacter())
+    }
+
+    override predicate isAdditionalFlowStep(
+      DataFlow::Node src, DataFlow::Node dst, DataFlow::FlowLabel srclabel,
+      DataFlow::FlowLabel dstlabel
+    ) {
+      super.isAdditionalFlowStep(src, dst) and srclabel = dstlabel
+    }
+
+    override predicate isLabeledBarrier(DataFlow::Node node, DataFlow::FlowLabel lbl) {
+      lbl = Label::characterToLabel(node.(StringReplaceCall).getAReplacedString()) or
+      isSanitizer(node)
+    }
+
+    override predicate isSanitizer(DataFlow::Node n) {
+      n instanceof Sanitizer or
+      super.isSanitizer(n)
+    }
+  }
+}

--- a/javascript/ql/src/semmle/javascript/security/dataflow/IncompleteHtmlAttributeSanitizationCustomizations.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/IncompleteHtmlAttributeSanitizationCustomizations.qll
@@ -1,0 +1,87 @@
+/**
+ * Provides default sources, sinks and sanitizers for reasoning about
+ * incomplete HTML sanitization vulnerabilities, as well as extension
+ * points for adding your own.
+ */
+
+import javascript
+import semmle.javascript.security.dataflow.RemoteFlowSources
+import semmle.javascript.security.IncompleteBlacklistSanitizer
+
+module IncompleteHtmlAttributeSanitization {
+  /**
+   * A data flow source for incomplete HTML sanitization vulnerabilities.
+   */
+  abstract class Source extends DataFlow::Node {
+    /**
+     * Gets a character that may come out of this source.
+     */
+    abstract string getAnUnsanitizedCharacter();
+  }
+
+  /**
+   * A data flow sink for incomplete HTML sanitization vulnerabilities.
+   */
+  abstract class Sink extends DataFlow::Node {
+    /**
+     * Gets a character that is dangerous for this sink.
+     */
+    abstract string getADangerousCharacter();
+  }
+
+  /**
+   * A sanitizer for incomplete HTML sanitization vulnerabilities.
+   */
+  abstract class Sanitizer extends DataFlow::Node { }
+
+  /**
+   * A source of incompletely sanitized characters, considered as a
+   * flow source for incomplete HTML sanitization vulnerabilities.
+   */
+  class IncompleteHtmlSanitizerAsSource extends Source, HtmlSanitization::IncompleteSanitizer {
+    override string getAnUnsanitizedCharacter() {
+      result = HtmlSanitization::IncompleteSanitizer.super.getAnUnsanitizedCharacter()
+    }
+  }
+
+  /**
+   * A concatenation that syntactically looks like a definition of an HTML attribute.
+   */
+  class HtmlAttributeConcatenation extends StringOps::ConcatenationLeaf {
+    string lhs;
+
+    HtmlAttributeConcatenation() {
+      lhs = this.getPreviousLeaf().getStringValue().regexpCapture("(.*)=\"[^\"]*", 1) and
+      this.getNextLeaf().getStringValue().regexpMatch(".*\".*")
+    }
+
+    /**
+     * Holds if the attribute value is interpreted as JavaScript source code.
+     */
+    predicate isInterpretedAsJavaScript() { lhs.regexpMatch("(?i)(.* )?on[a-z]+") }
+  }
+
+  /**
+   * A concatenation that syntactically looks like a definition of an
+   * HTML attribute, as a sink for incomplete HTML sanitization
+   * vulnerabilities.
+   */
+  class HtmlAttributeConcatenationAsSink extends Sink, DataFlow::ValueNode,
+    HtmlAttributeConcatenation {
+    override string getADangerousCharacter() {
+      isInterpretedAsJavaScript() and result = "&"
+      or
+      result = "\""
+    }
+  }
+
+  /**
+   * An encoder for potentially malicious characters, as a sanitizer
+   * for incomplete HTML sanitization vulnerabilities.
+   */
+  class EncodingSanitizer extends Sanitizer {
+    EncodingSanitizer() {
+      this = DataFlow::globalVarRef(["encodeURIComponent", "encodeURI"]).getACall()
+    }
+  }
+}

--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteBlacklistSanitizer.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteBlacklistSanitizer.expected
@@ -1,0 +1,29 @@
+| tst.js:206:2:206:24 | s().rep ... ]/g,'') | This HTML sanitizer does not sanitize ampersands |
+| tst.js:206:2:206:24 | s().rep ... ]/g,'') | This HTML sanitizer does not sanitize quotes |
+| tst.js:207:2:207:26 | s().rep ... /g, '') | This HTML sanitizer does not sanitize quotes |
+| tst.js:208:2:208:26 | s().rep ... /g, '') | This HTML sanitizer does not sanitize ampersands |
+| tst.js:209:2:209:40 | s().rep ... /g, '') | This HTML sanitizer does not sanitize ampersands |
+| tst.js:209:2:209:40 | s().rep ... /g, '') | This HTML sanitizer does not sanitize quotes |
+| tst.js:210:2:210:58 | s().rep ... /g, '') | This HTML sanitizer does not sanitize quotes |
+| tst.js:211:2:211:58 | s().rep ... /g, '') | This HTML sanitizer does not sanitize quotes |
+| tst.js:212:2:212:58 | s().rep ... /g, '') | This HTML sanitizer does not sanitize quotes |
+| tst.js:215:6:215:24 | s.replace(/>/g, '') | This HTML sanitizer does not sanitize ampersands |
+| tst.js:215:6:215:24 | s.replace(/>/g, '') | This HTML sanitizer does not sanitize quotes |
+| tst.js:217:2:217:93 | s().rep ... &#39;') | This HTML sanitizer does not sanitize quotes |
+| tst.js:243:9:243:31 | s().rep ... ]/g,'') | This HTML sanitizer does not sanitize ampersands |
+| tst.js:243:9:243:31 | s().rep ... ]/g,'') | This HTML sanitizer does not sanitize quotes |
+| tst.js:244:9:244:33 | s().rep ... /g, '') | This HTML sanitizer does not sanitize quotes |
+| tst.js:245:9:245:33 | s().rep ... /g, '') | This HTML sanitizer does not sanitize ampersands |
+| tst.js:249:9:249:33 | s().rep ... ]/g,'') | This HTML sanitizer does not sanitize quotes |
+| tst.js:251:9:251:33 | s().rep ... ]/g,'') | This HTML sanitizer does not sanitize quotes |
+| tst.js:253:21:253:45 | s().rep ... /g, '') | This HTML sanitizer does not sanitize ampersands |
+| tst.js:254:32:254:56 | s().rep ... /g, '') | This HTML sanitizer does not sanitize ampersands |
+| tst.js:255:26:255:50 | s().rep ... /g, '') | This HTML sanitizer does not sanitize ampersands |
+| tst.js:256:15:256:39 | s().rep ... /g, '') | This HTML sanitizer does not sanitize ampersands |
+| tst.js:261:10:261:81 | value.r ... '&gt;') | This HTML sanitizer does not sanitize quotes |
+| tst.js:270:61:270:85 | s().rep ... /g, '') | This HTML sanitizer does not sanitize ampersands |
+| tst.js:272:28:272:50 | s().rep ... ]/g,'') | This HTML sanitizer does not sanitize ampersands |
+| tst.js:272:28:272:50 | s().rep ... ]/g,'') | This HTML sanitizer does not sanitize quotes |
+| tst.js:274:12:274:94 | s().val ... g , '') | This HTML sanitizer does not sanitize ampersands |
+| tst.js:274:12:274:94 | s().val ... g , '') | This HTML sanitizer does not sanitize quotes |
+| tst.js:277:9:277:29 | arr2.re ... "/g,"") | This HTML sanitizer does not sanitize ampersands |

--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteBlacklistSanitizer.ql
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteBlacklistSanitizer.ql
@@ -1,0 +1,7 @@
+import javascript
+import semmle.javascript.security.IncompleteBlacklistSanitizer
+
+from IncompleteBlacklistSanitizer sanitizer
+select sanitizer,
+  "This " + sanitizer.getKind() + " sanitizer does not sanitize " +
+    describeCharacters(sanitizer.getAnUnsanitizedCharacter())

--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteHtmlAttributeSanitization.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteHtmlAttributeSanitization.expected
@@ -1,0 +1,45 @@
+nodes
+| tst.js:243:9:243:31 | s().rep ... ]/g,'') |
+| tst.js:243:9:243:31 | s().rep ... ]/g,'') |
+| tst.js:243:9:243:31 | s().rep ... ]/g,'') |
+| tst.js:244:9:244:33 | s().rep ... /g, '') |
+| tst.js:244:9:244:33 | s().rep ... /g, '') |
+| tst.js:244:9:244:33 | s().rep ... /g, '') |
+| tst.js:249:9:249:33 | s().rep ... ]/g,'') |
+| tst.js:249:9:249:33 | s().rep ... ]/g,'') |
+| tst.js:249:9:249:33 | s().rep ... ]/g,'') |
+| tst.js:253:21:253:45 | s().rep ... /g, '') |
+| tst.js:253:21:253:45 | s().rep ... /g, '') |
+| tst.js:253:21:253:45 | s().rep ... /g, '') |
+| tst.js:254:32:254:56 | s().rep ... /g, '') |
+| tst.js:254:32:254:56 | s().rep ... /g, '') |
+| tst.js:254:32:254:56 | s().rep ... /g, '') |
+| tst.js:270:61:270:85 | s().rep ... /g, '') |
+| tst.js:270:61:270:85 | s().rep ... /g, '') |
+| tst.js:270:61:270:85 | s().rep ... /g, '') |
+| tst.js:274:6:274:94 | arr |
+| tst.js:274:12:274:94 | s().val ... g , '') |
+| tst.js:274:12:274:94 | s().val ... g , '') |
+| tst.js:275:9:275:11 | arr |
+| tst.js:275:9:275:21 | arr.join(" ") |
+| tst.js:275:9:275:21 | arr.join(" ") |
+edges
+| tst.js:243:9:243:31 | s().rep ... ]/g,'') | tst.js:243:9:243:31 | s().rep ... ]/g,'') |
+| tst.js:244:9:244:33 | s().rep ... /g, '') | tst.js:244:9:244:33 | s().rep ... /g, '') |
+| tst.js:249:9:249:33 | s().rep ... ]/g,'') | tst.js:249:9:249:33 | s().rep ... ]/g,'') |
+| tst.js:253:21:253:45 | s().rep ... /g, '') | tst.js:253:21:253:45 | s().rep ... /g, '') |
+| tst.js:254:32:254:56 | s().rep ... /g, '') | tst.js:254:32:254:56 | s().rep ... /g, '') |
+| tst.js:270:61:270:85 | s().rep ... /g, '') | tst.js:270:61:270:85 | s().rep ... /g, '') |
+| tst.js:274:6:274:94 | arr | tst.js:275:9:275:11 | arr |
+| tst.js:274:12:274:94 | s().val ... g , '') | tst.js:274:6:274:94 | arr |
+| tst.js:274:12:274:94 | s().val ... g , '') | tst.js:274:6:274:94 | arr |
+| tst.js:275:9:275:11 | arr | tst.js:275:9:275:21 | arr.join(" ") |
+| tst.js:275:9:275:11 | arr | tst.js:275:9:275:21 | arr.join(" ") |
+#select
+| tst.js:243:9:243:31 | s().rep ... ]/g,'') | tst.js:243:9:243:31 | s().rep ... ]/g,'') | tst.js:243:9:243:31 | s().rep ... ]/g,'') | Cross-site scripting vulnerability as the output of $@ may contain quotes when it reaches this attribute definition. | tst.js:243:9:243:31 | s().rep ... ]/g,'') | this final HTML sanitizer step |
+| tst.js:244:9:244:33 | s().rep ... /g, '') | tst.js:244:9:244:33 | s().rep ... /g, '') | tst.js:244:9:244:33 | s().rep ... /g, '') | Cross-site scripting vulnerability as the output of $@ may contain quotes when it reaches this attribute definition. | tst.js:244:9:244:33 | s().rep ... /g, '') | this final HTML sanitizer step |
+| tst.js:249:9:249:33 | s().rep ... ]/g,'') | tst.js:249:9:249:33 | s().rep ... ]/g,'') | tst.js:249:9:249:33 | s().rep ... ]/g,'') | Cross-site scripting vulnerability as the output of $@ may contain quotes when it reaches this attribute definition. | tst.js:249:9:249:33 | s().rep ... ]/g,'') | this final HTML sanitizer step |
+| tst.js:253:21:253:45 | s().rep ... /g, '') | tst.js:253:21:253:45 | s().rep ... /g, '') | tst.js:253:21:253:45 | s().rep ... /g, '') | Cross-site scripting vulnerability as the output of $@ may contain ampersands or quotes when it reaches this attribute definition. | tst.js:253:21:253:45 | s().rep ... /g, '') | this final HTML sanitizer step |
+| tst.js:254:32:254:56 | s().rep ... /g, '') | tst.js:254:32:254:56 | s().rep ... /g, '') | tst.js:254:32:254:56 | s().rep ... /g, '') | Cross-site scripting vulnerability as the output of $@ may contain ampersands or quotes when it reaches this attribute definition. | tst.js:254:32:254:56 | s().rep ... /g, '') | this final HTML sanitizer step |
+| tst.js:270:61:270:85 | s().rep ... /g, '') | tst.js:270:61:270:85 | s().rep ... /g, '') | tst.js:270:61:270:85 | s().rep ... /g, '') | Cross-site scripting vulnerability as the output of $@ may contain ampersands or quotes when it reaches this attribute definition. | tst.js:270:61:270:85 | s().rep ... /g, '') | this final HTML sanitizer step |
+| tst.js:275:9:275:21 | arr.join(" ") | tst.js:274:12:274:94 | s().val ... g , '') | tst.js:275:9:275:21 | arr.join(" ") | Cross-site scripting vulnerability as the output of $@ may contain quotes when it reaches this attribute definition. | tst.js:274:12:274:94 | s().val ... g , '') | this final HTML sanitizer step |

--- a/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteHtmlAttributeSanitization.qlref
+++ b/javascript/ql/test/query-tests/Security/CWE-116/IncompleteSanitization/IncompleteHtmlAttributeSanitization.qlref
@@ -1,0 +1,1 @@
+Security/CWE-116/IncompleteHtmlAttributeSanitization.ql


### PR DESCRIPTION
As discussed in <https://github.com/github/codeql-javascript-team/issues/97>.

Putting this up slightly early without qhelp in case we decide that the scope of the query needs to be changed.

-   [x] write qhelp
-   [x] add change note
-   [x] check performance evaluation