### PR TITLE
Add link to new Go cookbook space

### DIFF
--- a/docs/language/learn-ql/go/ql-for-go.rst
+++ b/docs/language/learn-ql/go/ql-for-go.rst
@@ -15,5 +15,6 @@ Experiment and learn how to write effective and efficient queries for CodeQL dat
 Further reading
 ---------------
 
+-  For examples of how to query common Go elements, see the `Go cookbook <https://help.semmle.com/wiki/display/CBGO>`__.
 -  For the queries used in LGTM, display a `Go query <https://lgtm.com/search?q=language%3Ago&t=rules>`__ and click **Open in query console** to see the code used to find alerts.
 -  For more information about the library for Go see the `CodeQL library for Go <https://help.semmle.com/qldoc/go/>`__.


### PR DESCRIPTION
This PR adds a link to the CodeQL for Go topic to help people find the new cookbook space (https://help.semmle.com/wiki/display/CBGO/Go+cookbook). This space is currently published to the public wiki but only visible if you log in.