### PR TITLE
C++: Remove unnecessary part of comment

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/exprs/Literal.qll
+++ b/cpp/ql/src/semmle/code/cpp/exprs/Literal.qll
@@ -145,8 +145,6 @@ class HexLiteral extends Literal {
 
 /**
  * A C/C++ aggregate literal.
- *
- * For example:
  */
 class AggregateLiteral extends Expr, @aggregateliteral {
   override string getCanonicalQLClass() { result = "AggregateLiteral" }


### PR DESCRIPTION
All the classes that derives from this class has an example attached to it, so I figured we don't need an example in the base class.