### PR TITLE
Revert "C#: Improve db consistency by removing assembly id"

### DIFF
--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Accessor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Accessor.cs
@@ -77,7 +77,7 @@ namespace Semmle.Extraction.CSharp.Entities
         }
 
         public new static Accessor Create(Context cx, IMethodSymbol symbol) =>
-            AccessorFactory.Instance.CreateEntityFromSymbol(cx, symbol);
+            AccessorFactory.Instance.CreateEntity(cx, symbol);
 
         class AccessorFactory : ICachedEntityFactory<IMethodSymbol, Accessor>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Constructor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Constructor.cs
@@ -104,7 +104,7 @@ namespace Semmle.Extraction.CSharp.Entities
             {
                 case MethodKind.StaticConstructor:
                 case MethodKind.Constructor:
-                    return ConstructorFactory.Instance.CreateEntityFromSymbol(cx, constructor);
+                    return ConstructorFactory.Instance.CreateEntity(cx, constructor);
                 default:
                     throw new InternalError(constructor, "Attempt to create a Constructor from a symbol that isn't a constructor");
             }

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Conversion.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Conversion.cs
@@ -11,7 +11,7 @@ namespace Semmle.Extraction.CSharp.Entities
             : base(cx, init) { }
 
         public new static Conversion Create(Context cx, IMethodSymbol symbol) =>
-            ConversionFactory.Instance.CreateEntityFromSymbol(cx, symbol);
+            ConversionFactory.Instance.CreateEntity(cx, symbol);
 
         public override Microsoft.CodeAnalysis.Location ReportingLocation
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Destructor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Destructor.cs
@@ -24,7 +24,7 @@ namespace Semmle.Extraction.CSharp.Entities
         }
 
         public new static Destructor Create(Context cx, IMethodSymbol symbol) =>
-            DestructorFactory.Instance.CreateEntityFromSymbol(cx, symbol);
+            DestructorFactory.Instance.CreateEntity(cx, symbol);
 
         class DestructorFactory : ICachedEntityFactory<IMethodSymbol, Destructor>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Event.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Event.cs
@@ -60,7 +60,7 @@ namespace Semmle.Extraction.CSharp.Entities
                 TypeMention.Create(Context, syntaxType, this, type);
         }
 
-        public static Event Create(Context cx, IEventSymbol symbol) => EventFactory.Instance.CreateEntityFromSymbol(cx, symbol);
+        public static Event Create(Context cx, IEventSymbol symbol) => EventFactory.Instance.CreateEntity(cx, symbol);
 
         class EventFactory : ICachedEntityFactory<IEventSymbol, Event>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/EventAccessor.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/EventAccessor.cs
@@ -53,7 +53,7 @@ namespace Semmle.Extraction.CSharp.Entities
         }
 
         public new static EventAccessor Create(Context cx, IMethodSymbol symbol) =>
-            EventAccessorFactory.Instance.CreateEntityFromSymbol(cx, symbol);
+            EventAccessorFactory.Instance.CreateEntity(cx, symbol);
 
         class EventAccessorFactory : ICachedEntityFactory<IMethodSymbol, EventAccessor>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Field.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Field.cs
@@ -18,7 +18,7 @@ namespace Semmle.Extraction.CSharp.Entities
             type = new Lazy<AnnotatedType>(() => Entities.Type.Create(cx, symbol.GetAnnotatedType()));
         }
 
-        public static Field Create(Context cx, IFieldSymbol field) => FieldFactory.Instance.CreateEntityFromSymbol(cx, field);
+        public static Field Create(Context cx, IFieldSymbol field) => FieldFactory.Instance.CreateEntity(cx, field);
 
         // Do not populate backing fields.
         // Populate Tuple fields.

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Indexer.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Indexer.cs
@@ -71,7 +71,7 @@ namespace Semmle.Extraction.CSharp.Entities
                 TypeMention.Create(Context, syntax.Type, this, type);
         }
 
