### PR TITLE
sync-files.py: cast line to string before concat

### DIFF
--- a/config/sync-files.py
+++ b/config/sync-files.py
@@ -107,7 +107,7 @@ def choose_latest_file(files):
 
 local_error_count = 0
 def emit_local_error(path, line, error):
-    print('ERROR: ' + path + ':' + line + " - " + error)
+    print('ERROR: ' + path + ':' + str(line) + " - " + error)
     global local_error_count
     local_error_count += 1
 


### PR DESCRIPTION
I ran into an error running this locally, with Python 3.8.2.