### PR TITLE
C++/C#: Reuse some SSA def/use info from previous iteration

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/Instruction.qll
@@ -1279,6 +1279,14 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() { result = this.getAnInputOperand().getDef() }
+
+  /**
+   * Gets the input operand representing the value that flows from the specified predecessor block.
+   */
+  final PhiInputOperand getInputOperand(IRBlock predecessorBlock) {
+    result = this.getAnOperand() and
+    result.getPredecessorBlock() = predecessorBlock
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysis.qll
@@ -255,11 +255,7 @@ private predicate resultEscapesNonReturn(Instruction instr) {
  * allocation is marked as always escaping via `alwaysEscapes()`.
  */
 predicate allocationEscapes(Configuration::Allocation allocation) {
-  allocation.alwaysEscapes()
-  or
-  exists(IREscapeAnalysisConfiguration config |
-    config.useSoundEscapeAnalysis() and resultEscapesNonReturn(allocation.getABaseInstruction())
-  )
+  resultEscapesNonReturn(allocation.getABaseInstruction())
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysisImports.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/aliased_ssa/internal/AliasAnalysisImports.qll
@@ -1,3 +1,2 @@
-import semmle.code.cpp.ir.implementation.IRConfiguration
 import semmle.code.cpp.ir.internal.IntegerConstant as Ints
 import semmle.code.cpp.models.interfaces.Alias as AliasModels

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/Instruction.qll
@@ -1279,6 +1279,14 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() { result = this.getAnInputOperand().getDef() }
+
+  /**
+   * Gets the input operand representing the value that flows from the specified predecessor block.
+   */
+  final PhiInputOperand getInputOperand(IRBlock predecessorBlock) {
+    result = this.getAnOperand() and
+    result.getPredecessorBlock() = predecessorBlock
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/raw/internal/IRConstruction.qll
@@ -62,6 +62,9 @@ private module Cached {
   predicate hasModeledMemoryResult(Instruction instruction) { none() }
 
   cached
+  predicate canReuseSSAForMemoryResult(Instruction instruction) { none() }
+  
+  cached
   predicate hasConflatedMemoryResult(Instruction instruction) {
     instruction instanceof UnmodeledDefinitionInstruction
     or

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -1279,6 +1279,14 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() { result = this.getAnInputOperand().getDef() }
+
+  /**
+   * Gets the input operand representing the value that flows from the specified predecessor block.
+   */
+  final PhiInputOperand getInputOperand(IRBlock predecessorBlock) {
+    result = this.getAnOperand() and
+    result.getPredecessorBlock() = predecessorBlock
+  }
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -255,11 +255,7 @@ private predicate resultEscapesNonReturn(Instruction instr) {
  * allocation is marked as always escaping via `alwaysEscapes()`.
  */
 predicate allocationEscapes(Configuration::Allocation allocation) {
-  allocation.alwaysEscapes()
-  or
-  exists(IREscapeAnalysisConfiguration config |
-    config.useSoundEscapeAnalysis() and resultEscapesNonReturn(allocation.getABaseInstruction())
-  )
+  resultEscapesNonReturn(allocation.getABaseInstruction())
 }
 
 /**

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysisImports.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasAnalysisImports.qll
@@ -1,3 +1,2 @@
-import semmle.code.cpp.ir.implementation.IRConfiguration
 import semmle.code.cpp.ir.internal.IntegerConstant as Ints
 import semmle.code.cpp.models.interfaces.Alias as AliasModels

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasConfiguration.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/AliasConfiguration.qll
@@ -8,9 +8,4 @@ class Allocation extends IRAutomaticVariable {
   VariableAddressInstruction getABaseInstruction() { result.getIRVariable() = this }
 
   final string getAllocationString() { result = toString() }
-
-  predicate alwaysEscapes() {
-    // An automatic variable only escapes if its address is taken and escapes.
-    none()
-  }
 }

--- a/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SimpleSSAImports.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/implementation/unaliased_ssa/internal/SimpleSSAImports.qll
@@ -1,3 +1,4 @@
+import semmle.code.cpp.ir.IRConfiguration
 import semmle.code.cpp.ir.implementation.raw.IR
 import semmle.code.cpp.ir.internal.IntegerConstant as Ints
 import semmle.code.cpp.ir.implementation.internal.OperandTag

--- a/cpp/ql/src/semmle/code/cpp/ir/internal/Overlap.qll
+++ b/cpp/ql/src/semmle/code/cpp/ir/internal/Overlap.qll
@@ -5,16 +5,51 @@ private newtype TOverlap =
 
 abstract class Overlap extends TOverlap {
   abstract string toString();
+
+  /**
+   * Gets a value representing how precise this overlap is. The higher the value, the more precise
+   * the overlap. The precision values are ordered as
+   * follows, from most to least precise:
+   * `MustExactlyOverlap`
+   * `MustTotallyOverlap`
+   * `MayPartiallyOverlap`
+   */
+  abstract int getPrecision();
 }
 
 class MayPartiallyOverlap extends Overlap, TMayPartiallyOverlap {
   final override string toString() { result = "MayPartiallyOverlap" }
+
+  final override int getPrecision() { result = 0 }
 }
 
 class MustTotallyOverlap extends Overlap, TMustTotallyOverlap {
   final override string toString() { result = "MustTotallyOverlap" }
+
+  final override int getPrecision() { result = 1 }
 }
 
 class MustExactlyOverlap extends Overlap, TMustExactlyOverlap {
   final override string toString() { result = "MustExactlyOverlap" }
+
+  final override int getPrecision() { result = 2 }
+}
+
+/**
+ * Gets the `Overlap` that best represents the relationship between two memory locations `a` and
+ * `c`, where `getOverlap(a, b) = previousOverlap` and `getOverlap(b, c) = newOverlap`, for some
+ * intermediate memory location `b`.
+ */
+Overlap combineOverlap(Overlap previousOverlap, Overlap newOverlap) {
+  // Note that it's possible that two less precise overlaps could combine to result in a more
+  // precise overlap. For example, both `previousOverlap` and `newOverlap` could be
+  // `MustTotallyOverlap` even though the actual relationship between `a` and `c` is
+  // `MustExactlyOverlap`. We will still return `MustTotallyOverlap` as the best conservative
+  // approximation we can make without additional input information.
+  result =
+    min(Overlap overlap |
+      overlap = [previousOverlap, newOverlap]
+    |
+      overlap order by overlap.getPrecision()
+    )
 }

--- a/cpp/ql/test/library-tests/ir/points_to/points_to.cpp
+++ b/cpp/ql/test/library-tests/ir/points_to/points_to.cpp
@@ -37,51 +37,51 @@ void Locals() {
 }
 
 void PointsTo(
-  int a,         //$raw,ussa=a
-  Point& b,      //$raw,ussa=b $ussa=*b
-  Point* c,      //$raw,ussa=c $ussa=*c
-  int* d,        //$raw,ussa=d $ussa=*d
-  DerivedSI* e,  //$raw,ussa=e $ussa=*e
-  DerivedMI* f,  //$raw,ussa=f $ussa=*f
-  DerivedVI* g   //$raw,ussa=g $ussa=*g
+  int a,         //$raw=a
+  Point& b,      //$raw=b $ussa=*b
+  Point* c,      //$raw=c $ussa=*c
+  int* d,        //$raw=d $ussa=*d
+  DerivedSI* e,  //$raw=e $ussa=*e
+  DerivedMI* f,  //$raw=f $ussa=*f
+  DerivedVI* g   //$raw=g $ussa=*g
 ) {
 
-  int i = a;  //$raw,ussa=a
-  i = *&a;  //$raw,ussa=a
-  i = *(&a + 0);  //$raw,ussa=a
-  i = b.x;  //$raw,ussa=b $ussa=*b[0..4)<int>
-  i = b.y;  //$raw,ussa=b $ussa=*b[4..8)<int>
-  i = c->x;  //$raw,ussa=c $ussa=*c[0..4)<int>
-  i = c->y;  //$raw,ussa=c $ussa=*c[4..8)<int>
-  i = *d;  //$raw,ussa=d $ussa=*d[0..4)<int>
-  i = *(d + 0);  //$raw,ussa=d $ussa=*d[0..4)<int>
-  i = d[5];  //$raw,ussa=d $ussa=*d[20..24)<int>
-  i = 5[d];  //$raw,ussa=d $ussa=*d[20..24)<int>
-  i = d[a];  //$raw,ussa=d $raw,ussa=a $ussa=*d[?..?)<int>
-  i = a[d];  //$raw,ussa=d $raw,ussa=a $ussa=*d[?..?)<int>
+  int i = a;  //$raw=a
+  i = *&a;  //$raw=a
+  i = *(&a + 0);  //$raw=a
+  i = b.x;  //$raw=b $ussa=*b[0..4)<int>
+  i = b.y;  //$raw=b $ussa=*b[4..8)<int>
+  i = c->x;  //$raw=c $ussa=*c[0..4)<int>
+  i = c->y;  //$raw=c $ussa=*c[4..8)<int>
+  i = *d;  //$raw=d $ussa=*d[0..4)<int>
+  i = *(d + 0);  //$raw=d $ussa=*d[0..4)<int>
+  i = d[5];  //$raw=d $ussa=*d[20..24)<int>
+  i = 5[d];  //$raw=d $ussa=*d[20..24)<int>
+  i = d[a];  //$raw=d $raw=a $ussa=*d[?..?)<int>
+  i = a[d];  //$raw=d $raw=a $ussa=*d[?..?)<int>
 
-  int* p = &b.x;  //$raw,ussa=b
+  int* p = &b.x;  //$raw=b
   i = *p;  //$ussa=*b[0..4)<int>
-  p = &b.y;  //$raw,ussa=b
+  p = &b.y;  //$raw=b
   i = *p;  //$ussa=*b[4..8)<int>
-  p = &c->x;  //$raw,ussa=c
+  p = &c->x;  //$raw=c
   i = *p;  //$ussa=*c[0..4)<int>
-  p = &c->y;  //$raw,ussa=c
+  p = &c->y;  //$raw=c
   i = *p;  //$ussa=*c[4..8)<int>
-  p = &d[5];  //$raw,ussa=d
+  p = &d[5];  //$raw=d
   i = *p;  //$ussa=*d[20..24)<int>
-  p = &d[a];  //$raw,ussa=d $raw,ussa=a
+  p = &d[a];  //$raw=d $raw=a
   i = *p;  //$ussa=*d[?..?)<int>
 
-  Point* q = &c[a];  //$raw,ussa=c $raw,ussa=a
+  Point* q = &c[a];  //$raw=c $raw=a
   i = q->x;  //$ussa=*c[?..?)<int>
   i = q->y;  //$ussa=*c[?..?)<int>
 
-  i = e->b1;  //$raw,ussa=e $ussa=*e[0..4)<int>
-  i = e->dsi;  //$raw,ussa=e $ussa=*e[4..8)<int>
-  i = f->b1;  //$raw,ussa=f $ussa=*f[0..4)<int>
-  i = f->b2;  //$raw,ussa=f $ussa=*f[4..8)<int>
-  i = f->dmi;  //$raw,ussa=f $ussa=*f[8..12)<int>
-  i = g->b1;  //$raw,ussa=g $ussa=*g[?..?)<int>
-  i = g->dvi;  //$raw,ussa=g $ussa=*g[8..12)<int>
+  i = e->b1;  //$raw=e $ussa=*e[0..4)<int>
+  i = e->dsi;  //$raw=e $ussa=*e[4..8)<int>
+  i = f->b1;  //$raw=f $ussa=*f[0..4)<int>
+  i = f->b2;  //$raw=f $ussa=*f[4..8)<int>
+  i = f->dmi;  //$raw=f $ussa=*f[8..12)<int>
+  i = g->b1;  //$raw=g $ussa=*g[?..?)<int>
+  i = g->dvi;  //$raw=g $ussa=*g[8..12)<int>
 }

--- a/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir.expected
@@ -1533,3 +1533,91 @@ ssa.cpp:
 #  301|     v301_16(void)          = UnmodeledUse                     : mu*
 #  301|     v301_17(void)          = AliasedUse                       : ~m303_11
 #  301|     v301_18(void)          = ExitFunction                     : 
+
+#  307| int DegeneratePhiAfterUnreachable()
+#  307|   Block 0
+#  307|     v307_1(void)       = EnterFunction       : 
+#  307|     m307_2(unknown)    = AliasedDefinition   : 
+#  307|     m307_3(unknown)    = InitializeNonLocal  : 
+#  307|     m307_4(unknown)    = Chi                 : total:m307_2, partial:m307_3
+#  307|     mu307_5(unknown)   = UnmodeledDefinition : 
+#  308|     r308_1(glval<int>) = VariableAddress[a]  : 
+#  308|     r308_2(int)        = Constant[5]         : 
+#  308|     m308_3(int)        = Store               : &:r308_1, r308_2
+#  309|     r309_1(glval<int>) = VariableAddress[b]  : 
+#  309|     r309_2(int)        = Constant[5]         : 
+#  309|     m309_3(int)        = Store               : &:r309_1, r309_2
+#  310|     r310_1(glval<int>) = VariableAddress[a]  : 
+#  310|     r310_2(int)        = Load                : &:r310_1, m308_3
+#  310|     r310_3(glval<int>) = VariableAddress[b]  : 
+#  310|     r310_4(int)        = Load                : &:r310_3, m309_3
+#  310|     r310_5(bool)       = CompareEQ           : r310_2, r310_4
+#  310|     v310_6(void)       = ConditionalBranch   : r310_5
+#-----|   False -> Block 2
+#-----|   True -> Block 1
+
+#  311|   Block 1
+#  311|     r311_1(glval<int>) = VariableAddress[#return] : 
+#  311|     r311_2(int)        = Constant[0]              : 
+#  311|     m311_3(int)        = Store                    : &:r311_1, r311_2
+#  307|     r307_6(glval<int>) = VariableAddress[#return] : 
+#  307|     v307_7(void)       = ReturnValue              : &:r307_6, m311_3
+#  307|     v307_8(void)       = UnmodeledUse             : mu*
+#  307|     v307_9(void)       = AliasedUse               : m307_3
+#  307|     v307_10(void)      = ExitFunction             : 
+
+#  307|   Block 2
+#  307|     v307_11(void) = Unreached : 
+
+#  320| int TwoDegeneratePhisAfterUnreachable()
+#  320|   Block 0
+#  320|     v320_1(void)       = EnterFunction       : 
+#  320|     m320_2(unknown)    = AliasedDefinition   : 
+#  320|     m320_3(unknown)    = InitializeNonLocal  : 
+#  320|     m320_4(unknown)    = Chi                 : total:m320_2, partial:m320_3
+#  320|     mu320_5(unknown)   = UnmodeledDefinition : 
+#  321|     r321_1(glval<int>) = VariableAddress[a]  : 
+#  321|     r321_2(int)        = Constant[5]         : 
+#  321|     m321_3(int)        = Store               : &:r321_1, r321_2
+#  322|     r322_1(glval<int>) = VariableAddress[b]  : 
+#  322|     r322_2(int)        = Constant[5]         : 
+#  322|     m322_3(int)        = Store               : &:r322_1, r322_2
+#  323|     r323_1(glval<int>) = VariableAddress[r]  : 
+#  323|     m323_2(int)        = Uninitialized[r]    : &:r323_1
+#  324|     r324_1(glval<int>) = VariableAddress[a]  : 
+#  324|     r324_2(int)        = Load                : &:r324_1, m321_3
+#  324|     r324_3(glval<int>) = VariableAddress[b]  : 
+#  324|     r324_4(int)        = Load                : &:r324_3, m322_3
+#  324|     r324_5(bool)       = CompareEQ           : r324_2, r324_4
+#  324|     v324_6(void)       = ConditionalBranch   : r324_5
+#-----|   False -> Block 3
+#-----|   True -> Block 1
+
+#  325|   Block 1
+#  325|     r325_1(glval<int>) = VariableAddress[a] : 
+#  325|     r325_2(int)        = Load               : &:r325_1, m321_3
+#  325|     r325_3(int)        = Constant[5]        : 
+#  325|     r325_4(bool)       = CompareLT          : r325_2, r325_3
+#  325|     v325_5(void)       = ConditionalBranch  : r325_4
+#-----|   False -> Block 2
+#-----|   True -> Block 3
+
+#  332|   Block 2
+#  332|     r332_1(int)        = Constant[1]              : 
+#  332|     r332_2(glval<int>) = VariableAddress[r]       : 
+#  332|     m332_3(int)        = Store                    : &:r332_2, r332_1
+#  338|     r338_1(glval<int>) = VariableAddress[x]       : 
+#  338|     r338_2(int)        = Constant[7]              : 
+#  338|     m338_3(int)        = Store                    : &:r338_1, r338_2
+#  346|     r346_1(glval<int>) = VariableAddress[#return] : 
+#  346|     r346_2(glval<int>) = VariableAddress[r]       : 
+#  346|     r346_3(int)        = Load                     : &:r346_2, m332_3
+#  346|     m346_4(int)        = Store                    : &:r346_1, r346_3
+#  320|     r320_6(glval<int>) = VariableAddress[#return] : 
+#  320|     v320_7(void)       = ReturnValue              : &:r320_6, m346_4
+#  320|     v320_8(void)       = UnmodeledUse             : mu*
+#  320|     v320_9(void)       = AliasedUse               : m320_3
+#  320|     v320_10(void)      = ExitFunction             : 
+
+#  320|   Block 3
+#  320|     v320_11(void) = Unreached : 

--- a/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir_unsound.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/aliased_ssa_ir_unsound.expected
@@ -1520,3 +1520,91 @@ ssa.cpp:
 #  301|     v301_15(void)          = UnmodeledUse                     : mu*
 #  301|     v301_16(void)          = AliasedUse                       : ~m303_8
 #  301|     v301_17(void)          = ExitFunction                     : 
+
+#  307| int DegeneratePhiAfterUnreachable()
+#  307|   Block 0
+#  307|     v307_1(void)       = EnterFunction       : 
+#  307|     m307_2(unknown)    = AliasedDefinition   : 
+#  307|     m307_3(unknown)    = InitializeNonLocal  : 
+#  307|     m307_4(unknown)    = Chi                 : total:m307_2, partial:m307_3
+#  307|     mu307_5(unknown)   = UnmodeledDefinition : 
+#  308|     r308_1(glval<int>) = VariableAddress[a]  : 
+#  308|     r308_2(int)        = Constant[5]         : 
+#  308|     m308_3(int)        = Store               : &:r308_1, r308_2
+#  309|     r309_1(glval<int>) = VariableAddress[b]  : 
+#  309|     r309_2(int)        = Constant[5]         : 
+#  309|     m309_3(int)        = Store               : &:r309_1, r309_2
+#  310|     r310_1(glval<int>) = VariableAddress[a]  : 
+#  310|     r310_2(int)        = Load                : &:r310_1, m308_3
+#  310|     r310_3(glval<int>) = VariableAddress[b]  : 
+#  310|     r310_4(int)        = Load                : &:r310_3, m309_3
+#  310|     r310_5(bool)       = CompareEQ           : r310_2, r310_4
+#  310|     v310_6(void)       = ConditionalBranch   : r310_5
+#-----|   False -> Block 2
+#-----|   True -> Block 1
+
+#  311|   Block 1
+#  311|     r311_1(glval<int>) = VariableAddress[#return] : 
+#  311|     r311_2(int)        = Constant[0]              : 
+#  311|     m311_3(int)        = Store                    : &:r311_1, r311_2
+#  307|     r307_6(glval<int>) = VariableAddress[#return] : 
+#  307|     v307_7(void)       = ReturnValue              : &:r307_6, m311_3
+#  307|     v307_8(void)       = UnmodeledUse             : mu*
+#  307|     v307_9(void)       = AliasedUse               : m307_3
+#  307|     v307_10(void)      = ExitFunction             : 
+
+#  307|   Block 2
+#  307|     v307_11(void) = Unreached : 
+
+#  320| int TwoDegeneratePhisAfterUnreachable()
+#  320|   Block 0
+#  320|     v320_1(void)       = EnterFunction       : 
+#  320|     m320_2(unknown)    = AliasedDefinition   : 
+#  320|     m320_3(unknown)    = InitializeNonLocal  : 
+#  320|     m320_4(unknown)    = Chi                 : total:m320_2, partial:m320_3
+#  320|     mu320_5(unknown)   = UnmodeledDefinition : 
+#  321|     r321_1(glval<int>) = VariableAddress[a]  : 
+#  321|     r321_2(int)        = Constant[5]         : 
+#  321|     m321_3(int)        = Store               : &:r321_1, r321_2
+#  322|     r322_1(glval<int>) = VariableAddress[b]  : 
+#  322|     r322_2(int)        = Constant[5]         : 
+#  322|     m322_3(int)        = Store               : &:r322_1, r322_2
+#  323|     r323_1(glval<int>) = VariableAddress[r]  : 
+#  323|     m323_2(int)        = Uninitialized[r]    : &:r323_1
+#  324|     r324_1(glval<int>) = VariableAddress[a]  : 
+#  324|     r324_2(int)        = Load                : &:r324_1, m321_3
+#  324|     r324_3(glval<int>) = VariableAddress[b]  : 
+#  324|     r324_4(int)        = Load                : &:r324_3, m322_3
+#  324|     r324_5(bool)       = CompareEQ           : r324_2, r324_4
+#  324|     v324_6(void)       = ConditionalBranch   : r324_5
+#-----|   False -> Block 3
+#-----|   True -> Block 1
+
+#  325|   Block 1
+#  325|     r325_1(glval<int>) = VariableAddress[a] : 
+#  325|     r325_2(int)        = Load               : &:r325_1, m321_3
+#  325|     r325_3(int)        = Constant[5]        : 
+#  325|     r325_4(bool)       = CompareLT          : r325_2, r325_3
+#  325|     v325_5(void)       = ConditionalBranch  : r325_4
+#-----|   False -> Block 2
+#-----|   True -> Block 3
+
+#  332|   Block 2
+#  332|     r332_1(int)        = Constant[1]              : 
+#  332|     r332_2(glval<int>) = VariableAddress[r]       : 
+#  332|     m332_3(int)        = Store                    : &:r332_2, r332_1
+#  338|     r338_1(glval<int>) = VariableAddress[x]       : 
+#  338|     r338_2(int)        = Constant[7]              : 
+#  338|     m338_3(int)        = Store                    : &:r338_1, r338_2
+#  346|     r346_1(glval<int>) = VariableAddress[#return] : 
+#  346|     r346_2(glval<int>) = VariableAddress[r]       : 
+#  346|     r346_3(int)        = Load                     : &:r346_2, m332_3
+#  346|     m346_4(int)        = Store                    : &:r346_1, r346_3
+#  320|     r320_6(glval<int>) = VariableAddress[#return] : 
+#  320|     v320_7(void)       = ReturnValue              : &:r320_6, m346_4
+#  320|     v320_8(void)       = UnmodeledUse             : mu*
+#  320|     v320_9(void)       = AliasedUse               : m320_3
+#  320|     v320_10(void)      = ExitFunction             : 
+
+#  320|   Block 3
+#  320|     v320_11(void) = Unreached : 

--- a/cpp/ql/test/library-tests/ir/ssa/ssa.cpp
+++ b/cpp/ql/test/library-tests/ir/ssa/ssa.cpp
@@ -303,3 +303,45 @@ int main(int argc, char **argv) {
   unknownFunction(argc, argv);
   return **argv; // Chi chain goes through side effects from unknownFunction
 }
+
+int DegeneratePhiAfterUnreachable() {
+  int a = 5;
+  int b = 5;
+  if (a == b) {
+    return 0;
+  }
+  else {
+    // Unreachable, so the `Phi` for the return variable would have only the other `return`
+    // expression as input.
+    return 1;
+  }
+}
+
+int TwoDegeneratePhisAfterUnreachable() {
+  int a = 5;
+  int b = 5;
+  int r;
+  if (a == b) {
+    if (a < 5) {
+      // Unreachable.
+      r = 0;  // r0
+    }
+    else {
+      // After unreachable code removal, this feeds a degenerate `Phi` which in turn feeds another
+      // degenerate `Phi`.
+      r = 1;  // r1
+    }
+    // r01 = Phi(r0, r1) <-- First degenerate `Phi` here.
+
+    // The below statement is just to keep the above `if`/`else` from going directly to the `return`
+    // statement.
+    int x = 7;
+  }
+  else {
+    // Unreachable
+    r = 2;  // r2
+  }
+  // r012 = Phi(r01, r2) <-- Second degenerate `Phi` here.
+
+  return r;
+}

--- a/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir.expected
@@ -1403,3 +1403,113 @@ ssa.cpp:
 #  301|     v301_14(void)          = UnmodeledUse                     : mu*
 #  301|     v301_15(void)          = AliasedUse                       : ~mu301_4
 #  301|     v301_16(void)          = ExitFunction                     : 
+
+#  307| int DegeneratePhiAfterUnreachable()
+#  307|   Block 0
+#  307|     v307_1(void)       = EnterFunction       : 
+#  307|     mu307_2(unknown)   = AliasedDefinition   : 
+#  307|     mu307_3(unknown)   = InitializeNonLocal  : 
+#  307|     mu307_4(unknown)   = UnmodeledDefinition : 
+#  308|     r308_1(glval<int>) = VariableAddress[a]  : 
+#  308|     r308_2(int)        = Constant[5]         : 
+#  308|     m308_3(int)        = Store               : &:r308_1, r308_2
+#  309|     r309_1(glval<int>) = VariableAddress[b]  : 
+#  309|     r309_2(int)        = Constant[5]         : 
+#  309|     m309_3(int)        = Store               : &:r309_1, r309_2
+#  310|     r310_1(glval<int>) = VariableAddress[a]  : 
+#  310|     r310_2(int)        = Load                : &:r310_1, m308_3
+#  310|     r310_3(glval<int>) = VariableAddress[b]  : 
+#  310|     r310_4(int)        = Load                : &:r310_3, m309_3
+#  310|     r310_5(bool)       = CompareEQ           : r310_2, r310_4
+#  310|     v310_6(void)       = ConditionalBranch   : r310_5
+#-----|   False -> Block 3
+#-----|   True -> Block 2
+
+#  307|   Block 1
+#  307|     m307_5(int)        = Phi                      : from 2:m311_3, from 3:m316_3
+#  307|     r307_6(glval<int>) = VariableAddress[#return] : 
+#  307|     v307_7(void)       = ReturnValue              : &:r307_6, m307_5
+#  307|     v307_8(void)       = UnmodeledUse             : mu*
+#  307|     v307_9(void)       = AliasedUse               : ~mu307_4
+#  307|     v307_10(void)      = ExitFunction             : 
+
+#  311|   Block 2
+#  311|     r311_1(glval<int>) = VariableAddress[#return] : 
+#  311|     r311_2(int)        = Constant[0]              : 
+#  311|     m311_3(int)        = Store                    : &:r311_1, r311_2
+#-----|   Goto -> Block 1
+
+#  316|   Block 3
+#  316|     r316_1(glval<int>) = VariableAddress[#return] : 
+#  316|     r316_2(int)        = Constant[1]              : 
+#  316|     m316_3(int)        = Store                    : &:r316_1, r316_2
+#-----|   Goto -> Block 1
+
+#  320| int TwoDegeneratePhisAfterUnreachable()
+#  320|   Block 0
+#  320|     v320_1(void)       = EnterFunction       : 
+#  320|     mu320_2(unknown)   = AliasedDefinition   : 
+#  320|     mu320_3(unknown)   = InitializeNonLocal  : 
+#  320|     mu320_4(unknown)   = UnmodeledDefinition : 
+#  321|     r321_1(glval<int>) = VariableAddress[a]  : 
+#  321|     r321_2(int)        = Constant[5]         : 
+#  321|     m321_3(int)        = Store               : &:r321_1, r321_2
+#  322|     r322_1(glval<int>) = VariableAddress[b]  : 
+#  322|     r322_2(int)        = Constant[5]         : 
+#  322|     m322_3(int)        = Store               : &:r322_1, r322_2
+#  323|     r323_1(glval<int>) = VariableAddress[r]  : 
+#  323|     m323_2(int)        = Uninitialized[r]    : &:r323_1
+#  324|     r324_1(glval<int>) = VariableAddress[a]  : 
+#  324|     r324_2(int)        = Load                : &:r324_1, m321_3
+#  324|     r324_3(glval<int>) = VariableAddress[b]  : 
+#  324|     r324_4(int)        = Load                : &:r324_3, m322_3
+#  324|     r324_5(bool)       = CompareEQ           : r324_2, r324_4
+#  324|     v324_6(void)       = ConditionalBranch   : r324_5
+#-----|   False -> Block 5
+#-----|   True -> Block 1
+
+#  325|   Block 1
+#  325|     r325_1(glval<int>) = VariableAddress[a] : 
+#  325|     r325_2(int)        = Load               : &:r325_1, m321_3
+#  325|     r325_3(int)        = Constant[5]        : 
+#  325|     r325_4(bool)       = CompareLT          : r325_2, r325_3
+#  325|     v325_5(void)       = ConditionalBranch  : r325_4
+#-----|   False -> Block 3
+#-----|   True -> Block 2
+
+#  327|   Block 2
+#  327|     r327_1(int)        = Constant[0]        : 
+#  327|     r327_2(glval<int>) = VariableAddress[r] : 
+#  327|     m327_3(int)        = Store              : &:r327_2, r327_1
+#-----|   Goto -> Block 4
+
+#  332|   Block 3
+#  332|     r332_1(int)        = Constant[1]        : 
+#  332|     r332_2(glval<int>) = VariableAddress[r] : 
+#  332|     m332_3(int)        = Store              : &:r332_2, r332_1
+#-----|   Goto -> Block 4
+
+#  338|   Block 4
+#  338|     m338_1(int)        = Phi                : from 2:m327_3, from 3:m332_3
+#  338|     r338_2(glval<int>) = VariableAddress[x] : 
+#  338|     r338_3(int)        = Constant[7]        : 
+#  338|     m338_4(int)        = Store              : &:r338_2, r338_3
+#-----|   Goto -> Block 6
+
+#  342|   Block 5
+#  342|     r342_1(int)        = Constant[2]        : 
+#  342|     r342_2(glval<int>) = VariableAddress[r] : 
+#  342|     m342_3(int)        = Store              : &:r342_2, r342_1
+#-----|   Goto -> Block 6
+
+#  346|   Block 6
+#  346|     m346_1(int)        = Phi                      : from 4:m338_1, from 5:m342_3
+#  346|     r346_2(glval<int>) = VariableAddress[#return] : 
+#  346|     r346_3(glval<int>) = VariableAddress[r]       : 
+#  346|     r346_4(int)        = Load                     : &:r346_3, m346_1
+#  346|     m346_5(int)        = Store                    : &:r346_2, r346_4
+#  320|     r320_5(glval<int>) = VariableAddress[#return] : 
+#  320|     v320_6(void)       = ReturnValue              : &:r320_5, m346_5
+#  320|     v320_7(void)       = UnmodeledUse             : mu*
+#  320|     v320_8(void)       = AliasedUse               : ~mu320_4
+#  320|     v320_9(void)       = ExitFunction             : 

--- a/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir_unsound.expected
+++ b/cpp/ql/test/library-tests/ir/ssa/unaliased_ssa_ir_unsound.expected
@@ -1403,3 +1403,113 @@ ssa.cpp:
 #  301|     v301_14(void)          = UnmodeledUse                     : mu*
 #  301|     v301_15(void)          = AliasedUse                       : ~mu301_4
 #  301|     v301_16(void)          = ExitFunction                     : 
+
+#  307| int DegeneratePhiAfterUnreachable()
+#  307|   Block 0
+#  307|     v307_1(void)       = EnterFunction       : 
+#  307|     mu307_2(unknown)   = AliasedDefinition   : 
+#  307|     mu307_3(unknown)   = InitializeNonLocal  : 
+#  307|     mu307_4(unknown)   = UnmodeledDefinition : 
+#  308|     r308_1(glval<int>) = VariableAddress[a]  : 
+#  308|     r308_2(int)        = Constant[5]         : 
+#  308|     m308_3(int)        = Store               : &:r308_1, r308_2
+#  309|     r309_1(glval<int>) = VariableAddress[b]  : 
+#  309|     r309_2(int)        = Constant[5]         : 
+#  309|     m309_3(int)        = Store               : &:r309_1, r309_2
+#  310|     r310_1(glval<int>) = VariableAddress[a]  : 
+#  310|     r310_2(int)        = Load                : &:r310_1, m308_3
+#  310|     r310_3(glval<int>) = VariableAddress[b]  : 
+#  310|     r310_4(int)        = Load                : &:r310_3, m309_3
+#  310|     r310_5(bool)       = CompareEQ           : r310_2, r310_4
+#  310|     v310_6(void)       = ConditionalBranch   : r310_5
+#-----|   False -> Block 3
+#-----|   True -> Block 2
+
+#  307|   Block 1
+#  307|     m307_5(int)        = Phi                      : from 2:m311_3, from 3:m316_3
+#  307|     r307_6(glval<int>) = VariableAddress[#return] : 
+#  307|     v307_7(void)       = ReturnValue              : &:r307_6, m307_5
+#  307|     v307_8(void)       = UnmodeledUse             : mu*
+#  307|     v307_9(void)       = AliasedUse               : ~mu307_4
+#  307|     v307_10(void)      = ExitFunction             : 
+
+#  311|   Block 2
+#  311|     r311_1(glval<int>) = VariableAddress[#return] : 
+#  311|     r311_2(int)        = Constant[0]              : 
+#  311|     m311_3(int)        = Store                    : &:r311_1, r311_2
+#-----|   Goto -> Block 1
+
+#  316|   Block 3
+#  316|     r316_1(glval<int>) = VariableAddress[#return] : 
+#  316|     r316_2(int)        = Constant[1]              : 
+#  316|     m316_3(int)        = Store                    : &:r316_1, r316_2
+#-----|   Goto -> Block 1
+
+#  320| int TwoDegeneratePhisAfterUnreachable()
+#  320|   Block 0
+#  320|     v320_1(void)       = EnterFunction       : 
+#  320|     mu320_2(unknown)   = AliasedDefinition   : 
+#  320|     mu320_3(unknown)   = InitializeNonLocal  : 
+#  320|     mu320_4(unknown)   = UnmodeledDefinition : 
+#  321|     r321_1(glval<int>) = VariableAddress[a]  : 
+#  321|     r321_2(int)        = Constant[5]         : 
+#  321|     m321_3(int)        = Store               : &:r321_1, r321_2
+#  322|     r322_1(glval<int>) = VariableAddress[b]  : 
+#  322|     r322_2(int)        = Constant[5]         : 
+#  322|     m322_3(int)        = Store               : &:r322_1, r322_2
+#  323|     r323_1(glval<int>) = VariableAddress[r]  : 
+#  323|     m323_2(int)        = Uninitialized[r]    : &:r323_1
+#  324|     r324_1(glval<int>) = VariableAddress[a]  : 
+#  324|     r324_2(int)        = Load                : &:r324_1, m321_3
+#  324|     r324_3(glval<int>) = VariableAddress[b]  : 
+#  324|     r324_4(int)        = Load                : &:r324_3, m322_3
+#  324|     r324_5(bool)       = CompareEQ           : r324_2, r324_4
+#  324|     v324_6(void)       = ConditionalBranch   : r324_5
+#-----|   False -> Block 5
+#-----|   True -> Block 1
+
+#  325|   Block 1
+#  325|     r325_1(glval<int>) = VariableAddress[a] : 
+#  325|     r325_2(int)        = Load               : &:r325_1, m321_3
+#  325|     r325_3(int)        = Constant[5]        : 
+#  325|     r325_4(bool)       = CompareLT          : r325_2, r325_3
+#  325|     v325_5(void)       = ConditionalBranch  : r325_4
+#-----|   False -> Block 3
+#-----|   True -> Block 2
+
+#  327|   Block 2
+#  327|     r327_1(int)        = Constant[0]        : 
+#  327|     r327_2(glval<int>) = VariableAddress[r] : 
+#  327|     m327_3(int)        = Store              : &:r327_2, r327_1
+#-----|   Goto -> Block 4
+
+#  332|   Block 3
+#  332|     r332_1(int)        = Constant[1]        : 
+#  332|     r332_2(glval<int>) = VariableAddress[r] : 
+#  332|     m332_3(int)        = Store              : &:r332_2, r332_1
+#-----|   Goto -> Block 4
+
+#  338|   Block 4
+#  338|     m338_1(int)        = Phi                : from 2:m327_3, from 3:m332_3
+#  338|     r338_2(glval<int>) = VariableAddress[x] : 
+#  338|     r338_3(int)        = Constant[7]        : 
+#  338|     m338_4(int)        = Store              : &:r338_2, r338_3
+#-----|   Goto -> Block 6
+
+#  342|   Block 5
+#  342|     r342_1(int)        = Constant[2]        : 
+#  342|     r342_2(glval<int>) = VariableAddress[r] : 
+#  342|     m342_3(int)        = Store              : &:r342_2, r342_1
+#-----|   Goto -> Block 6
+
+#  346|   Block 6
+#  346|     m346_1(int)        = Phi                      : from 4:m338_1, from 5:m342_3
+#  346|     r346_2(glval<int>) = VariableAddress[#return] : 
+#  346|     r346_3(glval<int>) = VariableAddress[r]       : 
+#  346|     r346_4(int)        = Load                     : &:r346_3, m346_1
+#  346|     m346_5(int)        = Store                    : &:r346_2, r346_4
+#  320|     r320_5(glval<int>) = VariableAddress[#return] : 
+#  320|     v320_6(void)       = ReturnValue              : &:r320_5, m346_5
+#  320|     v320_7(void)       = UnmodeledUse             : mu*
+#  320|     v320_8(void)       = AliasedUse               : ~mu320_4
+#  320|     v320_9(void)       = ExitFunction             : 

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/raw/Instruction.qll
@@ -1279,6 +1279,14 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() { result = this.getAnInputOperand().getDef() }
+
+  /**
+   * Gets the input operand representing the value that flows from the specified predecessor block.
+   */
+  final PhiInputOperand getInputOperand(IRBlock predecessorBlock) {
+    result = this.getAnOperand() and
+    result.getPredecessorBlock() = predecessorBlock
+  }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Instruction.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/Instruction.qll
@@ -1279,6 +1279,14 @@ class PhiInstruction extends Instruction {
    */
   pragma[noinline]
   final Instruction getAnInput() { result = this.getAnInputOperand().getDef() }
+
+  /**
+   * Gets the input operand representing the value that flows from the specified predecessor block.
+   */
+  final PhiInputOperand getInputOperand(IRBlock predecessorBlock) {
+    result = this.getAnOperand() and
+    result.getPredecessorBlock() = predecessorBlock
+  }
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/AliasAnalysis.qll
@@ -255,11 +255,7 @@ private predicate resultEscapesNonReturn(Instruction instr) {
  * allocation is marked as always escaping via `alwaysEscapes()`.
  */
 predicate allocationEscapes(Configuration::Allocation allocation) {
-  allocation.alwaysEscapes()
-  or
-  exists(IREscapeAnalysisConfiguration config |
-    config.useSoundEscapeAnalysis() and resultEscapesNonReturn(allocation.getABaseInstruction())
-  )
+  resultEscapesNonReturn(allocation.getABaseInstruction())
 }
 
 /**

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/AliasAnalysisImports.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/AliasAnalysisImports.qll
@@ -1,5 +1,4 @@
 private import csharp
-import semmle.code.csharp.ir.implementation.IRConfiguration
 import semmle.code.csharp.ir.internal.IntegerConstant as Ints
 
 module AliasModels {

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/AliasConfiguration.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/AliasConfiguration.qll
@@ -8,9 +8,4 @@ class Allocation extends IRAutomaticVariable {
   VariableAddressInstruction getABaseInstruction() { result.getIRVariable() = this }
 
   final string getAllocationString() { result = toString() }
-
-  predicate alwaysEscapes() {
-    // An automatic variable only escapes if its address is taken and escapes.
-    none()
-  }
 }

--- a/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/SimpleSSAImports.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/implementation/unaliased_ssa/internal/SimpleSSAImports.qll
@@ -1,3 +1,4 @@
+import semmle.code.csharp.ir.IRConfiguration
 import semmle.code.csharp.ir.implementation.raw.IR
 import semmle.code.csharp.ir.internal.IntegerConstant as Ints
 import semmle.code.csharp.ir.implementation.internal.OperandTag

--- a/csharp/ql/src/semmle/code/csharp/ir/internal/Overlap.qll
+++ b/csharp/ql/src/semmle/code/csharp/ir/internal/Overlap.qll
@@ -5,16 +5,51 @@ private newtype TOverlap =
 
 abstract class Overlap extends TOverlap {
   abstract string toString();
+
+  /**
+   * Gets a value representing how precise this overlap is. The higher the value, the more precise
+   * the overlap. The precision values are ordered as
+   * follows, from most to least precise:
+   * `MustExactlyOverlap`
+   * `MustTotallyOverlap`
+   * `MayPartiallyOverlap`
+   */
+  abstract int getPrecision();
 }
 
 class MayPartiallyOverlap extends Overlap, TMayPartiallyOverlap {
   final override string toString() { result = "MayPartiallyOverlap" }
+
+  final override int getPrecision() { result = 0 }
 }
 
 class MustTotallyOverlap extends Overlap, TMustTotallyOverlap {
   final override string toString() { result = "MustTotallyOverlap" }
+
+  final override int getPrecision() { result = 1 }
 }
 
 class MustExactlyOverlap extends Overlap, TMustExactlyOverlap {
   final override string toString() { result = "MustExactlyOverlap" }
+
+  final override int getPrecision() { result = 2 }
+}
+
+/**
+ * Gets the `Overlap` that best represents the relationship between two memory locations `a` and
+ * `c`, where `getOverlap(a, b) = previousOverlap` and `getOverlap(b, c) = newOverlap`, for some
+ * intermediate memory location `b`.
+ */
+Overlap combineOverlap(Overlap previousOverlap, Overlap newOverlap) {
+  // Note that it's possible that two less precise overlaps could combine to result in a more
+  // precise overlap. For example, both `previousOverlap` and `newOverlap` could be
+  // `MustTotallyOverlap` even though the actual relationship between `a` and `c` is
+  // `MustExactlyOverlap`. We will still return `MustTotallyOverlap` as the best conservative
+  // approximation we can make without additional input information.
+  result =
+    min(Overlap overlap |
+      overlap = [previousOverlap, newOverlap]
+    |
+      overlap order by overlap.getPrecision()
+    )
 }


### PR DESCRIPTION
_Leaving as a draft until I have performance numbers from a CPP-Differences job_

This PR supercedes https://github.com/Semmle/ql/pull/3235. The necessary changes were extensive enough that it was too risky for `rc/1.24`, so this PR is against `master`.

We build SSA twice. The first iteration, "unaliased SSA", considers only those memory locations that are not aliased, do not have their address escape, and are always accessed in their entirety and as their underlying declared type. The second iteration, "aliased SSA", considers all memory locations. However, whatever defs and uses we computed for unaliased SSA are still valid for aliased SSA, because they never overlap with the aliased memory locations that aliased SSA adds into the mix. If we can reuse the unaliased SSA information directly, we can potentially save significant cost in building aliased SSA.

With this change, the SSA configuration can specify which definitions can be reused from the previous iteration of the IR. Unaliased SSA does not reuse anything from Raw IR, but Aliased SSA reuses any definition of a variable that did not escape. In addition, Unaliased SSA tells Aliased SSA which variables were did not escape, so that Aliased SSA can skip all alias analysis for those variables.

During SSA construction, instead of throwing away all Phi instructions and def/use information from the previous IR iteration, we reuse whatever we were told that we could. This is slightly complicated by the possibility of degenerate (single-operand) Phi instructions due to unreachable code being eliminated between iterations. If we would have wound up with a degenerate Phi instruction, we recurse to the definition of that Phi instruction's sole reachable input operand. See the new test cases for a couple examples.

In aliased SSA's AliasConfiguration.qll, I stopped creating allocations for variables that were already modeled in unaliased SSA. This in turn prevents us from creating memory locations for those variables and their defs and uses, which is where we hope to reduce evaluation time.

I also tweaked the getInstructionUniqueId() predicate to reuse the unique ID from the previous stage, which preserves ordering of Phi instructions in a block to minimize test output diffs.

The points_to test had to be updated to no longer expect points-to analysis on unaliased SSA to report results that were already reported when running on raw IR.

Finally, I added PhiInstruction.getInputOperand(). I'm surprised we didn't have it already.