-        public static new Indexer Create(Context cx, IPropertySymbol prop) => IndexerFactory.Instance.CreateEntityFromSymbol(cx, prop);
+        public static new Indexer Create(Context cx, IPropertySymbol prop) => IndexerFactory.Instance.CreateEntity(cx, prop);
 
         public override void WriteId(TextWriter trapFile)
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalFunction.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalFunction.cs
@@ -22,7 +22,7 @@ namespace Semmle.Extraction.CSharp.Entities
             trapFile.Write('*');
         }
 
-        public static new LocalFunction Create(Context cx, IMethodSymbol field) => LocalFunctionFactory.Instance.CreateEntityFromSymbol(cx, field);
+        public static new LocalFunction Create(Context cx, IMethodSymbol field) => LocalFunctionFactory.Instance.CreateEntity(cx, field);
 
         class LocalFunctionFactory : ICachedEntityFactory<IMethodSymbol, LocalFunction>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalVariable.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/LocalVariable.cs
@@ -43,7 +43,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public static LocalVariable Create(Context cx, ISymbol local)
         {
-            return LocalVariableFactory.Instance.CreateEntityFromSymbol(cx, local);
+            return LocalVariableFactory.Instance.CreateEntity(cx, local);
         }
 
         void DefineConstantValue(TextWriter trapFile)

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Method.cs
@@ -129,7 +129,7 @@ namespace Semmle.Extraction.CSharp.Entities
                     // Type arguments with different nullability can result in 
                     // a constructed method with different nullability of its parameters and return type,
                     // so we need to create a distinct database entity for it.
-                    trapFile.BuildList(",", m.symbol.GetAnnotatedTypeArguments(), (ta, tb0) => { AddSignatureTypeToId(m.Context, tb0, m.symbol, ta.Symbol, m.symbol); trapFile.Write((int)ta.Nullability); });
+                    trapFile.BuildList(",", m.symbol.GetAnnotatedTypeArguments(), (ta, tb0) => { AddSignatureTypeToId(m.Context, tb0, m.symbol, ta.Symbol); trapFile.Write((int)ta.Nullability); });
                     trapFile.Write('>');
                 }
             }
@@ -199,9 +199,12 @@ namespace Semmle.Extraction.CSharp.Entities
         /// to make the reference to <code>#3</code> in the label definition <code>#4</code> for
         /// <code>T</code> valid.
         /// </summary>
-        protected static void AddSignatureTypeToId(Context cx, TextWriter trapFile, IMethodSymbol method, ITypeSymbol type, ISymbol symbolBeingDefined)
+        protected static void AddSignatureTypeToId(Context cx, TextWriter trapFile, IMethodSymbol method, ITypeSymbol type)
         {
-            type.BuildTypeId(cx, trapFile, false, symbolBeingDefined, (cx0, tb0, type0, g) => AddSignatureTypeToId(cx, tb0, method, type0, g));
+            if (type.ContainsTypeParameters(cx, method))
+                type.BuildTypeId(cx, trapFile, (cx0, tb0, type0) => AddSignatureTypeToId(cx, tb0, method, type0));
+            else
+                trapFile.WriteSubId(Type.Create(cx, type));
         }
 
         protected static void AddParametersToId(Context cx, TextWriter trapFile, IMethodSymbol method)
