### PR TITLE
Recommend the CodeQL for VSCode extension

### DIFF
--- a/.vscode/.gitattributes
+++ b/.vscode/.gitattributes
@@ -1,0 +1,1 @@
+*.json  linguist-language=JSON-with-Comments

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,12 +1,10 @@
 {
     // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
     // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-
     // List of extensions which should be recommended for users of this workspace.
     "recommendations": [
         "github.vscode-codeql"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-    "unwantedRecommendations": [
-    ]
+    "unwantedRecommendations": []
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+    // List of extensions which should be recommended for users of this workspace.
+    "recommendations": [
+        "github.vscode-codeql"
+    ],
+    // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+    "unwantedRecommendations": [
+    ]
+}


### PR DESCRIPTION
I've added a `.vscode/extensions.json` file that will automatically recommend the CodeQL for Visual Studio Code extension to anyone who opens the repo in VS Code (without the extension already installed).