### PR TITLE
C++: Allocation.qll: Add support for openssl allocation/deallocation functions.

### DIFF
--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Allocation.qll
@@ -89,6 +89,18 @@ class MallocAllocationFunction extends AllocationFunction {
         or
         // kmem_zalloc(size, flags)
         name = "kmem_zalloc" and sizeArg = 0
+        or
+        // CRYPTO_malloc(size_t num, const char *file, int line)
+        name = "CRYPTO_malloc" and sizeArg = 0
+        or
+        // CRYPTO_zalloc(size_t num, const char *file, int line)
+        name = "CRYPTO_zalloc" and sizeArg = 0
+        or
+        // CRYPTO_secure_malloc(size_t num, const char *file, int line)
+        name = "CRYPTO_secure_malloc" and sizeArg = 0
+        or
+        // CRYPTO_secure_zalloc(size_t num, const char *file, int line)
+        name = "CRYPTO_secure_zalloc" and sizeArg = 0
       )
     )
   }
@@ -169,6 +181,9 @@ class ReallocAllocationFunction extends AllocationFunction {
         or
         // CoTaskMemRealloc(ptr, size)
         name = "CoTaskMemRealloc" and sizeArg = 1 and reallocArg = 0
+        or
+        // CRYPTO_realloc(void *addr, size_t num, const char *file, int line);
+        name = "CRYPTO_realloc" and sizeArg = 1 and reallocArg = 0
       )
     )
   }

--- a/cpp/ql/src/semmle/code/cpp/models/implementations/Deallocation.qll
+++ b/cpp/ql/src/semmle/code/cpp/models/implementations/Deallocation.qll
@@ -19,6 +19,10 @@ class StandardDeallocationFunction extends DeallocationFunction {
         name = "free" and freedArg = 0
         or
         name = "realloc" and freedArg = 0
+        or
+        name = "CRYPTO_free" and freedArg = 0
+        or
+        name = "CRYPTO_secure_free" and freedArg = 0
       )
       or
       hasGlobalOrStdName(name) and


### PR DESCRIPTION
Add support for (most) of openssl allocation functions.