@@ -212,13 +215,13 @@ namespace Semmle.Extraction.CSharp.Entities
             if (method.MethodKind == MethodKind.ReducedExtension)
             {
                 trapFile.WriteSeparator(",", ref index);
-                AddSignatureTypeToId(cx, trapFile, method, method.ReceiverType, method);
+                AddSignatureTypeToId(cx, trapFile, method, method.ReceiverType);
             }
 
             foreach (var param in method.Parameters)
             {
                 trapFile.WriteSeparator(",", ref index);
-                AddSignatureTypeToId(cx, trapFile, method, param.Type, method);
+                AddSignatureTypeToId(cx, trapFile, method, param.Type);
                 switch (param.RefKind)
                 {
                     case RefKind.Out:
@@ -241,10 +244,9 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public static void AddExplicitInterfaceQualifierToId(Context cx, System.IO.TextWriter trapFile, IEnumerable<ISymbol> explicitInterfaceImplementations)
         {
-            foreach (var i in explicitInterfaceImplementations)
+            if (explicitInterfaceImplementations.Any())
             {
-                trapFile.Write(';');
-                i.ContainingType.BuildNestedTypeId(cx, trapFile, null);
+                trapFile.AppendList(",", explicitInterfaceImplementations.Select(impl => cx.CreateEntity(impl.ContainingType)));
             }
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/OrdinaryMethod.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/OrdinaryMethod.cs
@@ -49,7 +49,7 @@ namespace Semmle.Extraction.CSharp.Entities
             ExtractCompilerGenerated(trapFile);
         }
 
-        public new static OrdinaryMethod Create(Context cx, IMethodSymbol method) => OrdinaryMethodFactory.Instance.CreateEntityFromSymbol(cx, method);
+        public new static OrdinaryMethod Create(Context cx, IMethodSymbol method) => OrdinaryMethodFactory.Instance.CreateEntity(cx, method);
 
         class OrdinaryMethodFactory : ICachedEntityFactory<IMethodSymbol, OrdinaryMethod>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Property.cs
@@ -113,7 +113,7 @@ namespace Semmle.Extraction.CSharp.Entities
         {
             bool isIndexer = prop.IsIndexer || prop.Parameters.Any();
 
-            return isIndexer ? Indexer.Create(cx, prop) : PropertyFactory.Instance.CreateEntityFromSymbol(cx, prop);
+            return isIndexer ? Indexer.Create(cx, prop) : PropertyFactory.Instance.CreateEntity(cx, prop);
         }
 
         public void VisitDeclaration(Context cx, PropertyDeclarationSyntax p)

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/ArrayType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/ArrayType.cs
@@ -36,7 +36,7 @@ namespace Semmle.Extraction.CSharp.Entities
             trapFile.Write(";type");
         }
 
-        public static ArrayType Create(Context cx, IArrayTypeSymbol symbol) => ArrayTypeFactory.Instance.CreateEntityFromSymbol(cx, symbol);
+        public static ArrayType Create(Context cx, IArrayTypeSymbol symbol) => ArrayTypeFactory.Instance.CreateEntity(cx, symbol);
 
         class ArrayTypeFactory : ICachedEntityFactory<IArrayTypeSymbol, ArrayType>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/DynamicType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/DynamicType.cs
@@ -9,7 +9,7 @@ namespace Semmle.Extraction.CSharp.Entities
         DynamicType(Context cx, IDynamicTypeSymbol init)
             : base(cx, init) { }
 
-        public static DynamicType Create(Context cx, IDynamicTypeSymbol type) => DynamicTypeFactory.Instance.CreateEntityFromSymbol(cx, type);
+        public static DynamicType Create(Context cx, IDynamicTypeSymbol type) => DynamicTypeFactory.Instance.CreateEntity(cx, type);
 
         public override Microsoft.CodeAnalysis.Location ReportingLocation => Context.Compilation.ObjectType.Locations.FirstOrDefault();
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/NamedType.cs
@@ -17,7 +17,7 @@ namespace Semmle.Extraction.CSharp.Entities
             typeArgumentsLazy = new Lazy<Type[]>(() => symbol.TypeArguments.Select(t => Create(cx, t)).ToArray());
         }
 
-        public static NamedType Create(Context cx, INamedTypeSymbol type) => NamedTypeFactory.Instance.CreateEntityFromSymbol(cx, type);
+        public static NamedType Create(Context cx, INamedTypeSymbol type) => NamedTypeFactory.Instance.CreateEntity(cx, type);
 
         public override bool NeedsPopulation => base.NeedsPopulation || symbol.TypeKind == TypeKind.Error;
 
@@ -111,7 +111,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            symbol.BuildTypeId(Context, trapFile, true, symbol, (cx0, tb0, sub, _) => tb0.WriteSubId(Create(cx0, sub)));
+            symbol.BuildTypeId(Context, trapFile, (cx0, tb0, sub) => tb0.WriteSubId(Create(cx0, sub)));
             trapFile.Write(";type");
         }
 
