### PR TITLE
JS: add $.jGrowl as an XSS sink

### DIFF
--- a/change-notes/1.25/analysis-javascript.md
+++ b/change-notes/1.25/analysis-javascript.md
@@ -2,6 +2,8 @@
 
 ## General improvements
 
+* Support for the following frameworks and libraries has been improved:
+  - [jGrowl](https://github.com/stanlemon/jGrowl)
 
 ## New queries
 

--- a/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
+++ b/javascript/ql/src/semmle/javascript/security/dataflow/Xss.qll
@@ -99,6 +99,8 @@ module DomBasedXss {
       this = any(Typeahead::TypeaheadSuggestionFunction f).getAReturn()
       or
       this = any(Handlebars::SafeString s).getAnArgument()
+      or
+      this = any(JQuery::MethodCall call | call.getMethodName() = "jGrowl").getArgument(0)
     }
   }
 

--- a/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/Xss.expected
@@ -341,6 +341,12 @@ nodes
 | tst.js:347:20:347:36 | document.location |
 | tst.js:349:5:349:30 | getUrl( ... ring(1) |
 | tst.js:349:5:349:30 | getUrl( ... ring(1) |
+| tst.js:354:7:354:39 | target |
+| tst.js:354:16:354:32 | document.location |
+| tst.js:354:16:354:32 | document.location |
+| tst.js:354:16:354:39 | documen ... .search |
+| tst.js:355:12:355:17 | target |
+| tst.js:355:12:355:17 | target |
 | typeahead.js:20:13:20:45 | target |
 | typeahead.js:20:22:20:38 | document.location |
 | typeahead.js:20:22:20:38 | document.location |
@@ -659,6 +665,11 @@ edges
 | tst.js:347:20:347:36 | document.location | tst.js:349:5:349:30 | getUrl( ... ring(1) |
 | tst.js:347:20:347:36 | document.location | tst.js:349:5:349:30 | getUrl( ... ring(1) |
 | tst.js:347:20:347:36 | document.location | tst.js:349:5:349:30 | getUrl( ... ring(1) |
+| tst.js:354:7:354:39 | target | tst.js:355:12:355:17 | target |
+| tst.js:354:7:354:39 | target | tst.js:355:12:355:17 | target |
+| tst.js:354:16:354:32 | document.location | tst.js:354:16:354:39 | documen ... .search |
+| tst.js:354:16:354:32 | document.location | tst.js:354:16:354:39 | documen ... .search |
+| tst.js:354:16:354:39 | documen ... .search | tst.js:354:7:354:39 | target |
 | typeahead.js:20:13:20:45 | target | typeahead.js:21:12:21:17 | target |
 | typeahead.js:20:22:20:38 | document.location | typeahead.js:20:22:20:45 | documen ... .search |
 | typeahead.js:20:22:20:38 | document.location | typeahead.js:20:22:20:45 | documen ... .search |
@@ -760,6 +771,7 @@ edges
 | tst.js:319:35:319:42 | location | tst.js:319:35:319:42 | location | tst.js:319:35:319:42 | location | Cross-site scripting vulnerability due to $@. | tst.js:319:35:319:42 | location | user-provided value |
 | tst.js:336:18:336:35 | params.get('name') | tst.js:330:18:330:34 | document.location | tst.js:336:18:336:35 | params.get('name') | Cross-site scripting vulnerability due to $@. | tst.js:330:18:330:34 | document.location | user-provided value |
 | tst.js:349:5:349:30 | getUrl( ... ring(1) | tst.js:347:20:347:36 | document.location | tst.js:349:5:349:30 | getUrl( ... ring(1) | Cross-site scripting vulnerability due to $@. | tst.js:347:20:347:36 | document.location | user-provided value |
+| tst.js:355:12:355:17 | target | tst.js:354:16:354:32 | document.location | tst.js:355:12:355:17 | target | Cross-site scripting vulnerability due to $@. | tst.js:354:16:354:32 | document.location | user-provided value |
 | typeahead.js:25:18:25:20 | val | typeahead.js:20:22:20:38 | document.location | typeahead.js:25:18:25:20 | val | Cross-site scripting vulnerability due to $@. | typeahead.js:20:22:20:38 | document.location | user-provided value |
 | v-html.vue:2:8:2:23 | v-html=tainted | v-html.vue:6:42:6:58 | document.location | v-html.vue:2:8:2:23 | v-html=tainted | Cross-site scripting vulnerability due to $@. | v-html.vue:6:42:6:58 | document.location | user-provided value |
 | winjs.js:3:43:3:49 | tainted | winjs.js:2:17:2:33 | document.location | winjs.js:3:43:3:49 | tainted | Cross-site scripting vulnerability due to $@. | winjs.js:2:17:2:33 | document.location | user-provided value |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssThroughDom.expected
@@ -38,6 +38,9 @@ nodes
 | xss-through-dom.js:64:30:64:40 | valMethod() |
 | xss-through-dom.js:64:30:64:40 | valMethod() |
 | xss-through-dom.js:64:30:64:40 | valMethod() |
+| xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name |
+| xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name |
+| xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name |
 edges
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() |
 | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() |
@@ -52,6 +55,7 @@ edges
 | xss-through-dom.js:57:30:57:67 | $("inpu ... "name") | xss-through-dom.js:57:30:57:67 | $("inpu ... "name") |
 | xss-through-dom.js:61:30:61:69 | $(docum ... value") | xss-through-dom.js:61:30:61:69 | $(docum ... value") |
 | xss-through-dom.js:64:30:64:40 | valMethod() | xss-through-dom.js:64:30:64:40 | valMethod() |
+| xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name | xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name |
 #select
 | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() | xss-through-dom.js:2:16:2:34 | $("textarea").val() | Cross-site scripting vulnerability due to $@. | xss-through-dom.js:2:16:2:34 | $("textarea").val() | DOM text |
 | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | Cross-site scripting vulnerability due to $@. | xss-through-dom.js:4:16:4:40 | $(".som ... .text() | DOM text |
@@ -66,3 +70,4 @@ edges
 | xss-through-dom.js:57:30:57:67 | $("inpu ... "name") | xss-through-dom.js:57:30:57:67 | $("inpu ... "name") | xss-through-dom.js:57:30:57:67 | $("inpu ... "name") | Cross-site scripting vulnerability due to $@. | xss-through-dom.js:57:30:57:67 | $("inpu ... "name") | DOM text |
 | xss-through-dom.js:61:30:61:69 | $(docum ... value") | xss-through-dom.js:61:30:61:69 | $(docum ... value") | xss-through-dom.js:61:30:61:69 | $(docum ... value") | Cross-site scripting vulnerability due to $@. | xss-through-dom.js:61:30:61:69 | $(docum ... value") | DOM text |
 | xss-through-dom.js:64:30:64:40 | valMethod() | xss-through-dom.js:64:30:64:40 | valMethod() | xss-through-dom.js:64:30:64:40 | valMethod() | Cross-site scripting vulnerability due to $@. | xss-through-dom.js:64:30:64:40 | valMethod() | DOM text |
+| xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name | xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name | xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name | Cross-site scripting vulnerability due to $@. | xss-through-dom.js:71:11:71:32 | $("inpu ... 0).name | DOM text |

--- a/javascript/ql/test/query-tests/Security/CWE-079/XssWithAdditionalSources.expected
+++ b/javascript/ql/test/query-tests/Security/CWE-079/XssWithAdditionalSources.expected
@@ -341,6 +341,12 @@ nodes
 | tst.js:347:20:347:36 | document.location |
 | tst.js:349:5:349:30 | getUrl( ... ring(1) |
 | tst.js:349:5:349:30 | getUrl( ... ring(1) |
+| tst.js:354:7:354:39 | target |
+| tst.js:354:16:354:32 | document.location |
+| tst.js:354:16:354:32 | document.location |
+| tst.js:354:16:354:39 | documen ... .search |
+| tst.js:355:12:355:17 | target |
+| tst.js:355:12:355:17 | target |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:9:28:9:30 | loc |
 | typeahead.js:10:16:10:18 | loc |
@@ -663,6 +669,11 @@ edges
 | tst.js:347:20:347:36 | document.location | tst.js:349:5:349:30 | getUrl( ... ring(1) |
 | tst.js:347:20:347:36 | document.location | tst.js:349:5:349:30 | getUrl( ... ring(1) |
 | tst.js:347:20:347:36 | document.location | tst.js:349:5:349:30 | getUrl( ... ring(1) |
+| tst.js:354:7:354:39 | target | tst.js:355:12:355:17 | target |
+| tst.js:354:7:354:39 | target | tst.js:355:12:355:17 | target |
+| tst.js:354:16:354:32 | document.location | tst.js:354:16:354:39 | documen ... .search |
+| tst.js:354:16:354:32 | document.location | tst.js:354:16:354:39 | documen ... .search |
+| tst.js:354:16:354:39 | documen ... .search | tst.js:354:7:354:39 | target |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |
 | typeahead.js:9:28:9:30 | loc | typeahead.js:10:16:10:18 | loc |

--- a/javascript/ql/test/query-tests/Security/CWE-079/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/tst.js
@@ -352,7 +352,6 @@ function hash() {
 
 function growl() {
   var target = document.location.search
-  $.jGrowl(target);
+  $.jGrowl(target); // NOT OK
 }
-
 

--- a/javascript/ql/test/query-tests/Security/CWE-079/tst.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/tst.js
@@ -349,3 +349,10 @@ function hash() {
   $(getUrl().hash.substring(1)); // NOT OK
 
 }
+
+function growl() {
+  var target = document.location.search
+  $.jGrowl(target);
+}
+
+

--- a/javascript/ql/test/query-tests/Security/CWE-079/xss-through-dom.js
+++ b/javascript/ql/test/query-tests/Security/CWE-079/xss-through-dom.js
@@ -67,4 +67,6 @@
 	if(myValue.property) {
 		$("#id").get(0).innerHTML = myValue; // OK.
 	}
+	
+	$.jGrowl($("input").get(0).name); // NOT OK.
 })();


### PR DESCRIPTION
Gets us a TP/TN pair for CVE-2018-8035. 

[JGrowl](https://github.com/stanlemon/jGrowl) has a few hundred stars on GitHub, and it is easy to [find usages across GitHub](https://github.com/search?q=%24+jgrowl+extension%3Ajs&ref=simplesearch). 
However, it [doesn't have many downloads on npm](https://www.npmjs.com/package/jgrowl), but I think developers rarely use npm to download jQuery plugins. 

If you think the library is to rarely used for us to include a model, then I'll close the PR. 