### PR TITLE
JS: add support for util.inherits in ClassNode

### DIFF
--- a/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
+++ b/javascript/ql/src/semmle/javascript/dataflow/Nodes.qll
@@ -1196,6 +1196,14 @@ module ClassNode {
         getAPropertySource("prototype") = newCall and
         result = newCall.getCalleeNode()
       )
+      or
+      // util.inherits(C, D);
+      exists(DataFlow::CallNode inheritsCall |
+        inheritsCall = DataFlow::moduleMember("util", "inherits").getACall()
+      |
+        this = inheritsCall.getArgument(0).getALocalSource() and
+        result = inheritsCall.getArgument(1)
+      )
     }
   }
 }

--- a/javascript/ql/test/library-tests/frameworks/EventEmitter/test.expected
+++ b/javascript/ql/test/library-tests/frameworks/EventEmitter/test.expected
@@ -4,6 +4,7 @@
 | customEmitter.js:18:15:18:20 | "baz2" | customEmitter.js:13:23:13:26 | data |
 | customEmitter.js:21:15:21:20 | "baz3" | customEmitter.js:13:23:13:26 | data |
 | customEmitter.js:21:15:21:20 | "baz3" | customEmitter.js:22:14:22:18 | yData |
+| tst2.js:18:16:18:20 | "bar" | tst2.js:17:14:17:16 | bar |
 | tst.js:9:23:9:33 | 'FirstData' | tst.js:6:40:6:44 | first |
 | tst.js:10:24:10:35 | 'SecondData' | tst.js:7:32:7:37 | second |
 | tst.js:15:24:15:39 | 'OtherFirstData' | tst.js:14:41:14:50 | otherFirst |

--- a/javascript/ql/test/library-tests/frameworks/EventEmitter/tst2.js
+++ b/javascript/ql/test/library-tests/frameworks/EventEmitter/tst2.js
@@ -1,0 +1,18 @@
+var util = require('util');
+var EventEmitter = require('events').EventEmitter;
+
+var Connector = function() {
+  if (!(this instanceof Connector)) {
+    return new Connector(port, host, opts);
+  }
+
+  EventEmitter.call(this);
+};
+
+util.inherits(Connector, EventEmitter);
+
+Connector.prototype.foo = function() {};
+
+var em = new Connector();
+em.on("foo", bar => {});
+em.emit("foo", "bar");


### PR DESCRIPTION
Allows us to recognize additional EventEmitters using `NodeJSLib::EventEmitterSubClass`. 