@@ -177,7 +177,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            referencedType.symbol.BuildNestedTypeId(Context, trapFile, referencedType.symbol);
+            trapFile.WriteSubId(referencedType);
             trapFile.Write(";typeRef");
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/PointerType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/PointerType.cs
@@ -29,7 +29,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public Type PointedAtType { get; private set; }
 
-        public static PointerType Create(Context cx, IPointerTypeSymbol symbol) => PointerTypeFactory.Instance.CreateEntityFromSymbol(cx, symbol);
+        public static PointerType Create(Context cx, IPointerTypeSymbol symbol) => PointerTypeFactory.Instance.CreateEntity(cx, symbol);
 
         class PointerTypeFactory : ICachedEntityFactory<IPointerTypeSymbol, PointerType>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TupleType.cs
@@ -13,7 +13,7 @@ namespace Semmle.Extraction.CSharp.Entities
     /// </summary>
     class TupleType : Type<INamedTypeSymbol>
     {
-        public static TupleType Create(Context cx, INamedTypeSymbol type) => TupleTypeFactory.Instance.CreateEntityFromSymbol(cx, type);
+        public static TupleType Create(Context cx, INamedTypeSymbol type) => TupleTypeFactory.Instance.CreateEntity(cx, type);
 
         class TupleTypeFactory : ICachedEntityFactory<INamedTypeSymbol, TupleType>
         {
@@ -32,7 +32,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            symbol.BuildTypeId(Context, trapFile, false, symbol, (cx0, tb0, sub, _) => tb0.WriteSubId(Create(cx0, sub)));
+            symbol.BuildTypeId(Context, trapFile, (cx0, tb0, sub) => tb0.WriteSubId(Create(cx0, sub)));
             trapFile.Write(";tuple");
         }
 

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/Type.cs
@@ -324,14 +324,6 @@ namespace Semmle.Extraction.CSharp.Entities
         }
 
         public override TrapStackBehaviour TrapStackBehaviour => TrapStackBehaviour.NoLabel;
-
-        public override bool Equals(object obj)
-        {
-            var other = obj as Type;
-            return other?.GetType() == GetType() && SymbolEqualityComparer.IncludeNullability.Equals(other.symbol, symbol);
-        }
-
-        public override int GetHashCode() => SymbolEqualityComparer.IncludeNullability.GetHashCode(symbol);
     }
 
     abstract class Type<T> : Type where T : ITypeSymbol

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameter.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/Types/TypeParameter.cs
@@ -88,7 +88,7 @@ namespace Semmle.Extraction.CSharp.Entities
         }
 
         static public TypeParameter Create(Context cx, ITypeParameterSymbol p) =>
-            TypeParameterFactory.Instance.CreateEntityFromSymbol(cx, p);
+            TypeParameterFactory.Instance.CreateEntity(cx, p);
 
         /// <summary>
         /// The variance of this type parameter.

--- a/csharp/extractor/Semmle.Extraction.CSharp/Entities/UserOperator.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/Entities/UserOperator.cs
@@ -51,7 +51,7 @@ namespace Semmle.Extraction.CSharp.Entities
 
         public override void WriteId(TextWriter trapFile)
         {
-            AddSignatureTypeToId(Context, trapFile, symbol, symbol.ReturnType, symbol); // Needed for op_explicit(), which differs only by return type.
+            AddSignatureTypeToId(Context, trapFile, symbol, symbol.ReturnType); // Needed for op_explicit(), which differs only by return type.
             trapFile.Write(' ');
             BuildMethodId(this, trapFile);
         }
@@ -190,7 +190,7 @@ namespace Semmle.Extraction.CSharp.Entities
             return result;
         }
 
-        public new static UserOperator Create(Context cx, IMethodSymbol symbol) => UserOperatorFactory.Instance.CreateEntityFromSymbol(cx, symbol);
+        public new static UserOperator Create(Context cx, IMethodSymbol symbol) => UserOperatorFactory.Instance.CreateEntity(cx, symbol);
 
         class UserOperatorFactory : ICachedEntityFactory<IMethodSymbol, UserOperator>
         {

--- a/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
+++ b/csharp/extractor/Semmle.Extraction.CSharp/SymbolExtensions.cs
@@ -123,24 +123,6 @@ namespace Semmle.Extraction.CSharp
         }
 
         /// <summary>
