### PR TITLE
Add a VS Code task to run `sync-files.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@
 /codeql/
 
 csharp/extractor/Semmle.Extraction.CSharp.Driver/Properties/launchSettings.json
-.vscode

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,4 +1,7 @@
 {
+    // To run a task, select the `Terminal | Run Task...` menu option, and then select the task from
+    // the list in the dropdown, or invoke the `Tasks: Run Task` command from the command palette/
+    // To bind a keyboard shortcut to invoke a task, see https://code.visualstudio.com/docs/editor/tasks#_binding-keyboard-shortcuts-to-tasks.
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
     "version": "2.0.0",
@@ -12,6 +15,7 @@
                 "config/sync-files.py",
                 "--latest"
             ],
+            "group": "build",
             "windows": {
                 // On Windows, use whatever Python interpreter is configured for this workspace. The default is
                 // just `python`, so if Python is already on the path, this will find it.

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Sync Identical Files",
+            "type": "process",
+            // Non-Windows OS will usually have Python 3 already installed at /usr/bin/python3.
+            "command": "python3",
+            "args": [
+                "config/sync-files.py",
+                "--latest"
+            ],
+            "windows": {
+                // On Windows, use whatever Python interpreter is configured for this workspace. The default is
+                // just `python`, so if Python is already on the path, this will find it.
+                "command": "${config:python.pythonPath}",
+            },
+            "problemMatcher": []
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ We welcome contributions to our standard library and standard checks. Do you hav
 ## License
 
 The code in this repository is licensed under the [MIT License](LICENSE) by [GitHub](https://github.com).
+
+## Visual Studio Code integration
+
+If you use Visual Studio Code to work in this repository, there are a few integration features to make development easier.
+
+### CodeQL for Visual Studio Code
+
+You can install the [CodeQL for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-codeql) extension to get syntax highlighting, IntelliSense, and code navigation for the QL language, as well as unit test support for testing CodeQL libraries and queries.
+
+### Tasks
+
+The `.vscode/tasks.json` file defines custom tasks specific to working in this repository. To invoke one of these tasks, select the `Terminal | Run Task...` menu option, and then select the desired task from the dropdown. You can also invoke the `Tasks: Run Task` command from the command palette.


### PR DESCRIPTION
If you're developing one of the libraries that has muiltiple copies auto-generated by `sync-files.py`, you can now run `sync-files.py --latest` by going to the `Terminal | Run Task...` menu in VS Code and selecting the `Sync Identical Files` task. You can set a keyboard binding to run this task for quicker access.