### PR TITLE
C++: inline arithTypesMatch predicate

### DIFF
--- a/cpp/ql/src/Likely Bugs/Underspecified Functions/MistypedFunctionArguments.qll
+++ b/cpp/ql/src/Likely Bugs/Underspecified Functions/MistypedFunctionArguments.qll
@@ -6,6 +6,7 @@
 
 import cpp
 
+pragma[inline]
 private predicate arithTypesMatch(Type arg, Type parm) {
   arg = parm
   or


### PR DESCRIPTION
~**WAIT:** I'm starting to wonder whether this bug is real or whether it was just my laptop that froze up for 170 seconds. I wasn't at the keyboard at the time. I'll repeat the experiment tonight and only take this PR out of draft if the problem reproduces.~

This predicate is effectively a Cartesian product between all enum types. It's infeasible to compute it in full, so luckily the optimizer has been able to apply enough magic to make it feasible. That's not a robust solution, and it has indeed broken on at least one version of the 1.24 release candidate.

On a Chromium snapshot where I ran the LGTM suite overnight, the `m#MistypedFunctionArguments::arithTypesMatch#bb` predicate (magic for `arithTypesMatch`) took 170m5s. That was commit b69fdf5 from the internal repo. I tried to reproduce it in VSCode, this time with commit 646646, but it wasn't quite as bad: the predicate took only 38 seconds. In any case, making the problematic predicate `pragma[inline]` removes the slow magic and makes the `MistypedFunctionArguments.ql` query faster.