### PR TITLE
C++: Make `Declaration` not abstract

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/Declaration.qll
+++ b/cpp/ql/src/semmle/code/cpp/Declaration.qll
@@ -25,7 +25,7 @@ private import semmle.code.cpp.internal.QualifiedName as Q
  * `DeclarationEntry`, because they always have a unique source location.
  * `EnumConstant` and `FriendDecl` are both examples of this.
  */
-abstract class Declaration extends Locatable, @declaration {
+class Declaration extends Locatable, @declaration {
   /**
    * Gets the innermost namespace which contains this declaration.
    *


### PR DESCRIPTION
I'm going to test this change overnight to see if it solves the re-evaluation problem I've observed.