-        /// Write the identifier for the symbol <paramref name="type"/> to the trapfile <paramref name="trapFile"/>.
-        /// If any nested types are found in the identifier, then they are written out explicitly, without
-        /// prefixing the assembly ID.
-        /// </summary>
-        /// <param name="type">The type to write.</param>
-        /// <param name="cx">The extraction context.</param>
-        /// <param name="trapFile">The trap file to write to.</param>
-        /// <param name="symbolBeingDefined">The outer symbol being defined (to avoid recursive ids).</param>
-        public static void BuildNestedTypeId(this ITypeSymbol type, Context cx, TextWriter trapFile, ISymbol symbolBeingDefined)
-        {
-            void WriteType(Context cx, TextWriter trapFile, ITypeSymbol symbol, ISymbol symbolBeingDefined)
-            {
-                symbol.BuildTypeId(cx, trapFile, false, symbolBeingDefined, WriteType);
-            }
-            WriteType(cx, trapFile, type, symbolBeingDefined);
-        }
-
-        /// <summary>
         /// Constructs a unique string for this type symbol.
         ///
         /// The supplied action <paramref name="subTermAction"/> is applied to the
@@ -148,12 +130,10 @@ namespace Semmle.Extraction.CSharp
         /// </summary>
         /// <param name="cx">The extraction context.</param>
         /// <param name="trapFile">The trap builder used to store the result.</param>
-        /// <param name="prefix">Whether to prefix the type ID with the assembly ID.</param>
-        /// <param name="symbolBeingDefined">The outer symbol being defined (to avoid recursive ids).</param>
         /// <param name="subTermAction">The action to apply to syntactic sub terms of this type.</param>
