### PR TITLE
1.24: Move python change notes into rc/1.24 branch

### DIFF
--- a/change-notes/1.24/analysis-python.md
+++ b/change-notes/1.24/analysis-python.md
@@ -14,7 +14,7 @@ The following changes in version 1.24 affect Python analysis in all applications
 
 - A large number of libraries and queries have been moved to the new `Value` API, which should result in more precise results.
 
-- The `Value` API has been extended in various ways:
+- The `Value` interface has been extended in various ways:
    - A new `StringValue` class has been added, for tracking string literals.
    - Values now have a `booleanValue` method which returns the boolean interpretation of the given value.
    - Built-in methods for which the return type is not fixed are now modeled as returning an unknown value by default.
@@ -24,10 +24,10 @@ The following changes in version 1.24 affect Python analysis in all applications
 
 | **Query**                  | **Expected impact**    | **Change**                                                       |
 |----------------------------|------------------------|------------------------------------------------------------------|
-| Arbitrary file write during tarfile extraction (`py/tarslip`) | Fewer false negatives | Negations are now handled correctly in conditionals that may sanitize tainted values. |
-| First parameter of a method is not named 'self' (`py/not-named-self`) | Fewer false positives | `__class_getitem__` is now recognized as a class method. |
-| Import of deprecated module (`py/import-deprecated-module) | Fewer false positives | Deprecated modules used for backwards compatibility are no longer reported.|
-| Module imports itself (`py/import-own-module`) | Fewer false positives | Imports local to a given package are no longer classified as self-imports. |
+| Arbitrary file write during tarfile extraction (`py/tarslip`) | Fewer false negative results | Negations are now handled correctly in conditional expressions that may sanitize tainted values. |
+| First parameter of a method is not named 'self' (`py/not-named-self`) | Fewer false positive results | `__class_getitem__` is now recognized as a class method. |
+| Import of deprecated module (`py/import-deprecated-module`) | Fewer false positive results | Deprecated modules that are used to provide backwards compatibility are no longer reported.|
+| Module imports itself (`py/import-own-module`) | Fewer false positive results | Imports local to a given package are no longer classified as self-imports. |
 | Uncontrolled command line (`py/command-line-injection`) | More results | We now model the `fabric` and `invoke` packages for command execution. |
 
 ### Web framework support

--- a/change-notes/1.24/analysis-python.md
+++ b/change-notes/1.24/analysis-python.md
@@ -32,23 +32,22 @@ The following changes in version 1.24 affect Python analysis in all applications
 
 ### Web framework support
 
-The QL-library support for the web frameworks Bottle, CherryPy, Falcon, Pyramid, TurboGears, Tornado, and Twisted have
-been fixed so they provide a proper HttpRequestTaintSource, instead of a TaintSource. This will enable results for the following queries:
+The CodeQL library has improved support for the web frameworks: Bottle, CherryPy, Falcon, Pyramid, TurboGears, Tornado, and Twisted. They now provide a proper `HttpRequestTaintSource`, instead of a `TaintSource`. This will enable results for the following queries:
 
-- py/path-injection
-- py/command-line-injection
-- py/reflective-xss
-- py/sql-injection
-- py/code-injection
-- py/unsafe-deserialization
-- py/url-redirection
+- `py/path-injection`
+- `py/command-line-injection`
+- `py/reflective-xss`
+- `py/sql-injection`
+- `py/code-injection`
+- `py/unsafe-deserialization`
+- `py/url-redirection`
 
-The QL-library support for the web framework Twisted have been fixed so they provide a proper
-HttpResponseTaintSink, instead of a TaintSink. This will enable results for the following
+The library also has improved support for the web framework Twisted. It now provides a proper
+`HttpResponseTaintSink`, instead of a `TaintSink`. This will enable results for the following
 queries:
 
-- py/reflective-xss
-- py/stack-trace-exposure
+- `py/reflective-xss`
+- `py/stack-trace-exposure`
 
 ## Changes to libraries
 ### Taint tracking


### PR DESCRIPTION
From the point of view of history, https://github.com/Semmle/ql/pull/3315 should have been targeted against the `rc/1.24` branch. I entirely overlooked this when reviewing it.

I've cherry-picked those commit directly onto a new branch from `rc/1.24`.

@tausbn - not sure if this is the best way to resolve this, or whether it's not worth worrying about. 