-        public static void BuildTypeId(this ITypeSymbol type, Context cx, TextWriter trapFile, bool prefix, ISymbol symbolBeingDefined, Action<Context, TextWriter, ITypeSymbol, ISymbol> subTermAction)
+        public static void BuildTypeId(this ITypeSymbol type, Context cx, TextWriter trapFile, Action<Context, TextWriter, ITypeSymbol> subTermAction)
         {
-            if (type.SpecialType != SpecialType.None && !(type is INamedTypeSymbol n && n.IsGenericType))
+            if (type.SpecialType != SpecialType.None)
             {
                 /*
                  * Use the keyword ("int" etc) for the built-in types.
@@ -170,7 +150,7 @@ namespace Semmle.Extraction.CSharp
                 {
                     case TypeKind.Array:
                         var array = (IArrayTypeSymbol)type;
-                        subTermAction(cx, trapFile, array.ElementType, symbolBeingDefined);
+                        subTermAction(cx, trapFile, array.ElementType);
                         array.BuildArraySuffix(trapFile);
                         return;
                     case TypeKind.Class:
@@ -180,30 +160,15 @@ namespace Semmle.Extraction.CSharp
                     case TypeKind.Delegate:
                     case TypeKind.Error:
                         var named = (INamedTypeSymbol)type;
-                        named.BuildNamedTypeId(cx, trapFile, prefix, symbolBeingDefined, subTermAction);
+                        named.BuildNamedTypeId(cx, trapFile, subTermAction);
                         return;
                     case TypeKind.Pointer:
                         var ptr = (IPointerTypeSymbol)type;
-                        subTermAction(cx, trapFile, ptr.PointedAtType, symbolBeingDefined);
+                        subTermAction(cx, trapFile, ptr.PointedAtType);
                         trapFile.Write('*');
                         return;
                     case TypeKind.TypeParameter:
                         var tp = (ITypeParameterSymbol)type;
-                        if (!SymbolEqualityComparer.Default.Equals(tp.ContainingSymbol, symbolBeingDefined))
-                        {
-                            switch (tp.TypeParameterKind)
-                            {
-                                case TypeParameterKind.Method:
-                                    var method = Method.Create(cx, (IMethodSymbol)tp.ContainingSymbol);
-                                    trapFile.WriteSubId(method);
-                                    trapFile.Write('_');
-                                    break;
-                                case TypeParameterKind.Type:
-                                    subTermAction(cx, trapFile, tp.ContainingType, symbolBeingDefined);
-                                    trapFile.Write('_');
-                                    break;
-                            }
-                        }
                         trapFile.Write(tp.Name);
                         return;
                     case TypeKind.Dynamic:
@@ -246,8 +211,9 @@ namespace Semmle.Extraction.CSharp
             trapFile.Write("::");
         }
 
-        static void BuildNamedTypeId(this INamedTypeSymbol named, Context cx, TextWriter trapFile, bool prefixAssembly, ISymbol symbolBeingDefined, Action<Context, TextWriter, ITypeSymbol, ISymbol> subTermAction)
+        static void BuildNamedTypeId(this INamedTypeSymbol named, Context cx, TextWriter trapFile, Action<Context, TextWriter, ITypeSymbol> subTermAction)
         {
+            bool prefixAssembly = true;
             if (named.ContainingAssembly is null) prefixAssembly = false;
 
             if (named.IsTupleType)
@@ -258,7 +224,7 @@ namespace Semmle.Extraction.CSharp
                     {
                         trapFile.Write(f.Name);
                         trapFile.Write(":");
-                        subTermAction(cx, tb0, f.Type, symbolBeingDefined);
+                        subTermAction(cx, tb0, f.Type);
                     }
                     );
                 trapFile.Write(")");
@@ -267,7 +233,7 @@ namespace Semmle.Extraction.CSharp
 
             if (named.ContainingType != null)
             {
-                subTermAction(cx, trapFile, named.ContainingType, symbolBeingDefined);
+                subTermAction(cx, trapFile, named.ContainingType);
                 trapFile.Write('.');
             }
             else if (named.ContainingNamespace != null)
@@ -289,14 +255,14 @@ namespace Semmle.Extraction.CSharp
             }
             else
             {
-                subTermAction(cx, trapFile, named.ConstructedFrom, symbolBeingDefined);
+                subTermAction(cx, trapFile, named.ConstructedFrom);
                 trapFile.Write('<');
                 // Encode the nullability of the type arguments in the label.
                 // Type arguments with different nullability can result in 
                 // a constructed type with different nullability of its members and methods,
                 // so we need to create a distinct database entity for it.
                 trapFile.BuildList(",", named.GetAnnotatedTypeArguments(),
-                    (ta, tb0) => subTermAction(cx, tb0, ta.Symbol, symbolBeingDefined)
+                    (ta, tb0) => subTermAction(cx, tb0, ta.Symbol)
                     );
                 trapFile.Write('>');
             }
@@ -308,16 +274,16 @@ namespace Semmle.Extraction.CSharp
             trapFile.Write('.');
         }
 
-        static void BuildAnonymousName(this ITypeSymbol type, Context cx, TextWriter trapFile, Action<Context, TextWriter, ITypeSymbol, ISymbol> subTermAction, bool includeParamName)
+        static void BuildAnonymousName(this ITypeSymbol type, Context cx, TextWriter trapFile, Action<Context, TextWriter, ITypeSymbol> subTermAction, bool includeParamName)
         {
             var buildParam = includeParamName
                 ? (prop, tb0) =>
                 {
                     tb0.Write(prop.Name);
                     tb0.Write(' ');
-                    subTermAction(cx, tb0, prop.Type, null);
+                    subTermAction(cx, tb0, prop.Type);
                 }
-            : (Action<IPropertySymbol, TextWriter>)((prop, tb0) => subTermAction(cx, tb0, prop.Type, null));
+            : (Action<IPropertySymbol, TextWriter>)((prop, tb0) => subTermAction(cx, tb0, prop.Type));
             int memberCount = type.GetMembers().OfType<IPropertySymbol>().Count();
             int hackTypeNumber = memberCount == 1 ? 1 : 0;
             trapFile.Write("<>__AnonType");
@@ -389,7 +355,7 @@ namespace Semmle.Extraction.CSharp
 
             if (namedType.IsAnonymousType)
             {
-                namedType.BuildAnonymousName(cx, trapFile, (cx0, tb0, sub, _) => sub.BuildDisplayName(cx0, tb0), false);
+                namedType.BuildAnonymousName(cx, trapFile, (cx0, tb0, sub) => sub.BuildDisplayName(cx0, tb0), false);
             }
 
             trapFile.Write(namedType.Name);

--- a/csharp/extractor/Semmle.Extraction/Entity.cs
+++ b/csharp/extractor/Semmle.Extraction/Entity.cs
@@ -131,19 +131,6 @@ namespace Semmle.Extraction
             where Entity : ICachedEntity => cx.CreateEntity(factory, init);
 
         /// <summary>
-        /// Creates and populates a new entity, or returns the existing one from the cache.
-        /// </summary>
-        /// <typeparam name="Type">The symbol type used to construct the entity.</typeparam>
-        /// <typeparam name="Entity">The type of the entity to create.</typeparam>
-        /// <param name="cx">The extractor context.</param>
-        /// <param name="factory">The factory used to construct the entity.</param>
-        /// <param name="init">The initializer for the entity, which may not be null.</param>
-        /// <returns>The entity.</returns>
-        public static Entity CreateEntityFromSymbol<Type, Entity>(this ICachedEntityFactory<Type, Entity> factory, Context cx, Type init)
-            where Entity : ICachedEntity
-            where Type : ISymbol => cx.CreateEntityFromSymbol(factory, init);
-
-        /// <summary>
         /// Creates and populates a new entity, but uses a different cache.
         /// </summary>
         /// <typeparam name="Type">The symbol type used to construct the entity.</typeparam>

--- a/csharp/ql/test/library-tests/aliases/aliases2.expected
+++ b/csharp/ql/test/library-tests/aliases/aliases2.expected
@@ -1,9 +1,3 @@
 | Program.cs:18:21:18:22 | c1 | Assembly1.dll:0:0:0:0 | Class |
-| Program.cs:18:21:18:22 | c1 | Assembly2.dll:0:0:0:0 | Class |
-| Program.cs:18:21:18:22 | c1 | Program.cs:10:7:10:11 | Class |
-| Program.cs:19:21:19:22 | c2 | Assembly1.dll:0:0:0:0 | Class |
 | Program.cs:19:21:19:22 | c2 | Assembly2.dll:0:0:0:0 | Class |
-| Program.cs:19:21:19:22 | c2 | Program.cs:10:7:10:11 | Class |
-| Program.cs:20:15:20:16 | c3 | Assembly1.dll:0:0:0:0 | Class |
-| Program.cs:20:15:20:16 | c3 | Assembly2.dll:0:0:0:0 | Class |
 | Program.cs:20:15:20:16 | c3 | Program.cs:10:7:10:11 | Class |

--- a/csharp/ql/test/library-tests/csharp8/NullableRefTypes.expected
+++ b/csharp/ql/test/library-tests/csharp8/NullableRefTypes.expected
@@ -243,7 +243,7 @@ expressionTypes
 | NullableRefTypes.cs:19:33:19:36 | this access | MyClass! |
 | NullableRefTypes.cs:26:44:26:53 | throw ... | MyClass![]! |
 | NullableRefTypes.cs:26:50:26:53 | null | null |
-| NullableRefTypes.cs:27:44:27:53 | throw ... | MyClass?[]! |
+| NullableRefTypes.cs:27:44:27:53 | throw ... | MyClass![]! |
 | NullableRefTypes.cs:27:50:27:53 | null | null |
 | NullableRefTypes.cs:30:21:30:24 | null | null |
 | NullableRefTypes.cs:31:20:31:23 | this access | MyClass! |


### PR DESCRIPTION
Reverts https://github.com/Semmle/ql/pull/2814.

Turns out that this change caused performance issues (see https://jenkins.internal.semmle.com/job/Changes/job/CSharp-Differences/124/), so rolling back until we have identified a fix.